### PR TITLE
[ir/tests] Add allo.bmm() op and test cases

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -749,7 +749,7 @@ def test_const_tensor_int():
     def kernel() -> int32[2, 2]:
         cp1: int32[2, 2] = [[1, 2], [3, 4]]
         cp2: int32[2, 2] = [[1, 2], [3, 4]]
-        res: int32[2, 2]
+        res: int32[2, 2] = 0
         for i, j in allo.grid(2, 2):
             res[i, j] = cp1[i, j] + cp2[i, j]
         return res
@@ -767,9 +767,9 @@ def test_const_tensor_float():
     def kernel() -> float32[2, 3]:
         cp1: float32[2, 3] = [[1.05, 2.0, 3.5], [3.0, 4.0, 4.5]]
         cp2: float32[2, 3] = [[1.05, 2.0, 3.5], [3.0, 4.0, 4.5]]
-        res: float32[2, 3]
+        res: float32[2, 3] = 0.0
         for i, j in allo.grid(2, 3):
-            res[i, j] += cp1[i, j] + cp2[i, j]
+            res[i, j] = cp1[i, j] + cp2[i, j]
         return res
 
     s = allo.customize(kernel)
@@ -790,7 +790,7 @@ def test_const_tensor_int_vars():
     def kernel() -> int32[M, N]:
         cp1: int32[M, N] = np_0
         cp2: int32[M, N] = np_1
-        res: int32[M, N]
+        res: int32[M, N] = 1
         for i, j in allo.grid(M, N):
             res[i, j] += cp1[i, j] * cp2[i, j]
         return res
@@ -800,7 +800,7 @@ def test_const_tensor_int_vars():
     print(s.module)
     np_2 = np.zeros((M, N), dtype="int32")
     np_2 = f()
-    assert np.array_equal(np_2, np_0 * np_1)
+    assert np.array_equal(np_2, 1 + np_0 * np_1)
 
 
 def test_const_tensor_float_vars():
@@ -823,117 +823,6 @@ def test_const_tensor_float_vars():
     np_2 = np.zeros((M, N), dtype="float32")
     np_2 = f()
     np.testing.assert_allclose(np_2, 1.0 + np_0 * np_1, atol=1e-4)
-
-
-def test_tensor_matmul():
-    M = 10
-    K = 15
-    N = 20
-    np_0 = np.random.randint(0, 20, size=(M, K), dtype="int32")
-    np_1 = np.random.randint(0, 20, size=(K, N), dtype="int32")
-
-    def kernel(A: int32[M, K], B: int32[K, N]) -> int32[M, N]:
-        C = allo.matmul(A, B)
-        return C
-
-    s = allo.customize(kernel)
-    f = s.build()
-    np_2 = np.zeros((M, N), dtype="int32")
-    np_2 = f(np_0, np_1)
-    np.testing.assert_array_equal(np_2, np.matmul(np_0, np_1))
-    print(s.module)
-
-
-def test_tensor_matmul_only2D():
-    M = 10
-    K = 15
-    N = 20
-
-    def kernel(A: int32[M, K, M, K], B: int32[M, K, K, N]) -> int32[M, K, M, N]:
-        C = allo.matmul(A, B)
-        return C
-
-    with pytest.raises(RuntimeError) as excinfo:
-        allo.customize(kernel)
-    assert "Only support two 2D matrix multiplication" in str(excinfo.value)
-
-
-def test_tensor_matmul_nested():
-    M = 10
-    K = 15
-    A = np.random.uniform(size=(M, K))
-    B = np.random.uniform(size=(K, M))
-
-    def kernel() -> float32[M, K]:
-        A1: float32[M, K] = A
-        B1: float32[K, M] = B
-        D = allo.matmul(allo.matmul(A1, B1), A1)
-        return D
-
-    s = allo.customize(kernel)
-    f = s.build()
-    outs = np.zeros((M, K), dtype="float32")
-    outs = f(A, B, A)
-    print(s.module)
-    np.testing.assert_allclose(outs, np.matmul(np.matmul(A, B), A), atol=1e-4)
-
-
-def test_batch_matmul():
-    M = 10
-    K = 20
-    N = 25
-    A = np.float32(np.random.uniform(size=(M, M, K)))
-    B = np.float32(np.random.uniform(size=(M, K, N)))
-
-    def kernel(A: float32[M, M, K], B: float32[M, K, N]) -> float32[M, M, N]:
-        D = allo.bmm(A, B)
-        return D
-
-    s = allo.customize(kernel)
-    print(s.module)
-    f = s.build()
-
-    outs = np.zeros((M, M, N), dtype="float32")
-    outs = f(A, B)
-    bmm_outs = np.einsum("ijk,ikn->ijn", A, B)
-    np.testing.assert_allclose(outs, bmm_outs, atol=1e-4)
-
-
-def test_batch_matmul_only3D():
-    M = 10
-    K = 20
-    N = 25
-
-    def kernel(A: float32[M, K, K, N], B: float32[M, K, N, M]) -> float32[M, K, K, M]:
-        D = allo.bmm(A, B)
-        return D
-
-    with pytest.raises(RuntimeError) as excinfo:
-        allo.customize(kernel)
-    assert "Only support two 3D batch matrix multiplication" in str(excinfo.value)
-
-
-def test_batch_matmul_nested():
-    M = 10
-    K = 20
-    N = 25
-    A = np.random.randint(0, 20, size=(M, N, K), dtype="int32")
-    B = np.random.randint(0, 20, size=(M, K, N), dtype="int32")
-
-    def kernel(
-        A: int32[M, N, K], B: int32[M, K, N], C: int32[M, N, K]
-    ) -> int32[M, N, K]:
-        D = allo.bmm(allo.bmm(A, B), C)
-        return D
-
-    s = allo.customize(kernel)
-    print(s.module)
-    f = s.build()
-    outs = np.zeros((M, N, K), dtype="int32")
-    outs = f(A, B, A)
-    out_1 = np.einsum("ijk,ikn->ijn", A, B)
-    out_2 = np.einsum("ijk,ikn->ijn", out_1, A)
-    np.testing.assert_allclose(outs, out_2, atol=1e-4)
 
 
 if __name__ == "__main__":
@@ -969,9 +858,3 @@ if __name__ == "__main__":
     test_const_tensor_float()
     test_const_tensor_int_vars()
     test_const_tensor_float_vars()
-    test_tensor_matmul()
-    test_tensor_matmul_only2D()
-    test_tensor_matmul_nested()
-    test_batch_matmul()
-    test_batch_matmul_only3D()
-    test_batch_matmul_nested()


### PR DESCRIPTION

























<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR adds the `build_bmm()` frontend feature to support the backend function `allo.bmm()`, fixes `no_init` initial values in `build_init()` and more diverse tests by using `linalg` dialect:

```python
@staticmethod
def build_Matmul(ctx, attr, new_args):
def build_init_zero(ctx, init_op, type):
```

### Changes and examples ###
- [Frontend] Support using the function of `allo.bmm()` like this. Besides, you can also nest this func:

``` python
def kernel(
    A: int32[M, N, K], B: int32[M, K, N], C: int32[M, N, K]
) -> int32[M, N, K]:
    D = allo.bmm(allo.bmm(A, B), C)
    return D
```
The generated IR displays:
``` mlir
module {
  func.func @kernel(%arg0: memref<10x25x20xi32>, %arg1: memref<10x20x25xi32>, %arg2: memref<10x25x20xi32>) -> memref<10x25x20xi32> {
    %0 = memref.alloc() : memref<10x25x25xi32>
    %c0_i32 = arith.constant 0 : i32
    linalg.fill ins(%c0_i32 : i32) outs(%0 : memref<10x25x25xi32>)
    linalg.batch_matmul ins(%arg0, %arg1 : memref<10x25x20xi32>, memref<10x20x25xi32>) outs(%0 : memref<10x25x25xi32>)
    %1 = memref.alloc() : memref<10x25x20xi32>
    %c0_i32_0 = arith.constant 0 : i32
    linalg.fill ins(%c0_i32_0 : i32) outs(%1 : memref<10x25x20xi32>)
    linalg.batch_matmul ins(%0, %arg2 : memref<10x25x25xi32>, memref<10x25x20xi32>) outs(%1 : memref<10x25x20xi32>)
    return %1 : memref<10x25x20xi32>
  }
}
```
After building:
``` mlir
module {
  func.func @kernel(%arg0: memref<10x25x20xi32>, %arg1: memref<10x20x25xi32>) -> memref<10x25x20xi32> {
    %c0_i32 = arith.constant 0 : i32
    %c1_i32 = arith.constant 1 : i32
    %alloc = memref.alloc() {name = "C"} : memref<10x25x20xi32>
    affine.for %arg2 = 0 to 10 {
      affine.for %arg3 = 0 to 25 {
        affine.for %arg4 = 0 to 20 {
          %0 = affine.load %arg0[%arg2, %arg3, %arg4] {from = "A"} : memref<10x25x20xi32>
          %1 = arith.addi %0, %c1_i32 : i32
          affine.store %1, %alloc[%arg2, %arg3, %arg4] {to = "C"} : memref<10x25x20xi32>
        } {loop_name = "k"}
      } {loop_name = "j"}
    } {loop_name = "i", op_name = "S_i_j_k_0"}
    %alloc_0 = memref.alloc() : memref<10x25x25xi32>
    affine.for %arg2 = 0 to 10 {
      affine.for %arg3 = 0 to 25 {
        affine.for %arg4 = 0 to 25 {
          affine.store %c0_i32, %alloc_0[%arg2, %arg3, %arg4] : memref<10x25x25xi32>
        }
      }
    }
    affine.for %arg2 = 0 to 10 {
      affine.for %arg3 = 0 to 25 {
        affine.for %arg4 = 0 to 25 {
          affine.for %arg5 = 0 to 20 {
            %0 = affine.load %arg0[%arg2, %arg3, %arg5] : memref<10x25x20xi32>
            %1 = affine.load %arg1[%arg2, %arg5, %arg4] : memref<10x20x25xi32>
            %2 = affine.load %alloc_0[%arg2, %arg3, %arg4] : memref<10x25x25xi32>
            %3 = arith.muli %0, %1 : i32
            %4 = arith.addi %2, %3 : i32
            affine.store %4, %alloc_0[%arg2, %arg3, %arg4] : memref<10x25x25xi32>
          }
        }
      }
    }
    %alloc_1 = memref.alloc() : memref<10x25x20xi32>
    affine.for %arg2 = 0 to 10 {
      affine.for %arg3 = 0 to 25 {
        affine.for %arg4 = 0 to 20 {
          affine.store %c0_i32, %alloc_1[%arg2, %arg3, %arg4] : memref<10x25x20xi32>
        }
      }
    }
    affine.for %arg2 = 0 to 10 {
      affine.for %arg3 = 0 to 25 {
        affine.for %arg4 = 0 to 20 {
          affine.for %arg5 = 0 to 25 {
            %0 = affine.load %alloc_0[%arg2, %arg3, %arg5] : memref<10x25x25xi32>
            %1 = affine.load %alloc[%arg2, %arg5, %arg4] : memref<10x25x20xi32>
            %2 = affine.load %alloc_1[%arg2, %arg3, %arg4] : memref<10x25x20xi32>
            %3 = arith.muli %0, %1 : i32
            %4 = arith.addi %2, %3 : i32
            affine.store %4, %alloc_1[%arg2, %arg3, %arg4] : memref<10x25x20xi32>
          }
        }
      }
    }
    return %alloc_1 : memref<10x25x20xi32>
  }
}
```
- [Frontend fix] Add `build_init_zero()` function in ir/builder.py, which uses linalg dialect to set values to zeros.

- [Test cases] Make a new file `test_linalg.py` for linalg dialect building. Moreover, add new complex tests to ensure the robustness of codes.
## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [x] Code is well-documented














