### PR TITLE
[IR]Add semantics to allow users to directly create an array or scalar from another one defined before.

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -884,6 +884,28 @@ def test_copy_scalar():
     f = s.build(target="vhls")
     print(f)
 
+def test_copy_Arg():
+    M, N = 2, 2
+    def kernel(inp:int32[M,N]) -> int32[M, N]:
+        outp: int32[M, N] = inp
+        return outp
+
+    s = allo.customize(kernel)
+    print(s.module)
+    f = s.build(target="vhls")
+    print(f)
+
+def test_copy_Arg_scalar():
+    M, N = 2, 2
+    def kernel(inp:int32) -> int32:
+        outp: int32 = inp
+        return outp
+
+    s = allo.customize(kernel)
+    print(s.module)
+    f = s.build(target="vhls")
+    print(f)
+
 
 if __name__ == "__main__":
     test_gemm_grid_for()
@@ -921,3 +943,5 @@ if __name__ == "__main__":
     test_const_tensor_float_vars()
     test_copy_memref()
     test_copy_scalar()
+    test_copy_Arg()
+    test_copy_Arg_scalar()


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
Add semantics to allow users to use "=" directly create an array or scalar from another one defined before.

### Problems ###
In the previous version, when users want to create a copy of a defined arrays, they need to traverse all the elements of the previous one and pass the values to the new array. For example:  
```
def arrays_copy() -> int32[M, N]:
      A: int32[M, N] = 0
      B: int32[M, N]
      for i, j in allo.grid(M, N):
          B[i, j] = A[i, j]
      return B
```


### Proposed Solutions ###
Modify `build_AnnAssign()` function to permit users to use semantics like `B: int32[M, N] = A` to directly create an array or scalar from another one defined before.

### Examples ###
code:
```
def arrays_copy() -> int32[M, N]:
      A: int32[M, N] = 0
      B: int32[M, N] = A
      return B
```
MLIR output:
```
module {
  func.func @arrays_copy() -> i32 {
    %alloc = memref.alloc() {name = "A"} : memref<1xi32>
    %c0_i32 = arith.constant 0 : i32
    affine.store %c0_i32, %alloc[0] {to = "A"} : memref<1xi32>
    %alloc_0 = memref.alloc() {name = "B"} : memref<1xi32>
    %0 = affine.load %alloc[0] {from = "A"} : memref<1xi32>
    affine.store %0, %alloc_0[0] {to = "B"} : memref<1xi32>
    %1 = affine.load %alloc_0[0] {from = "B"} : memref<1xi32>
    return %1 : i32
  }
}
```

## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [x] Code is well-documented
