### PR TITLE
[IR] Add .copy function to copy memref and tensor

### DIFF
--- a/allo/dsl.py
+++ b/allo/dsl.py
@@ -33,6 +33,10 @@ def div(lhs, rhs, name=None):
     return lhs / rhs
 
 
+def copy(x, name=None):
+    return np.copy(x)
+
+
 def exp(x, name=None):
     return np.exp(x)
 

--- a/allo/ir/infer.py
+++ b/allo/ir/infer.py
@@ -519,7 +519,17 @@ class TypeInferer(ASTVisitor):
 
     @staticmethod
     def visit_library_op(ctx, node, op_name, new_args):
-        if op_name in {"exp", "softmax", "abs", "log", "add", "sub", "div", "relu"}:
+        if op_name in {
+            "exp",
+            "softmax",
+            "abs",
+            "log",
+            "add",
+            "sub",
+            "div",
+            "relu",
+            "copy",
+        }:
             # Element-wise operation
             if op_name in {"add", "sub", "div"}:
                 assert (

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -330,5 +330,39 @@ def test_linalg_broadcast_tensor(enable_tensor):
     np.testing.assert_allclose(outs, np_outs, atol=1e-3)
 
 
+def test_copy_arg():
+    M, N = 2, 2
+
+    def kernel(inp: float32[M, N]) -> float32[M, N]:
+        A = allo.copy(inp)
+        C = allo.copy(A)
+        return C
+
+    s = allo.customize(kernel)
+    print(s.module)
+
+    mod = s.build()
+    inp = np.ones((M, N)).astype(np.float32)
+    outp = mod(inp)
+    np.testing.assert_allclose(inp, outp, rtol=1e-5)
+
+
+def test_copy_const():
+    M, N = 2, 2
+
+    def kernel() -> float32[M, N]:
+        A: float32[M, N] = 1.0
+        C = allo.copy(A)
+        return C
+
+    s = allo.customize(kernel)
+    print(s.module)
+
+    mod = s.build()
+    inp = np.ones((M, N)).astype(np.float32)
+    outp = mod()
+    np.testing.assert_allclose(inp, outp, rtol=1e-5)
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
Add  `allo.copy()`  function to copy memref and tensor from another one assigned before or from an input.

### Problems and  Proposed Solutions###
In #31, we didn't finish the part of tensor. To align with NumPy's behavior, now we add `allo.copy()`  function to copy memref and tensor from another one assigned before or from an input.

### Examples ###
code:
```
def test_copy_arg_tensor():
    M, N = 2, 2

    def kernel(inp: float32[M, N]) -> float32[M, N]:
        A = allo.copy(inp)
        C = allo.copy(A)
        return C

    s = allo.customize(kernel, enable_tensor=True)
    print(s.module)

    mod = s.build()
    inp = np.ones((M, N)).astype(np.float32)
    outp = mod(inp)
    np.testing.assert_allclose(inp, outp, rtol=1e-5)
```
MLIR output:
```
module {
  func.func @kernel(%arg0: tensor<2x2xf32>) -> tensor<2x2xf32> attributes {itypes = "_", otypes = "_"} {
    %0 = tensor.empty() : tensor<2x2xf32>
    %1 = linalg.copy {cast = #linalg.type_fn<cast_signed>, op_name = "copy_0"} ins(%arg0 : tensor<2x2xf32>) outs(%0 : tensor<2x2xf32>) -> tensor<2x2xf32>
    %2 = tensor.empty() : tensor<2x2xf32>
    %3 = linalg.copy {cast = #linalg.type_fn<cast_signed>, op_name = "copy_1"} ins(%1 : tensor<2x2xf32>) outs(%2 : tensor<2x2xf32>) -> tensor<2x2xf32>
    return %3 : tensor<2x2xf32>
  }
}
```
np.testing result: Pass

## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [x] Code is well-documented

## Additional Change
In `build_library_op()`, I change the code to let the zero-initiation happen only when the operation is matmul or bmm. In this way, it can avoid generating redandunt zero-initiation in other types of operations.
