### PR TITLE
[Frontend] Add PyTorch frontend call_module builder with torch.fx

### DIFF
--- a/examples/mlp.py
+++ b/examples/mlp.py
@@ -7,19 +7,22 @@ import torch.nn as nn
 import allo
 
 
-class Model(nn.Module):
+class MLP(nn.Module):
     def __init__(self):
-        super(Model, self).__init__()
+        super().__init__()
+        self.linear1 = torch.nn.Linear(30, 30)
+        self.linear2 = torch.nn.Linear(30, 30)
 
-    def forward(self, x, y):
-        x = x + y
-        x = F.relu(x)
-        return x
+    def forward(self, data):
+        out = self.linear1(data)
+        out = self.linear2(out)
+        out = F.relu(out)
+        return out
 
 
-model = Model()
+model = MLP()
 model.eval()
-example_inputs = [torch.rand(1, 3, 10, 10), torch.rand(1, 3, 10, 10)]
+example_inputs = [torch.rand(30, 30)]
 llvm_mod = allo.frontend.from_pytorch(
     model, example_inputs=example_inputs, verbose=True
 )


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR is to add a new feature to support `call_module` builder for `torch.nn.Linear` and directly load and lower MLP layers written by PyTorch.

Different from `call_function` for `relu`, the linear module has hidden parameters, thus we need to get them and insert to arguments.

### Proposed Solutions ###
Following #49, this PR continues lowering PyTorch Model to MLIR by using [torch.fx](https://pytorch.org/docs/stable/fx.html). Actually, this PR inserts the model parameters (such as `linear.weight`, `linear.bias`) as args in the function call process. After that, users can directly write PyTorch model (e.g., MLP), which is captured and lowered to MLIR.


### How it organizes ###
We need to insert the model parameters to support Linear Layer lowering. Call `get_parameters` and then lower this params to `memref.global`. The final step is to `build_call_module` and collect it with Allo API.


### Examples ###
Users can pass MLP using this new API `allo.frontend.from_pytorch` and return an LLVM/MLIR module. Now, we display how to lower PyTorch by using a two-layer MLP example:
```python
class MLP(torch.nn.Module):
    def __init__(self):
        super().__init__()
        self.linear1 = torch.nn.Linear(30, 30)
        self.linear2 = torch.nn.Linear(30, 30)

    def forward(self, data):
        out = self.linear1(data)
        out = self.linear2(out)
        out = F.relu(out)
        return out

model = MLP()
model.eval()
example_inputs = [torch.rand(30, 30)]
llvm_mod = allo.frontend.from_pytorch(
    model, example_inputs=example_inputs, verbose=True
)
```
Firstly, it will generate fx IR by calling `gm.graph`:
```ir
graph():
    %data : [#users=1] = placeholder[target=data]
    %linear1 : [#users=1] = call_module[target=linear1](args = (%data,), kwargs = {})
    %linear2 : [#users=1] = call_module[target=linear2](args = (%linear1,), kwargs = {})
    %relu : [#users=1] = call_function[target=torch.nn.functional.relu](args = (%linear2,), kwargs = {inplace: False})
    return relu
```
Then translate it to Allo expression:
```python
def forward(data: float32[30, 30]) -> float32[30, 30]:
  linear1_weight: float32[30, 30] = g_linear1_weight
  linear1_bias: float32[30] = g_linear1_bias
  linear2_weight: float32[30, 30] = g_linear2_weight
  linear2_bias: float32[30] = g_linear2_bias
  linear1 = dsl.linear(data, linear1_weight, linear1_bias)
  linear2 = dsl.linear(linear1, linear2_weight, linear2_bias)
  relu = dsl.relu(linear2)
  return relu
```
The generated MLIR module uses linalg dialect and demonstrates all the core operations.

```mlir
module {
  memref.global "private" @linear1_weight : memref<30x30xf32> = dense<"0x3FC0AB3B827021BED980BD...">
  memref.global "private" @linear1_bias : memref<30xf32> = dense<[0.143637836, 0.00479529379, 8.589070e-03...]>
  memref.global "private" @linear2_weight : memref<30x30xf32> = dense<"0xA7AA2DBE807B0FBE746817...">
  memref.global "private" @linear2_bias : memref<30xf32> = dense<[-0.15802379, -0.131048009, 0.16979222...]>
  func.func @forward(%arg0: memref<30x30xf32>) -> memref<30x30xf32> attributes {itypes = "_", otypes = "_"} {
    %0 = memref.get_global @linear1_weight : memref<30x30xf32>
    %1 = memref.get_global @linear1_bias : memref<30xf32>
    %2 = memref.get_global @linear2_weight : memref<30x30xf32>
    %3 = memref.get_global @linear2_bias : memref<30xf32>
    %alloc = memref.alloc() : memref<30x30xf32>
    %c0_i32 = arith.constant 0 : i32
    %4 = arith.sitofp %c0_i32 : i32 to f32
    linalg.fill {op_name = "linear_init_zero_0"} ins(%4 : f32) outs(%alloc : memref<30x30xf32>)
    %alloc_0 = memref.alloc() : memref<30x30xf32>
    %c0_i32_1 = arith.constant 0 : i32
    %5 = arith.sitofp %c0_i32_1 : i32 to f32
    linalg.fill {op_name = "transpose_init_zero_1"} ins(%5 : f32) outs(%alloc_0 : memref<30x30xf32>)
    linalg.transpose ins(%0 : memref<30x30xf32>) outs(%alloc_0 : memref<30x30xf32>) permutation = [1, 0]  {op_name = "transpose_2"}
    %alloc_2 = memref.alloc() : memref<30x30xf32>
    %c0_i32_3 = arith.constant 0 : i32
    %6 = arith.sitofp %c0_i32_3 : i32 to f32
    linalg.fill {op_name = "matmul_init_zero_3"} ins(%6 : f32) outs(%alloc_2 : memref<30x30xf32>)
    linalg.matmul {cast = #linalg.type_fn<cast_signed>, op_name = "matmul_4"} ins(%arg0, %alloc_0 : memref<30x30xf32>, memref<30x30xf32>) outs(%alloc_2 : memref<30x30xf32>)
    %alloc_4 = memref.alloc() : memref<30x30xf32>
    linalg.broadcast ins(%1 : memref<30xf32>) outs(%alloc_4 : memref<30x30xf32>) dimensions = [0] 
    %alloc_5 = memref.alloc() {name = "linear1"} : memref<30x30xf32>
    %c0_i32_6 = arith.constant 0 : i32
    %7 = arith.sitofp %c0_i32_6 : i32 to f32
    linalg.fill {op_name = "add_init_zero_5"} ins(%7 : f32) outs(%alloc_5 : memref<30x30xf32>)
    linalg.add {op_name = "add_6"} ins(%alloc_2, %alloc_4 : memref<30x30xf32>, memref<30x30xf32>) outs(%alloc_5 : memref<30x30xf32>)
    %alloc_7 = memref.alloc() : memref<30x30xf32>
    %c0_i32_8 = arith.constant 0 : i32
    %8 = arith.sitofp %c0_i32_8 : i32 to f32
    linalg.fill {op_name = "linear_init_zero_7"} ins(%8 : f32) outs(%alloc_7 : memref<30x30xf32>)
    %alloc_9 = memref.alloc() : memref<30x30xf32>
    %c0_i32_10 = arith.constant 0 : i32
    %9 = arith.sitofp %c0_i32_10 : i32 to f32
    linalg.fill {op_name = "transpose_init_zero_8"} ins(%9 : f32) outs(%alloc_9 : memref<30x30xf32>)
    linalg.transpose ins(%2 : memref<30x30xf32>) outs(%alloc_9 : memref<30x30xf32>) permutation = [1, 0]  {op_name = "transpose_9"}
    %alloc_11 = memref.alloc() : memref<30x30xf32>
    %c0_i32_12 = arith.constant 0 : i32
    %10 = arith.sitofp %c0_i32_12 : i32 to f32
    linalg.fill {op_name = "matmul_init_zero_10"} ins(%10 : f32) outs(%alloc_11 : memref<30x30xf32>)
    linalg.matmul {cast = #linalg.type_fn<cast_signed>, op_name = "matmul_11"} ins(%alloc_5, %alloc_9 : memref<30x30xf32>, memref<30x30xf32>) outs(%alloc_11 : memref<30x30xf32>)
    %alloc_13 = memref.alloc() : memref<30x30xf32>
    linalg.broadcast ins(%3 : memref<30xf32>) outs(%alloc_13 : memref<30x30xf32>) dimensions = [0] 
    %alloc_14 = memref.alloc() {name = "linear2"} : memref<30x30xf32>
    %c0_i32_15 = arith.constant 0 : i32
    %11 = arith.sitofp %c0_i32_15 : i32 to f32
    linalg.fill {op_name = "add_init_zero_12"} ins(%11 : f32) outs(%alloc_14 : memref<30x30xf32>)
    linalg.add {op_name = "add_13"} ins(%alloc_11, %alloc_13 : memref<30x30xf32>, memref<30x30xf32>) outs(%alloc_14 : memref<30x30xf32>)
    %alloc_16 = memref.alloc() {name = "relu"} : memref<30x30xf32>
    %c0_i32_17 = arith.constant 0 : i32
    %12 = arith.sitofp %c0_i32_17 : i32 to f32
    linalg.fill {op_name = "relu_init_zero_14"} ins(%12 : f32) outs(%alloc_16 : memref<30x30xf32>)
    %alloc_18 = memref.alloc() : memref<30x30xf32>
    %c0_i32_19 = arith.constant 0 : i32
    linalg.fill ins(%c0_i32_19 : i32) outs(%alloc_18 : memref<30x30xf32>)
    linalg.max {op_name = "relu_15"} ins(%alloc_14, %alloc_18 : memref<30x30xf32>, memref<30x30xf32>) outs(%alloc_16 : memref<30x30xf32>)
    return %alloc_16 : memref<30x30xf32>
  }
}
```
## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [x] Code is well-documented
