### PR TITLE
[IR] Support compile-time constant expression

### DIFF
--- a/allo/ir/infer.py
+++ b/allo/ir/infer.py
@@ -46,10 +46,7 @@ class TypeInferer(ASTVisitor):
             assert dtype is not None, f"Unsupported type {node.value.id}"
             size = node.slice.value if isinstance(node.slice, ast.Index) else node.slice
             elts = size.elts if isinstance(size, ast.Tuple) else [size]
-            shape = tuple(
-                x.value if isinstance(x, ast.Constant) else ctx.global_vars[x.id]
-                for x in elts
-            )
+            shape = tuple(ASTResolver.resolve_constant(x, ctx) for x in elts)
             return dtype, shape
         if isinstance(node, ast.Name):
             dtype = ASTResolver.resolve(node, ctx.global_vars)

--- a/allo/ir/symbol_resolver.py
+++ b/allo/ir/symbol_resolver.py
@@ -57,8 +57,5 @@ class ASTResolver:
 
     @staticmethod
     def resolve_constant(node, ctx):
-        if isinstance(node, ast.Constant):
-            return node.value
-        if isinstance(node, ast.Name) and node.id in ctx.global_vars:
-            return ctx.global_vars[node.id]
-        raise RuntimeError("Unsupported constant type")
+        # pylint: disable=eval-used
+        return eval(compile(ast.Expression(node), "", "eval"), ctx.global_vars)

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -375,5 +375,21 @@ def test_copy_arg_scalar():
     assert np.array_equal(kernel(5), mod(5))
 
 
+def test_constexpr():
+    M = 10
+
+    def kernel(A: int32[((M + 1) * 2) // 2]) -> float32[M + 1]:
+        res: float32[M + 1] = 0
+        for i in range(M + 1):
+            res[i] = A[i] + 1
+        return res
+
+    s = allo.customize(kernel)
+    mod = s.build()
+    np_A = np.random.randint(0, 10, size=((M + 1) * 2) // 2).astype(np.int32)
+    np_res = mod(np_A)
+    np.testing.assert_allclose(np_res, np_A + 1)
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR adds compile-time constant expression evaluation.

### Problems ###
Currently users are able to array with fixed size like `A: int32[M, N]`, but if the shape is a constant expression (e.g., `A: int32[M * 2, N + 1]`), even though they are known compile-time, the array cannot be correctly generated.


### Proposed Solutions ###
Directly use Python builtin facilities to evaluate the expression.

```python
eval(compile(ast.Expression(node), "", "eval"), ctx.global_vars)
```

### Examples ###
See the following example. Constant expression in for loop bound is also supported.

```python
def test_constexpr():
    M = 10

    def kernel(A: int32[((M + 1) * 2) // 2]) -> float32[M + 1]:
        res: float32[M + 1] = 0
        for i in range(M + 1):
            res[i] = A[i] + 1
        return res

    s = allo.customize(kernel)
    mod = s.build()
    np_A = np.random.randint(0, 10, size=((M + 1) * 2) // 2).astype(np.int32)
    np_res = mod(np_A)
    np.testing.assert_allclose(np_res, np_A + 1)
```

## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [x] Code is well-documented
