### PR TITLE
[Primitive] Add `pack` and `unpack` primitives

### DIFF
--- a/allo/customize.py
+++ b/allo/customize.py
@@ -733,8 +733,6 @@ class Schedule:
             [],
             ip=InsertionPoint(func.entry_block.operations[0]),
         )
-        for attribute in tensor.attributes:
-            memref_orig.attributes[attribute.name] = attribute.attr
         tensor.result.replace_all_uses_with(memref_orig.result)
 
         new_type = IntegerType.get_signless(bits * factor)
@@ -849,8 +847,6 @@ class Schedule:
         # allocate a memref to replace the original argument
         ip = InsertionPoint.at_block_begin(func.entry_block)
         memref_unpacked = memref_d.AllocOp(unpacked_memref_type, [], [], ip=ip)
-        for attribute in tensor.attributes:
-            memref_unpacked.attributes[attribute.name] = attribute.attr
         tensor.result.replace_all_uses_with(memref_unpacked.result)
         with InsertionPoint(loop_band[-1].body.operations[0]):
             # build load op for packed tensor

--- a/allo/customize.py
+++ b/allo/customize.py
@@ -784,7 +784,7 @@ class Schedule:
             ub = arith_d.AddIOp(lb.result, bitwidth_cst.result)
             ub_minus_one = arith_d.SubIOp(ub.result, one_cst.result)
             res_type = IntegerType.get_signless(bits * factor)
-            val = hcl_d.SetIntSliceOp(res_type, load_packed.result, lb.result, ub_minus_one.result, load_org.result)
+            val = hcl_d.SetIntSliceOp(res_type, load_packed.result, ub_minus_one.result, lb.result, load_org.result)
             # build store
             affine_d.AffineStoreOp(val.result, tensor.result, induction_vars[:-1], affine_attr)
         
@@ -845,7 +845,9 @@ class Schedule:
             ub = arith_d.AddIOp(lb.result, bitwidth_cst.result)
             ub_minus_one = arith_d.SubIOp(ub.result, one_cst.result)
             res_type = IntegerType.get_signless(bits)
-            val = hcl_d.GetIntSliceOp(res_type, load_packed.result, lb.result, ub_minus_one.result)
+            val = hcl_d.GetIntSliceOp(res_type, load_packed.result, ub_minus_one.result, lb.result)
+            # truncate 
+            # val = arith_d.TruncIOp(memref_unpacked.result.type.element_type, load_packed.result)
             # build store
             in_str = ", ".join([f"d{i}" for i in range(len(loop_band))])
             out_str = ""

--- a/tests/test_schedule_compose.py
+++ b/tests/test_schedule_compose.py
@@ -312,7 +312,7 @@ def test_nested_compose_partition():
 
 def test_compose_pack_unpack():
     T = int32
-    
+
     def func1(A: T[10, 20], B: T[10, 20]):
         for i, j in allo.grid(10, 20):
             B[i, j] = A[i, j] + 1
@@ -342,6 +342,7 @@ def test_compose_pack_unpack():
     f = sch.build()
     allo_C = f(np_A)
     assert np.allclose(allo_C, np_C)
+
 
 def test_reuse_function_1():
     M, N = 2, 2

--- a/tests/test_schedule_stream.py
+++ b/tests/test_schedule_stream.py
@@ -122,7 +122,7 @@ def test_fork_join_function():
 
 def test_pack_unpack():
     T = int32
-    
+
     def func1(A: T[10, 20], B: T[10, 20]):
         for i, j in allo.grid(10, 20):
             B[i, j] = A[i, j] + 1

--- a/tests/test_schedule_stream.py
+++ b/tests/test_schedule_stream.py
@@ -3,7 +3,7 @@
 
 import allo
 import pytest
-from allo.ir.types import Fixed, int32, int64
+from allo.ir.types import Fixed, int32
 
 
 def test_two_bands():

--- a/tests/test_schedule_stream.py
+++ b/tests/test_schedule_stream.py
@@ -144,18 +144,15 @@ def test_pack_unpack():
     sch2 = allo.customize(func2)
     sch2.unpack(sch2.B, axis=0, factor=2)
 
-    # top-level customization
     sch = allo.customize(top)
-    sch.use_def_chain.dump_graph('top')
-    tensors = sch.use_def_chain.get_equivalent_tensors('top:B')
-
     sch.compose(sch1, sch2)
-    print(sch.module)
     sch.to(sch.B, "func2")
+
     code = sch.build(target="vhls").hls_code
-    print(code)
+    # remove all space, new line, tab
+    code = "".join(code.split())
+    assert "hls::stream<int64_t>B" in code
 
 
 if __name__ == "__main__":
-    # pytest.main([__file__])
-    test_pack_unpack()
+    pytest.main([__file__])


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR adds two customization primitives `pack` and `unpack` for function interface bit packing/unpacking.

### Problems ###
For dataflow designs, `pack` and `unpack` are useful for building wider FIFOs and transferring more data per transaction. For examples, the producer can pack two `int32` values into one `int64` value and transfer it through a FIFO in one transaction. 

### Proposed Solutions ###
We use the same `pack`/`unpack` abstraction from HeteroCL, but instead of being APIs they are now decoupled customizations:
```python
schedule.pack(tensor, axis, factor, name, dtype):
schedule.unpack(tensor, axis, factor, name, dtype):
```
- `tensor`: target tensor type function argument to pack/unpack
- `axis`: target axis of the tensor to pack/unpack. For example: packing a `int32[10, 20]` on axis 0 by factor 2 produces `int64[5, 20]`.
- `factor`: pack/unpack factor
- `dtype`: the destination data type. If factor is not given, this destination data type is used to compute the pack/unpack factor.



### Examples ###

Pack and unpack change the function interface and builds pack/unpack logic in the function body. The following example is a producer-consumer set up where `B` is first packed in `func1` and unpacked in `func2`. 

```python
T = int32

def func1(A: T[10, 20], B: T[10, 20]):
    for i, j in allo.grid(10, 20):
        B[i, j] = A[i, j] + 1

def func2(B: T[10, 20], C: T[10, 20]):
    for i, j in allo.grid(10, 20):
        C[i, j] = B[i, j] * 2

def top(A: T[10, 20]) -> T[10, 20]:
    B: T[10, 20]
    C: T[10, 20]
    func1(A, B)
    func2(B, C)
    return C

sch1 = allo.customize(func1)
sch1.pack(sch1.B, axis=0, factor=2)

sch2 = allo.customize(func2)
sch2.unpack(sch2.B, axis=0, factor=2)

sch = allo.customize(top)
sch.compose(sch1, sch2)
sch.to(sch.B, "func2")
```

These customizations generate the following HLS code:
```cpp
void func1(
  int32_t v0[10][20],
  hls::stream< int64_t > &v1 /* v1[5][20] */
) {     // L2
  #pragma HLS stream variable=v1 depth=100
  int32_t v2[10][20];   // L3
  l_S_i_j_0_i: for (int i = 0; i < 10; i++) {   // L4
    l_j: for (int j = 0; j < 20; j++) { // L5
      int32_t v5 = v0[i][j];    // L6
      ap_int<33> v6 = v5;       // L7
      ap_int<33> v7 = v6 + 1;   // L10
      int32_t v8 = v7;  // L11
      v2[i][j] = v8;    // L12
    }
  }
  l_S_loop_loop_l_0: for (int loop_l_0 = 0; loop_l_0 < 5; loop_l_0++) { // L15
    l_loop_l_1: for (int loop_l_1 = 0; loop_l_1 < 20; loop_l_1++) {     // L16
      l_loop_l_2: for (int loop_l_2 = 0; loop_l_2 < 2; loop_l_2++) {    // L17
        int32_t v12 = v2[((loop_l_0 * 2) + loop_l_2)][loop_l_1];        // L18
        int64_t v13 = v1.read(); // v1[loop_l_0][loop_l_1];     // L19
        int v14 = loop_l_2 * 32;        // L22
        int v15 = v14 + 32;     // L23
        int v16 = v15 - 1;      // L24
        v13(v16, v14) = v12;    // L25
        v1.write(int64_t v17); // v1[loop_l_0][loop_l_1] = v17; // L26
      }
    }
  }
}

void func2(
  hls::stream< int64_t > &v18 /* v18[5][20] */,
  int32_t v19[10][20]
) {     // L32
  #pragma HLS stream variable=v18 depth=100
  int32_t v20[10][20];  // L33
  l_S_loop_loop_l_01: for (int loop_l_01 = 0; loop_l_01 < 5; loop_l_01++) {     // L34
    l_loop_l_11: for (int loop_l_11 = 0; loop_l_11 < 20; loop_l_11++) { // L35
      l_loop_l_21: for (int loop_l_21 = 0; loop_l_21 < 2; loop_l_21++) {        // L36
        int64_t v24 = v18.read(); // v18[loop_l_01][loop_l_11]; // L37
        int v25 = loop_l_21 * 32;       // L40
        int v26 = v25 + 32;     // L41
        int v27 = v26 - 1;      // L42
        int32_t v28 = v24(v27, v25);    // L43
        v20[((loop_l_01 * 2) + loop_l_21)][loop_l_11] = v28;    // L44
      }
    }
  }
  l_S_i_j_0_i1: for (int i1 = 0; i1 < 10; i1++) {       // L48
    l_j1: for (int j1 = 0; j1 < 20; j1++) {     // L49
      int32_t v31 = v20[i1][j1];        // L50
      int64_t v32 = v31;        // L51
      int64_t v33 = v32 * 2;    // L54
      int32_t v34 = v33;        // L55
      v19[i1][j1] = v34;        // L56
    }
  }
}

void top(
  int32_t v35[10][20],
  int32_t v36[10][20]
) {     // L61
  #pragma HLS dataflow
  hls::stream< int64_t > B /* B[5][20] */;      // L62
  #pragma HLS stream variable=B depth=100
  func1(v35, B);        // L64
  func2(B, v36);        // L65
}
```

Notice that the FIFO has a packed element type `i64`, and there are packing logic at the end of `func1` and unpacking logic at the beginning of `func2`.

## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [ ] Code is well-documented
