### PR TITLE
[Build] Update build.sh script to install Python dependencies (Fix #131)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,6 +5,9 @@
 # Pull the LLVM project and hcl-mlir dialect
 git submodule update --init --recursive
 
+# Install the required Python packages
+python3 -m pip install -r requirements.txt
+
 # Note: we need to patch the LLVM project to add additional
 # supports for Python binding
 echo "Patching LLVM project ..."
@@ -15,7 +18,7 @@ git apply llvm_patch
 # Install LLVM v18.x
 # Make sure you are in the correct Python environment
 echo "Installing LLVM v18.x ..."
-mkdir build && cd build
+mkdir -p build && cd build
 cmake -G "Unix Makefiles" ../llvm \
    -DLLVM_ENABLE_PROJECTS=mlir \
    -DLLVM_BUILD_EXAMPLES=ON \
@@ -34,7 +37,7 @@ echo "LLVM build directory: $LLVM_BUILD_DIR"
 # Build the hcl dialect
 echo "Building hcl dialect ..."
 cd ../../..
-mkdir build && cd build
+mkdir -p build && cd build
 cmake -G "Unix Makefiles" .. \
    -DMLIR_DIR=$LLVM_BUILD_DIR/lib/cmake/mlir \
    -DLLVM_EXTERNAL_LIT=$LLVM_BUILD_DIR/bin/llvm-lit \


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR updates the `build.sh` script to install Python dependencies before building LLVM18.x.

### Problems ###
Building LLVM18.x with Python binding enabled requires numpy. The error message during cmake is:
```
  Could NOT find Python3 (missing: Python3_INCLUDE_DIRS
  Python3_NumPy_INCLUDE_DIRS Development.Module NumPy)
```

### Proposed Solutions ###
When user run `bash build.sh`, install python requirements as well.

## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
