### PR TITLE
[PyTorch] Support for Conv2D

### DIFF
--- a/allo/frontend/pytorch.py
+++ b/allo/frontend/pytorch.py
@@ -156,6 +156,7 @@ class TorchBuilder:
             torch.nn.Dropout: "identity",
             torch.nn.GELU: "gelu",
             torch.nn.LayerNorm: "layernorm",
+            torch.nn.Conv2d: "conv2d",
         }.get(type(module), None)
         if self.leaf_modules:
             for leaf_module in self.leaf_modules:
@@ -390,3 +391,9 @@ class TorchBuilder:
         if src not in self.subfunctions:
             self.subfunctions.append(src)
         return f"{node.name} = KVCache({', '.join([get_var_name(arg) for arg in node.args])})"
+    
+    def build_conv2d(self, node):
+        target_name = node.target.replace(".", "_")
+        inp = get_var_name(node.args[0])
+        filter = get_var_name(target_name + "_weight")
+        return f"{node.name} = dsl.conv2d({inp}, {filter})"

--- a/examples/conv.py
+++ b/examples/conv.py
@@ -1,0 +1,40 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import allo
+
+in_channels = 3
+out_channels = 10
+kernel_size = 3
+
+N = 2 # batch size
+C = 3 # num of channels
+H = 8 # image height
+W = 5 # image width
+
+out_features = 2
+
+class ImageClassify(nn.Module):
+    def __init__(self):
+        super(ImageClassify, self).__init__()
+        self.conv = nn.Conv2d(in_channels, out_channels, kernel_size)
+        self.linear = nn.Linear(C * H * W, out_features)
+        self.relu = F.relu
+        
+    def forward(self, x):
+        x = self.conv(x)
+        x = self.relu(x)
+        x = x.view(-1, C * H * W)
+        x = self.linear(x)
+        return x
+
+model = ImageClassify()
+model.eval()
+example_inputs = [torch.rand(N, C, H, W)]
+llvm_mod = allo.frontend.from_pytorch(
+    model, example_inputs=example_inputs, verbose=False
+)
+golden = model(*example_inputs)
+np_inputs = [x.detach().numpy() for x in example_inputs]
+res = llvm_mod(*np_inputs)
+torch.testing.assert_close(res, golden.detach().numpy())


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR works on enabling the lowering of PyTorch Conv2D module. I added the corresponding `build_` function in `frontend/pytorch.py`

### Problems ###
I want to enable the lower of [`torch.nn.Conv2D`](https://pytorch.org/docs/stable/generated/torch.nn.Conv2d.html).


### Proposed Solutions ###
I [added `torch.nn.Conv2d` into `build_call_module`](https://github.com/cornell-zhang/allo/blob/cbea5d25ee12a5821db23dd43163eaebc9d851e0/allo/frontend/pytorch.py#L159) and [added the corresponding `build_conv2d`](https://github.com/cornell-zhang/allo/blob/cbea5d25ee12a5821db23dd43163eaebc9d851e0/allo/frontend/pytorch.py#L395).


### Examples ###
```python
class ImageClassify(nn.Module):
    def __init__(self):
        super(ImageClassify, self).__init__()
        self.conv = nn.Conv2d(in_channels, out_channels, kernel_size)
        self.linear = nn.Linear(C * H * W, out_features)
        self.relu = F.relu
        
    def forward(self, x):
        x = self.conv(x)
        x = self.relu(x)
        x = x.view(-1, C * H * W)
        x = self.linear(x)
        return x

model = ImageClassify()
model.eval()
example_inputs = [torch.empty(N, C, H, W).random_(256)]
llvm_mod = allo.frontend.from_pytorch(
    model, example_inputs=example_inputs, verbose=False
)
golden = model(*example_inputs)
np_inputs = [x.detach().numpy() for x in example_inputs]
torch.testing.assert_close(res, golden.detach().numpy(), atol=1e-1, rtol=1e-2)
```

## Still Problems ##
I have to set `atol` to `1e-1` and `rtol` to `1e-2` to pass the`assert_close` test.

## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [x] Code is well-documented
