### PR TITLE
[Backend] Unify csim and hw/sw_emu codegen

### DIFF
--- a/allo/backend/hls.py
+++ b/allo/backend/hls.py
@@ -10,6 +10,7 @@ import time
 from hcl_mlir.dialects import hcl as hcl_d
 from hcl_mlir.ir import (
     Context,
+    Location,
     Module,
 )
 from hcl_mlir.passmanager import PassManager
@@ -25,9 +26,11 @@ from .report import parse_xml
 from ..passes import (
     _mlir_lower_pipeline,
     decompose_library_function,
+    generate_input_output_buffers,
 )
 from ..harness.makefile_gen.makegen import generate_makefile
 from ..ir.transform import find_func_in_module
+from .. import primitives as prim
 
 
 def run_process(cmd, pattern=None):
@@ -110,7 +113,7 @@ def separate_header(hls_code, top=None):
     sig_str = "#ifndef KERNEL_H\n"
     sig_str += "#define KERNEL_H\n\n"
     args = []
-    sig_str += "extern \"C\" {\n"
+    sig_str += 'extern "C" {\n'
     for line in hls_code.split("\n"):
         if line.startswith(f"void {top}"):
             func_decl = True
@@ -129,7 +132,7 @@ def separate_header(hls_code, top=None):
             shape = tuple(s.split("]")[0] for s in arg_type.split("[")[1:])
             args.append((allo_type, shape))
             sig_str += "  " + ele_type + " *" + var + f"{comma}\n"
-    sig_str += "} // extern \"C\"\n"
+    sig_str += '} // extern "C"\n'
     sig_str += "\n#endif // KERNEL_H\n"
     return sig_str, args
 
@@ -143,16 +146,46 @@ class HLSModule:
         mode=None,
         project=None,
         ext_libs=None,
+        configs=None,
+        func_args=None,
     ):
         self.top_func_name = top_func_name
         self.mode = mode
         self.project = project
         self.platform = platform
         self.ext_libs = [] if ext_libs is None else ext_libs
-        with Context() as ctx:
+        with Context() as ctx, Location.unknown():
             hcl_d.register_dialect(ctx)
             self.module = Module.parse(str(mod), ctx)
             self.func = find_func_in_module(self.module, top_func_name)
+            if platform == "vitis_hls":
+                if configs is not None:
+                    mappings = configs.get("mappings", None)
+                else:
+                    mappings = None
+                buffers = generate_input_output_buffers(
+                    self.func, flatten=True, mappings=mappings
+                )
+                if "dataflow" in self.func.attributes:
+                    assert func_args is not None, "Need to specify func_args"
+                    for inp in buffers["inputs"]:
+                        prim.to(
+                            self.module,
+                            inp,
+                            "",
+                            depth=4,
+                            func_args=func_args,
+                            top_func_name=top_func_name,
+                        )
+                    for out in buffers["outputs"]:
+                        prim.to(
+                            self.module,
+                            out,
+                            "",
+                            depth=4,
+                            func_args=func_args,
+                            top_func_name=top_func_name,
+                        )
             self.module = decompose_library_function(self.module)
             _mlir_lower_pipeline(self.module, lower_linalg=True)
             # Run through lowering passes
@@ -194,14 +227,10 @@ class HLSModule:
                     update_makefile(
                         os.path.join(project, f"makefile_{postfix}.mk"), self.ext_libs
                     )
-                header, self.args = separate_header(
-                    self.hls_code, self.top_func_name
-                )
+                header, self.args = separate_header(self.hls_code, self.top_func_name)
                 with open(f"{project}/kernel.h", "w", encoding="utf-8") as outfile:
                     outfile.write(header)
-                self.hls_code = postprocess_hls_code(
-                    self.hls_code, self.top_func_name
-                )
+                self.hls_code = postprocess_hls_code(self.hls_code, self.top_func_name)
                 for lib in self.ext_libs:
                     for header in lib.headers:
                         header = header.split("/")[-1]

--- a/allo/primitives/__init__.py
+++ b/allo/primitives/__init__.py
@@ -1,0 +1,5 @@
+# Copyright Allo authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+# pylint: disable=redefined-builtin
+
+from .relay import _to as to

--- a/allo/primitives/__init__.py
+++ b/allo/primitives/__init__.py
@@ -1,5 +1,4 @@
 # Copyright Allo authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=redefined-builtin
 
 from .relay import _to as to

--- a/allo/primitives/relay.py
+++ b/allo/primitives/relay.py
@@ -1,0 +1,93 @@
+# Copyright Allo authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from hcl_mlir.ir import (
+    InsertionPoint,
+    StringAttr,
+    UnitAttr,
+    IntegerType,
+    IntegerAttr,
+    TypeAttr,
+    FunctionType,
+    MemRefType,
+)
+from hcl_mlir.dialects import (
+    hcl as hcl_d,
+    memref as memref_d,
+    func as func_d,
+)
+from hcl_mlir.ir import Type as MLIRType
+from ..ir.transform import update_streaming_interface, find_buffer, find_func_in_module
+
+
+def _to(module, target, dst, axis=None, depth=-1, func_args=None, top_func_name=None):
+    assert func_args is not None, "Need to specify func_args"
+    assert top_func_name is not None, "Need to specify top_func_name"
+    func, _, target = find_buffer(module, target, func_args)
+    func.attributes["dataflow"] = UnitAttr.get()
+    top_func = find_func_in_module(module, top_func_name)
+    ip = InsertionPoint.at_block_terminator(top_func.entry_block)
+    # pylint: disable=too-many-nested-blocks
+    if axis is None:
+        op_hdl = hcl_d.CreateOpHandleOp(StringAttr.get(dst), ip=ip)
+        i32 = IntegerType.get_signless(32)
+        hcl_d.InterKernelToOp(
+            target.result,
+            op_hdl.result,
+            fifo_depth=IntegerAttr.get(i32, depth),
+            ip=ip,
+        )
+        update_streaming_interface(module, target, depth=depth)
+    else:
+        assert dst is not None, "Need to specify dst"
+        # TODO: fix the ad-hoc logic here
+        memref = MemRefType(target.result.type)
+        space_time_label = ["T"] * len(memref.shape)
+        for idx in dst:
+            space_time_label[idx] = "S"
+        memory_space = f"stream:{depth};{''.join(space_time_label)}"
+        new_memref = MemRefType.get(
+            memref.shape,
+            memref.element_type,
+            memref.layout,
+            StringAttr.get(memory_space),
+        )
+        new_alloc = memref_d.AllocOp(new_memref, [], [], ip=InsertionPoint(target))
+        new_alloc.attributes["name"] = target.attributes["name"]
+        target.result.replace_all_uses_with(new_alloc.result)
+        for use in new_alloc.result.uses:
+            op = use.owner
+            if isinstance(op, memref_d.SubViewOp):
+                subview_memref = MLIRType.parse(
+                    str(op.result.type)[:-1] + f', "{memory_space}">'
+                )
+                subview = memref_d.SubViewOp(
+                    source=op.source,
+                    result=subview_memref,
+                    static_offsets=op.static_offsets,
+                    static_sizes=op.static_sizes,
+                    static_strides=op.static_strides,
+                    offsets=op.offsets,
+                    sizes=[],
+                    strides=[],
+                    ip=InsertionPoint(op),
+                )
+                op.result.replace_all_uses_with(subview.result)
+                op.operation.erase()
+        target.operation.erase()
+        # Find target in the top function
+        for op in func.entry_block.operations:
+            if isinstance(op, func_d.CallOp):
+                for func in module.body.operations:
+                    if (
+                        isinstance(func, func_d.FuncOp)
+                        and func.name.value == op.attributes["callee"].value
+                    ):
+                        out_types = func.attributes["function_type"].value.results
+                        new_in_types = []
+                        for i, operand in enumerate(op.operands):
+                            new_in_types.append(operand.type)
+                        func_type = FunctionType.get(new_in_types, out_types)
+                        func.attributes["function_type"] = TypeAttr.get(func_type)
+                        for i, arg in enumerate(func.arguments):
+                            arg.set_type(new_in_types[i])

--- a/allo/primitives/relay.py
+++ b/allo/primitives/relay.py
@@ -1,5 +1,6 @@
 # Copyright Allo authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+# pylint: disable=no-name-in-module
 
 from hcl_mlir.ir import (
     InsertionPoint,

--- a/tests/ip_integration/test_external.py
+++ b/tests/ip_integration/test_external.py
@@ -128,5 +128,4 @@ def test_systolic_stream():
 
 
 if __name__ == "__main__":
-    # pytest.main([__file__])
-    test_extern_c()
+    pytest.main([__file__])

--- a/tests/ip_integration/test_external.py
+++ b/tests/ip_integration/test_external.py
@@ -24,6 +24,22 @@ def test_pybind11():
     print("Passed!")
 
 
+def test_extern_c():
+    vadd = allo.IPModule(
+        top="vadd",
+        headers=["vadd_extern.h"],
+        impls=["vadd_extern.cpp"],
+        signature=["int32[32]", "int32[32]", "int32[32]"],
+        link_hls=False,
+    )
+    np_A = np.random.randint(0, 100, (32,)).astype(np.int32)
+    np_B = np.random.randint(0, 100, (32,)).astype(np.int32)
+    np_C = np.zeros((32,), dtype=np.int32)
+    vadd(np_A, np_B, np_C)
+    np.testing.assert_allclose(np_A + np_B, np_C, atol=1e-6)
+    print("Passed!")
+
+
 def test_shared_lib():
     vadd = allo.IPModule(
         top="vadd",
@@ -112,4 +128,5 @@ def test_systolic_stream():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    # pytest.main([__file__])
+    test_extern_c()

--- a/tests/ip_integration/vadd.cpp
+++ b/tests/ip_integration/vadd.cpp
@@ -1,3 +1,8 @@
+/*
+ * Copyright Allo authors. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <iostream>
 #include "vadd.h"
 using namespace std;

--- a/tests/ip_integration/vadd_extern.cpp
+++ b/tests/ip_integration/vadd_extern.cpp
@@ -1,0 +1,13 @@
+#include <iostream>
+#include "vadd_extern.h"
+using namespace std;
+
+extern "C" {
+
+void vadd(int *A, int *B, int *C) {
+  for (int i = 0; i < 32; ++i) {
+    C[i] = A[i] + B[i];
+  }
+}
+
+} // extern "C"

--- a/tests/ip_integration/vadd_extern.h
+++ b/tests/ip_integration/vadd_extern.h
@@ -1,0 +1,13 @@
+/*
+ * Copyright Allo authors. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef VADD_H
+#define VADD_H
+
+extern "C" {
+void vadd(int *A, int *B, int *C);
+} // extern "C"
+
+#endif // VADD_H

--- a/tests/test_vhls.py
+++ b/tests/test_vhls.py
@@ -45,6 +45,15 @@ def test_vitis_gemm():
     print(s.module)
     mod = s.build(target="vitis_hls", mode="sw_emu", project="gemm_vitis.prj")
     print(mod.hls_code)
+    if os.system("which vitis_hls >> /dev/null") == 0:
+        mod = s.build(target="vitis_hls", mode="csim", project="gemm_vitis_csim.prj")
+        np_A = np.random.randint(0, 10, size=(32, 32)).astype(np.int32)
+        np_B = np.random.randint(0, 10, size=(32, 32)).astype(np.int32)
+        np_C = np.matmul(np_A, np_B)
+        np_C_allo = np.zeros((32, 32), dtype=np.int32)
+        mod(np_A, np_B, np_C_allo)
+        np.testing.assert_allclose(np_C, np_C_allo, rtol=1e-5)
+        print("Passed!")
 
 
 def test_vitis_io_stream():


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR unifies the csim and hw/sw_emu interface. Previously the csim interface will generate explicit arrays for pybind to operator. However, this is not necessary, and pybind can work on pointer interface. Therefore, we do not need two different codegens for csim and hw/sw_emu, which can also make sure the simulated code is exactly the code used to generate hardware accelerator.

Since the dataflow interface may need to change the function arguments, the `generate_input_output_buffers` and `update_interface` passes are both moved into the `HLSModule`. The implementation of the `.to()` primitive is now separated from the `customize.py` file to enable other files to invoke it.

### Examples ###
```python
def test_vitis_gemm():
    def gemm(A: int32[32, 32], B: int32[32, 32]) -> int32[32, 32]:
        C: int32[32, 32] = 0
        for i, j, k in allo.grid(32, 32, 32, name="C"):
            C[i, j] += A[i, k] * B[k, j]
        return C

    s = allo.customize(gemm)
    print(s.module)
    mod = s.build(target="vitis_hls", mode="sw_emu", project="gemm_vitis.prj")
    print(mod.hls_code)
    mod = s.build(target="vitis_hls", mode="csim", project="gemm_vitis_csim.prj")
    np_A = np.random.randint(0, 10, size=(32, 32)).astype(np.int32)
    np_B = np.random.randint(0, 10, size=(32, 32)).astype(np.int32)
    np_C = np.matmul(np_A, np_B)
    np_C_allo = np.zeros((32, 32), dtype=np.int32)
    mod(np_A, np_B, np_C_allo)
    np.testing.assert_allclose(np_C, np_C_allo, rtol=1e-5)
    print("Passed!")
```

## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [x] Code is well-documented
