### PR TITLE
[Builder] Support comment blocks for Allo kernels

### DIFF
--- a/allo/ir/builder.py
+++ b/allo/ir/builder.py
@@ -507,9 +507,11 @@ class ASTTransformer(ASTBuilder):
                     ip=ctx.get_ip(),
                     inputs=[op.result],
                     outputs=[alloc_op.result],
-                    result_tensors=[RankedTensorType.get(shape, mlir_type)]
-                    if ctx.enable_tensor
-                    else [],
+                    result_tensors=(
+                        [RankedTensorType.get(shape, mlir_type)]
+                        if ctx.enable_tensor
+                        else []
+                    ),
                     iterator_types=iterator_types_attr,
                 )
                 # create block
@@ -2070,7 +2072,12 @@ class ASTTransformer(ASTBuilder):
 
     @staticmethod
     def build_Expr(ctx, node):
-        return build_stmt(ctx, node.value)
+        if isinstance(node.value, ast.Constant):
+            # Python comments
+            return
+        if isinstance(node.value, ast.Call):
+            return build_stmt(ctx, node.value)
+        raise RuntimeError("Unsupported expression")
 
     @staticmethod
     def build_Pass(ctx, node):

--- a/allo/ir/infer.py
+++ b/allo/ir/infer.py
@@ -894,10 +894,17 @@ class TypeInferer(ASTVisitor):
 
     @staticmethod
     def visit_Expr(ctx, node):
-        visit_stmt(ctx, node.value)
-        node.dtype = None
-        node.shape = None
-        return node
+        if isinstance(node.value, ast.Constant):
+            # Python comments
+            node.dtype = None
+            node.shape = None
+            return node
+        if isinstance(node.value, ast.Call):
+            visit_stmt(ctx, node.value)
+            node.dtype = None
+            node.shape = None
+            return node
+        raise RuntimeError(f"Unsupported expression: {node.value}")
 
     @staticmethod
     def visit_Pass(ctx, node):

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -5,7 +5,7 @@ import os
 import numpy as np
 import pytest
 import allo
-from allo.ir.types import int32, float32, index
+from allo.ir.types import int8, int32, float32, index
 import allo.backend.hls as hls
 
 
@@ -558,6 +558,14 @@ def test_dynamic_shape():
     np.testing.assert_allclose(np_A, allo_A)
     code = s.build(target="vhls")
     print(code)
+
+
+def test_comments():
+    def top(x_in: "int8[1]") -> "int8":
+        """Test text"""
+        return x_in[0]
+
+    print(allo.customize(top, verbose=True).build()(np.array([5], dtype=np.int8)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR adds support for comment blocks inside the Allo kernels, which should fix #145.

## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [x] Code is well-documented
