### PR TITLE
[Utils] Unify loop utils naming convention

### DIFF
--- a/allo/customize.py
+++ b/allo/customize.py
@@ -669,7 +669,8 @@ class Schedule:
                         args[0] = get_name(args[0])
                 with self.module.context, Location.unknown():
                     primitive_func = getattr(self, primitive[0])
-                    primitive_func.__wrapped__(self, *args, **kwargs)
+                    # directly apply primitives to new functions
+                    primitive_func(*args, **kwargs)
                     self.primitive_sequences.append((primitive[0], args, kwargs))
 
     def build(self, target=None, mode=None, project=None, configs=None):

--- a/allo/customize.py
+++ b/allo/customize.py
@@ -179,11 +179,7 @@ class Schedule:
 
     def _get_func_and_axis(self, axis):
         if isinstance(axis, LoopWrapper):
-            func = (
-                self._find_function(axis.path)
-                if axis.path is not None
-                else self.top_func
-            )
+            func = self._find_function(axis.func)
             return func, axis
         if ":" in axis:
             func_name, axis = axis.split(":")
@@ -267,7 +263,7 @@ class Schedule:
         for parray, items in self.partitioned_arrays.items():
             for item in items:
                 if (
-                    parray.split(":")[0] == target.path
+                    parray.split(":")[0] == target.func
                     and parray.split(":")[1] == target.name
                 ):
                     if item[0] == Partition.Complete and item[1] == 0:
@@ -284,7 +280,7 @@ class Schedule:
         visited_func_calls = []
 
         def recursive_partition(inner_target):
-            name = f"{inner_target.path}:{inner_target.name}"
+            name = f"{inner_target.func}:{inner_target.name}"
             if name in visited_target_names:
                 return
             visited_target_names.append(name)
@@ -484,7 +480,7 @@ class Schedule:
                         if (
                             isinstance(op, memref_d.AllocOp)
                             and "name" in op.attributes
-                            and StringAttr(band_name).value + "_reuse"
+                            and band_name + "_reuse"
                             in StringAttr(op.attributes["name"]).value
                         ):
                             res.append(op)
@@ -603,13 +599,13 @@ class Schedule:
         def get_name(arg):
             if isinstance(arg, (LoopWrapper, MockBuffer)):
                 arg = copy.copy(arg)
-                orig_func_name = arg.path if arg.path is not None else sch.top_func_name
+                orig_func_name = arg.func if arg.func is not None else sch.top_func_name
                 func_name = (
                     orig_func_name if id is None else orig_func_name + "_" + str(id)
                 )
                 if self._find_function(func_name, error=False) is None:
                     func_name = orig_func_name + "_0"
-                arg.path = func_name
+                arg.func = func_name
                 return arg
             orig_func_name = arg.split(":")[0] if ":" in arg else sch.top_func_name
             arg = arg.split(":")[1] if ":" in arg else arg

--- a/allo/ir/transform.py
+++ b/allo/ir/transform.py
@@ -29,8 +29,8 @@ class LoopWrapper:
     def __init__(self, name, loop):
         self.name = name
         self.loop = loop
-        # used for function name
-        self.path = None
+        self.func = self.name.split(":")[0]
+        self.band = self.name.split(":")[1].split(".")[0]
 
     def __repr__(self):
         return f"LoopWrapper({self.name})"
@@ -40,12 +40,12 @@ class LoopBand:
     def __init__(self):
         """
         Loops will be directly attached to this class as an attribute
+        Naming convention: `func:band.loop`
         """
         self.loops = {}
 
-    def add_loop(self, path, name, loop):
-        if path != "":
-            full_name = f"{path}.{name}"
+    def add_loop(self, func, band, name, loop):
+        full_name = f"{func}:{band}.{name}"
         if not isinstance(loop, LoopBand):
             loop = LoopWrapper(full_name, loop)
         self.loops[name] = loop
@@ -119,20 +119,33 @@ def find_buffer(module, target, func_args):
 
 
 def find_loop_in_bands(func, axis):
+    """
+    Parameters
+    ----------
+    func: hcl_mlir.ir.func.FuncOp
+        The function to search for the loop
+    axis: str or LoopWrapper
+        The name of the loop or the LoopWrapper object
+
+    Returns
+    -------
+    band_name, str
+        The name of the band containing the loop
+    axis_name: str
+        The name of the loop
+    """
     results = []
     bands = get_affine_loop_nests(func)
     # pylint: disable=no-else-return
     if isinstance(axis, LoopWrapper):
-        assert "." in axis.name
-        path, axis = axis.name.split(".", 1)
-        return path, axis
+        return axis.band, axis.name.split(".", 1)[1]
     elif isinstance(axis, affine_d.AffineForOp):
         axis_name = StringAttr(axis.attributes["loop_name"]).value
         for _, band in bands:
             op_name = None
             for i, (_, for_loop) in enumerate(band):
                 if i == 0:
-                    op_name = for_loop.attributes["op_name"]
+                    op_name = StringAttr(for_loop.attributes["op_name"]).value
                 if for_loop == axis:
                     return op_name, axis_name
         raise RuntimeError(f"Cannot find the band of loop {axis_name}")
@@ -142,7 +155,7 @@ def find_loop_in_bands(func, axis):
             op_name = None
             for i, (name, for_loop) in enumerate(band):
                 if i == 0:
-                    op_name = for_loop.loop.attributes["op_name"]
+                    op_name = StringAttr(for_loop.loop.attributes["op_name"]).value
                 if name == axis_name:
                     results.append(op_name)
         if len(results) == 0:
@@ -155,7 +168,7 @@ def find_loop_in_bands(func, axis):
 def get_affine_loop_nests(func):
     cnt_unnamed = 0
 
-    def DFS(operations, band, path=""):
+    def DFS(operations, band):
         nonlocal cnt_unnamed
         for op in operations:
             if isinstance(op, affine_d.AffineForOp):
@@ -164,23 +177,25 @@ def get_affine_loop_nests(func):
                     cnt_unnamed += 1
                 else:
                     name = StringAttr(op.attributes["loop_name"]).value
-                band.add_loop(path, name, op)
-                DFS(op.body.operations, band, path)
+                band.add_loop(func_name, band_name, name, op)
+                DFS(op.body.operations, band)
             elif isinstance(op, (affine_d.AffineIfOp, scf_d.IfOp)):
-                DFS(op.then_block.operations, band, path)
+                DFS(op.then_block.operations, band)
                 try:
-                    DFS(op.else_block.operations, band, path)
+                    DFS(op.else_block.operations, band)
                 except IndexError:
                     pass
 
     results = LoopBand()
+    # get function name
+    func_name = func.attributes["sym_name"].value
     for op in func.entry_block.operations:
         if isinstance(op, affine_d.AffineForOp):  # outer-most
             band_name = StringAttr(op.attributes["op_name"]).value
             band = LoopBand()
-            band.add_loop(band_name, StringAttr(op.attributes["loop_name"]).value, op)
-            DFS(op.body.operations, band, path=band_name)
-            results.add_loop("", band_name, band)
+            band.add_loop(func_name, band_name, StringAttr(op.attributes["loop_name"]).value, op)
+            DFS(op.body.operations, band)
+            results.add_loop(func_name, "", band_name, band)
     return results
 
 
@@ -354,3 +369,17 @@ def find_func_in_module(module, func_name):
         if isinstance(op, func_d.FuncOp) and op.name.value == func_name:
             return op
     return None
+
+
+def find_func_and_axis(self, axis):
+    if isinstance(axis, LoopWrapper):
+        func = (
+            self._find_function(axis.path) if axis.path is not None else self.top_func
+        )
+        return func, axis
+    if ":" in axis:
+        func_name, axis = axis.split(":")
+    else:
+        func_name = self.top_func_name
+    func = self._find_function(func_name)
+    return func, axis

--- a/allo/ir/transform.py
+++ b/allo/ir/transform.py
@@ -159,7 +159,9 @@ def find_loop_in_bands(func, axis):
                 if name == axis_name:
                     results.append(op_name)
         if len(results) == 0:
-            raise RuntimeError(f"Cannot find the band of loop {axis_name}")
+            raise RuntimeError(
+                f"Cannot find the band of loop {axis_name} in function {func.sym_name}"
+            )
         if len(results) > 1:
             raise RuntimeError(f"Find multiple bands containing loop {axis_name}")
         return results[0], axis_name

--- a/allo/ir/transform.py
+++ b/allo/ir/transform.py
@@ -78,7 +78,7 @@ def find_buffer(module, target, func_args):
     assert isinstance(target, MockBuffer), "Target must be a buffer"
     if target.op is not None:
         return None, -1, target.op
-    func_name, target_name = target.path, target.name
+    func_name, target_name = target.func, target.name
     target_func = None
     for op in module.body.operations:
         if (
@@ -374,7 +374,7 @@ def find_func_in_module(module, func_name):
 def find_func_and_axis(self, axis):
     if isinstance(axis, LoopWrapper):
         func = (
-            self._find_function(axis.path) if axis.path is not None else self.top_func
+            self._find_function(axis.func) if axis.func is not None else self.top_func
         )
         return func, axis
     if ":" in axis:

--- a/allo/ir/transform.py
+++ b/allo/ir/transform.py
@@ -193,7 +193,9 @@ def get_affine_loop_nests(func):
         if isinstance(op, affine_d.AffineForOp):  # outer-most
             band_name = StringAttr(op.attributes["op_name"]).value
             band = LoopBand()
-            band.add_loop(func_name, band_name, StringAttr(op.attributes["loop_name"]).value, op)
+            band.add_loop(
+                func_name, band_name, StringAttr(op.attributes["loop_name"]).value, op
+            )
             DFS(op.body.operations, band)
             results.add_loop(func_name, "", band_name, band)
     return results

--- a/allo/ir/utils.py
+++ b/allo/ir/utils.py
@@ -98,8 +98,8 @@ class MockArg(MockOp):
 
 
 class MockBuffer(MockOp):
-    def __init__(self, path, name, idx=None, op=None):
-        self.path = path
+    def __init__(self, func, name, idx=None, op=None):
+        self.func = func
         self.name = name
         # Normally we do not use this attribute to avoid possible context conflicts
         # only when we need to access the op directly, we set this attribute (e.g., compose)
@@ -110,9 +110,9 @@ class MockBuffer(MockOp):
 
     def __repr__(self):
         return (
-            f"MockBuffer({self.path}:{self.name})"
+            f"MockBuffer({self.func}:{self.name})"
             if self.idx is None
-            else f"MockBuffer({self.path}:{self.name}:{self.idx})"
+            else f"MockBuffer({self.func}:{self.name}:{self.idx})"
         )
 
 

--- a/tests/test_schedule_compose.py
+++ b/tests/test_schedule_compose.py
@@ -458,5 +458,20 @@ def test_reuse_function_2():
     print(s.module)
 
 
+def test_dependent_primitives():
+    def kernel(A: int32[32]):
+        for i in range(32):
+            A[i] = i
+
+    def top(A: int32[32]):
+        kernel(A)
+
+    s0 = allo.customize(kernel)
+    s0.split("i", factor=2)
+    s0.pipeline("i.inner")
+    s = allo.customize(top)
+    s.compose(s0)
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,6 @@
+# Copyright Allo authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import allo
 from allo.ir.types import int32
 from allo.ir.transform import find_loop_in_bands

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 import allo
 from allo.ir.types import int32
 from allo.ir.transform import find_loop_in_bands
+import pytest
 
 
 def test_get_loops():
@@ -48,4 +49,4 @@ def test_func_call():
 
 
 if __name__ == "__main__":
-    test_func_call()
+    pytest.main([__file__])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,51 @@
+import allo
+from allo.ir.types import int32
+from allo.ir.transform import find_loop_in_bands
+
+
+def test_get_loops():
+    def kernel(A: int32[32]):
+        for i in range(32):
+            A[i] = i
+        for ii in range(32):
+            for jj in range(32):
+                A[ii] = A[ii] * 2
+        for i0 in allo.grid(32, name="imperfect"):
+            A[i0] = A[i0] + 1
+            for i1 in range(32):
+                A[i1] = A[i1] * 2
+            A[i0] = A[i0] + 1
+            for i2 in range(32):
+                A[i2] = A[i2] + 1
+                for i3 in range(32):
+                    A[i3] = A[i3] * 2
+
+    s = allo.customize(kernel)
+    loops = s.get_loops("kernel")
+    assert hasattr(loops["S_i_0"], "i")
+    assert hasattr(loops["S_ii_1"], "jj")
+    assert hasattr(loops["imperfect"], "i0")
+    assert hasattr(loops["imperfect"], "i1")
+    assert hasattr(loops["imperfect"], "i2")
+
+
+def test_func_call():
+    def kernel(A: int32[32]):
+        for i in range(32):
+            A[i] = i
+
+    def top(A: int32[32]):
+        for i in range(32):
+            kernel(A)
+            for j in range(32):
+                A[j] = A[j] * 2
+
+    s = allo.customize(top)
+    print(s.module)
+    band_name, axis_name = find_loop_in_bands(s.top_func, "j")
+    assert band_name == "S_i_0"
+    assert axis_name == "j"
+
+
+if __name__ == "__main__":
+    test_func_call()


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR unifies the naming convention of `LoopWrapper` and `MockBuffer`. The `LoopWrapper` will explicitly contain the func_name info, which is separated by `:`. The full name is labeled as `<func>:<band>.<loop>`. This PR fixed #155.


## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [x] Code is well-documented
