### PR TITLE
[Primitive] Fix dataflow attribute

### DIFF
--- a/allo/backend/ip.py
+++ b/allo/backend/ip.py
@@ -17,12 +17,14 @@ allo2c_type = {
     "int16": "int16_t",
     "int32": "int",
     "int64": "int64_t",
+    "int128": "ap_int<128>",
     # bitwidth larger than 64 is not supported by numpy+pybind11
     "uint1": "bool",
     "uint8": "uint8_t",
     "uint16": "uint16_t",
     "uint32": "unsigned int",
     "uint64": "uint64_t",
+    "uint128": "ap_uint<128>",
 }
 
 c2allo_type = {v: k for k, v in allo2c_type.items()}


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR fixes the potential issue introduced by #156. If users call `.dataflow` to an inner loop, it may not correctly attach the attribute to the loop.

This PR also adds `ap_int<128>` to the `c2allo` type, so that the systolic array examples can be correctly executed.

## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [x] Code is well-documented
