### PR TITLE
[lib] Fix naming issue in the softmax library function

### DIFF
--- a/allo/library/nn.py
+++ b/allo/library/nn.py
@@ -8,15 +8,15 @@ from .systolic import systolic
 
 def softmax[Ty, D](X: "Ty[D, D]") -> "Ty[D, D]":
     Z: Ty[D, D]
-    exp: Ty[D, D]
-    row_sum: Ty[D] = 0.0
+    E: Ty[D, D]
+    S: Ty[D] = 0.0
 
     for i, j in dsl.grid(D, D, name="exp_sum"):
-        exp[i, j] = dsl.exp(X[i, j])
-        row_sum[i] += exp[i, j]
+        E[i, j] = dsl.exp(X[i, j])
+        S[i] += E[i, j]
 
     for i, j in dsl.grid(D, D, name="update"):
-        Z[i, j] = exp[i, j] / row_sum[i]
+        Z[i, j] = E[i, j] / S[i]
     return Z
 
 


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR fixes #161 by renaming the intermediate variables. Results from running HLS are attached below.

```
+-------------------+-----------------------------------+
| HLS Version       | Vivado HLS 2019.2.1               |
| Product family    | zynq                              |
| Target device     | xc7z020-clg484-1                  |
| Top Model Name    | softmax                           |
+-------------------+-----------------------------------+
| Target CP         | 10.00 ns                          |
| Estimated CP      | 10.510 ns                         |
| Latency (cycles)  | Min 4129573; Max 4129573          |
| Interval (cycles) | Min 4129574; Max 4129574          |
| Resources         | Type        Used    Total    Util |
|                   | --------  ------  -------  ------ |
|                   | BRAM_18K    2052      280    733% |
|                   | DSP48E         9      220      4% |
|                   | FF          2028   106400      2% |
|                   | LUT         3002    53200      6% |
+-------------------+-----------------------------------+
+------------------+--------------+-----------+---------------------+---------------+------------------+
|                  |   Trip Count |   Latency |   Iteration Latency |   Pipeline II |   Pipeline Depth |
|------------------+--------------+-----------+---------------------+---------------+------------------|
| Loop1            |          768 |       768 |                   1 |           N/A |              N/A |
| l_exp_sum_i_l_j  |       589824 |   3538955 |                 N/A |             6 |               18 |
| l_update_i1_l_j1 |       589824 |    589845 |                 N/A |             1 |               23 |
+------------------+--------------+-----------+---------------------+---------------+------------------+
* Units in clock cycles
```

## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [x] Code is well-documented
