### PR TITLE
Corrected vivado_hls g++ version check

### DIFF
--- a/allo/backend/hls.py
+++ b/allo/backend/hls.py
@@ -316,7 +316,7 @@ class HLSModule:
             ), f"cannot find {self.platform} on system path"
             ver = run_process("g++ --version", r"\d+\.\d+\.\d+")[0].split(".")
             assert (
-                int(ver[0]) * 4 + int(ver[1]) >= 48
+                int(ver[0]) * 10 + int(ver[1]) >= 48
             ), f"g++ version too old {ver[0]}.{ver[1]}.{ver[2]}"
 
             cmd = f"cd {self.project}; make "

--- a/allo/harness/vivado/run.tcl
+++ b/allo/harness/vivado/run.tcl
@@ -21,7 +21,7 @@ add_files -tb host.cpp -cflags "-std=gnu++0x"
 
 open_solution "solution1"
 # Use Zynq device
-set_part {xczu3eg-sbva484-1-i}
+set_part {xc7z020clg484-1}
 
 # Target clock period is 10ns
 create_clock -period 10

--- a/allo/harness/vivado/run.tcl
+++ b/allo/harness/vivado/run.tcl
@@ -21,7 +21,7 @@ add_files -tb host.cpp -cflags "-std=gnu++0x"
 
 open_solution "solution1"
 # Use Zynq device
-set_part {xc7z020clg484-1}
+set_part {xczu3eg-sbva484-1-i}
 
 # Target clock period is 10ns
 create_clock -period 10


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
Corrected the parsing of the version returned from g++ version.

### Problems ###
G++ 11.4.0 was judged as a "too old" version.


### Proposed Solutions ###
11 * 10 + 4 >= 48 will be working with this change.
4 * 10 + 8 >= 48 will be working with this change.


### Examples ###
(Please provide an example of the input program and the expected behavior, e.g., the generated IR.)


## Checklist ##

- [ ] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [ ] Code is well-documented
