### PR TITLE
[Bugfix] Add scf ForOp support in get_loops()

### DIFF
--- a/allo/ir/transform.py
+++ b/allo/ir/transform.py
@@ -173,7 +173,7 @@ def get_affine_loop_nests(func):
     def DFS(operations, band):
         nonlocal cnt_unnamed
         for op in operations:
-            if isinstance(op, affine_d.AffineForOp):
+            if isinstance(op, (scf_d.ForOp, affine_d.AffineForOp)):
                 if "loop_name" not in op.attributes:
                     name = f"L_{cnt_unnamed}"
                     cnt_unnamed += 1
@@ -192,7 +192,7 @@ def get_affine_loop_nests(func):
     # get function name
     func_name = func.attributes["sym_name"].value
     for op in func.entry_block.operations:
-        if isinstance(op, affine_d.AffineForOp):  # outer-most
+        if isinstance(op, (scf_d.ForOp, affine_d.AffineForOp)):  # outer-most
             band_name = StringAttr(op.attributes["op_name"]).value
             band = LoopBand()
             band.add_loop(

--- a/tests/test_schedule_compute.py
+++ b/tests/test_schedule_compute.py
@@ -4,7 +4,7 @@
 import allo
 import numpy as np
 import pytest
-from allo.ir.types import int32, float32
+from allo.ir.types import int32, float32, bool
 
 
 def test_gemm_grid_for():
@@ -309,7 +309,7 @@ def test_getloops_scf():
         for i in range(times, name="scf_loop"):
             for j in range(N, name="target"):
                 C[j] = C[j] + 1
-    
+
     def case2[N: int32](A: int32, B: int32, C: int32[N], s: bool):
         times_out: int32 = A if s else B
         times_in: int32 = B if s else A
@@ -317,7 +317,7 @@ def test_getloops_scf():
             for j in range(times_in, name="scf_in"):
                 for k in range(N, name="target"):
                     C[k] = C[k] + 1
-    
+
     s1 = allo.customize(case1, instantiate=[8])
     s1.get_loops(s1.top_func_name)["scf_loop"]["j"]
 

--- a/tests/test_schedule_compute.py
+++ b/tests/test_schedule_compute.py
@@ -310,17 +310,17 @@ def test_getloops_scf():
             for j in range(N, name="target"):
                 C[j] = C[j] + 1
     
-    def case2[N: int32](A: int32, B: int32, C: int32[N], s: bool):
-        times: int32 = A if s else B
-        for i in range(times, name="scf_loop"):
-            for j in range(N, name="target"):
-                C[j] = C[j] + 1
+    # def case2[N: int32](A: int32, B: int32, C: int32[N], s: bool):
+    #     times: int32 = A if s else B
+    #     for i in range(times, name="scf_loop"):
+    #         for j in range(N, name="target"):
+    #             C[j] = C[j] + 1
     
     s1 = allo.customize(case1, instantiate=[8])
     s1.get_loops(s1.top_func_name)["scf_loop"]["j"]
 
-    s2 = allo.customize(case2, instantiate=[8])
-    s2.get_loops(s2.top_func_name)["scf_loop"]["j"]
+    # s2 = allo.customize(case2, instantiate=[8])
+    # s2.get_loops(s2.top_func_name)["scf_loop"]["j"]
 
 
 if __name__ == "__main__":

--- a/tests/test_schedule_compute.py
+++ b/tests/test_schedule_compute.py
@@ -303,5 +303,25 @@ def test_access_imperfect_loops():
     print(s1.build("vhls"))
 
 
+def test_getloops_scf():
+    def case1[N: int32](A: int32, B: int32, C: int32[N]):
+        times: int32 = A - B
+        for i in range(times, name="scf_loop"):
+            for j in range(N, name="target"):
+                C[j] = C[j] + 1
+    
+    def case2[N: int32](A: int32, B: int32, C: int32[N], s: bool):
+        times: int32 = A if s else B
+        for i in range(times, name="scf_loop"):
+            for j in range(N, name="target"):
+                C[j] = C[j] + 1
+    
+    s1 = allo.customize(case1, instantiate=[8])
+    s1.get_loops(s1.top_func_name)["scf_loop"]["j"]
+
+    s2 = allo.customize(case2, instantiate=[8])
+    s2.get_loops(s2.top_func_name)["scf_loop"]["j"]
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/test_schedule_compute.py
+++ b/tests/test_schedule_compute.py
@@ -310,17 +310,19 @@ def test_getloops_scf():
             for j in range(N, name="target"):
                 C[j] = C[j] + 1
     
-    # def case2[N: int32](A: int32, B: int32, C: int32[N], s: bool):
-    #     times: int32 = A if s else B
-    #     for i in range(times, name="scf_loop"):
-    #         for j in range(N, name="target"):
-    #             C[j] = C[j] + 1
+    def case2[N: int32](A: int32, B: int32, C: int32[N], s: bool):
+        times_out: int32 = A if s else B
+        times_in: int32 = B if s else A
+        for i in range(times_out, name="scf_out"):
+            for j in range(times_in, name="scf_in"):
+                for k in range(N, name="target"):
+                    C[k] = C[k] + 1
     
     s1 = allo.customize(case1, instantiate=[8])
     s1.get_loops(s1.top_func_name)["scf_loop"]["j"]
 
-    # s2 = allo.customize(case2, instantiate=[8])
-    # s2.get_loops(s2.top_func_name)["scf_loop"]["j"]
+    s2 = allo.customize(case2, instantiate=[8])
+    s2.get_loops(s2.top_func_name)["scf_out"]["k"]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
Add scf ForOp support in get_loops().

### Problems ###
Original get_loops() can't identify the scf ForOp.


### Proposed Solutions ###
Add scf ForOp in condition of loop detection.


### Examples ###
SCF loop in mlir like:
`scf.for %arg6 = %26 to %28 step %29 { .... }`
can be identified as a loop by get_loops(). 

## Checklist ##

- [√] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [√] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [ ] Code is well-documented
