### PR TITLE
[Bugfix] Resolve softmax and sdp overflow for large values

### DIFF
--- a/allo/library/nn.py
+++ b/allo/library/nn.py
@@ -13,17 +13,17 @@ def softmax[Ty, L](X: "Ty[L, L]") -> "Ty[L, L]":
     S: Ty[L] = 0.0
 
     for i, j in dsl.grid(L, L, name="row_max"):
-        if X[i,j] > M[i]:
+        if X[i, j] > M[i]:
             M[i] = X[i, j]
 
-    #compute exp and sum
+    # compute exp and sum
     for i, j in dsl.grid(L, L, name="exp_sum"):
         E[i, j] = dsl.exp(X[i, j] - M[i])
         S[i] += E[i, j]
-    
+
     for i, j in dsl.grid(L, L, name="update"):
         Z[i, j] = E[i, j] / S[i]
-    
+
     return Z
 
 

--- a/allo/library/nn.py
+++ b/allo/library/nn.py
@@ -6,17 +6,24 @@ from .. import dsl
 from .systolic import systolic
 
 
-def softmax[Ty, D](X: "Ty[D, D]") -> "Ty[D, D]":
-    Z: Ty[D, D]
-    E: Ty[D, D]
-    S: Ty[D] = 0.0
+def softmax[Ty, L](X: "Ty[L, L]") -> "Ty[L, L]":
+    Z: Ty[L, L]
+    E: Ty[L, L]
+    M: Ty[L] = -10000.0
+    S: Ty[L] = 0.0
 
-    for i, j in dsl.grid(D, D, name="exp_sum"):
-        E[i, j] = dsl.exp(X[i, j])
+    for i, j in dsl.grid(L, L, name="row_max"):
+        if X[i,j] > M[i]:
+            M[i] = X[i, j]
+
+    #compute exp and sum
+    for i, j in dsl.grid(L, L, name="exp_sum"):
+        E[i, j] = dsl.exp(X[i, j] - M[i])
         S[i] += E[i, j]
-
-    for i, j in dsl.grid(D, D, name="update"):
+    
+    for i, j in dsl.grid(L, L, name="update"):
         Z[i, j] = E[i, j] / S[i]
+    
     return Z
 
 

--- a/allo/library/nn.py
+++ b/allo/library/nn.py
@@ -9,7 +9,7 @@ from .systolic import systolic
 def softmax[Ty, L](X: "Ty[L, L]") -> "Ty[L, L]":
     Z: Ty[L, L]
     E: Ty[L, L]
-    M: Ty[L] = -10000.0
+    M: Ty[L] = -1000000000000.0
     S: Ty[L] = 0.0
 
     for i, j in dsl.grid(L, L, name="row_max"):

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -63,6 +63,7 @@ def test_softmax():
     s = allo.customize(softmax, instantiate=[float32, 8])
     mod = s.build()
     inp = np.random.randn(8, 8).astype(np.float32)
+    inp = 1000 * inp
     allo_out = mod(inp)
     np_out = np_softmax(inp)
     np.testing.assert_allclose(allo_out, np_out, atol=1e-3)

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -51,6 +51,11 @@ def test_linear_float():
     print(s.build(target="vhls"))
 
 
+def np_softmax(x, axis=-1):
+    x_max = np.max(x, axis=axis, keepdims=True)
+    e_x = np.exp(x - x_max)
+    return e_x / np.sum(e_x, axis=axis, keepdims=True)
+
 def test_softmax():
     from allo.library.nn import softmax
 
@@ -58,7 +63,7 @@ def test_softmax():
     mod = s.build()
     inp = np.random.randn(8, 8).astype(np.float32)
     allo_out = mod(inp)
-    np_out = np.exp(inp) / np.exp(inp).sum(axis=1, keepdims=True)
+    np_out = np_softmax(inp)
     np.testing.assert_allclose(allo_out, np_out, atol=1e-3)
     print("Passed!")
     print(s.build(target="vhls"))

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -56,6 +56,7 @@ def np_softmax(x, axis=-1):
     e_x = np.exp(x - x_max)
     return e_x / np.sum(e_x, axis=axis, keepdims=True)
 
+
 def test_softmax():
     from allo.library.nn import softmax
 


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
The PR solves the issue related to numerical overflow during softmax calculation and the scaled_dot_product_attention that utilizes it. In addition, a similar overflow error occurs in the numpy implementation used in `allo/tests/test_nn.py` that generate golden results for testing. The PR fixes this issue by adding a correct `np_softmax()` function in the testing script.

### Problems ###
- **Softmax Overflow**: The softmax calculation could result in overflow when handling large input values, causing NaNs in hte output.
- **Incorrect Numpy Softmax Implementation**: In the original test script, `np_out = np.exp(inp) / np.exp(inp).sum(axis=1, keepdims=True)` will cause similar overflow problems in the exponentiation computation.


### Proposed Solutions ###
The softmax function has been updated to subtract the maximum value in each row before exponentiation to cope with larger values correctly.


### Examples ###
```
(allo) sl3558@brg-zhang-xcel:/work/shared/users/ugrad/sl3558/mdlm/dit_numpy_allo$ pytest allo/tests/test_nn.py::test_softmax
========================================================= test session starts =========================================================
platform linux -- Python 3.12.4, pytest-8.2.2, pluggy-1.5.0
rootdir: /work/shared/users/ugrad/sl3558/mdlm/dit_numpy_allo/allo
collected 1 item                                                                                                                      

allo/tests/test_nn.py .                                                                                                         [100%]

========================================================== 1 passed in 2.91s ==========================================================
```


## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [ ] Code is well-documented
