### PR TITLE
[Bugfix] Add scf ForOp support and nested loop search in dataflow and pipeline

### DIFF
--- a/allo/customize.py
+++ b/allo/customize.py
@@ -433,11 +433,11 @@ class Schedule:
         band_name = band_name.split(":")[1]
         cnt = 0
 
-        def locateLoop(op):
+        def locate_loop(op):
             nonlocal cnt
             for ope in op.body.operations:
                 if isinstance(ope, (scf_d.ForOp, affine_d.AffineForOp)):
-                    locateLoop(ope)
+                    locate_loop(ope)
             if (
                 "loop_name" in op.attributes
                 and op.attributes["loop_name"].value == loop_name
@@ -451,7 +451,7 @@ class Schedule:
                     "op_name" in op.attributes
                     and op.attributes["op_name"].value == band_name
                 ):
-                    locateLoop(op)
+                    locate_loop(op)
 
         if cnt == 0:
             raise RuntimeError(f"Dataflow loop {band_name}.{loop_name} not found")

--- a/allo/customize.py
+++ b/allo/customize.py
@@ -32,6 +32,7 @@ from hcl_mlir.dialects import (
     hcl as hcl_d,
     memref as memref_d,
     affine as affine_d,
+    scf as scf_d,
     arith as arith_d,
     func as func_d,
 )
@@ -401,10 +402,7 @@ class Schedule:
             self.get_loops(func)[band_name][axis].loop.attributes[
                 "rewind"
             ] = UnitAttr.get()
-        ip = InsertionPoint.at_block_terminator(func.entry_block)
-        op_hdl = hcl_d.CreateOpHandleOp(band_name, ip=ip)
-        loop_hdl = hcl_d.CreateLoopHandleOp(op_hdl.result, StringAttr.get(axis), ip=ip)
-        hcl_d.PipelineOp(loop_hdl.result, ii=ii, ip=ip)
+        self.get_loops(func)[band_name][axis].loop.attributes["pipeline_ii"] = ii
 
     @wrapped_apply
     def parallel(self, axis):
@@ -435,24 +433,25 @@ class Schedule:
         band_name = band_name.split(":")[1]
         cnt = 0
 
-        # TODO: Fix deep nested
-        def DFS(op):
+        def locateLoop(op):
             nonlocal cnt
-            if isinstance(op, affine_d.AffineForOp):
+            for ope in op.body.operations:
+                if isinstance(ope, (scf_d.ForOp, affine_d.AffineForOp)):
+                    locateLoop(ope)
+            if (
+                "loop_name" in op.attributes
+                and op.attributes["loop_name"].value == loop_name
+            ):
+                cnt += 1
+                op.attributes["dataflow"] = UnitAttr.get()
+
+        for op in func.entry_block.operations:
+            if isinstance(op, (scf_d.ForOp, affine_d.AffineForOp)):
                 if (
                     "op_name" in op.attributes
                     and op.attributes["op_name"].value == band_name
                 ):
-                    DFS(op.body.operations[0])
-                if (
-                    "loop_name" in op.attributes
-                    and op.attributes["loop_name"].value == loop_name
-                ):
-                    cnt += 1
-                    op.attributes["dataflow"] = UnitAttr.get()
-
-        for op in func.entry_block.operations:
-            DFS(op)
+                    locateLoop(op)
 
         if cnt == 0:
             raise RuntimeError(f"Dataflow loop {band_name}.{loop_name} not found")


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
1. Add scf ForOp support for dataflow() and pipeline() in customize.py;
2. Add nested loop search support for dataflow() in customize.py


### Problems ###
1. Absence of scf ForOp support in some functions.
2. Fail to search the inner loop when it's deeply nested when executing dataflow().


### Proposed Solutions ###
Modify the recursive searching in nested loop.


### Examples ###
Provided in the test_schedule_stream.py.


## Checklist ##

- [√] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [√] Changes are complete (i.e. I finished coding on this PR)
- [√] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [ ] Code is well-documented
