### PR TITLE
[Builder] Fix incorrect NotOp IR

### DIFF
--- a/allo/ir/builder.py
+++ b/allo/ir/builder.py
@@ -665,6 +665,18 @@ class ASTTransformer(ASTBuilder):
                 ctx, value, node.operand.dtype, node.dtype
             )
             return arith_d.NegFOp(value.result, ip=ctx.get_ip())
+        if isinstance(node.op, ast.Not):
+            if not (
+                isinstance(value.result.type, IntegerType)
+                and value.result.type.width == 1
+            ):
+                raise RuntimeError("The operand of 'not' should be a boolean value")
+            # test if value.val is a bool value
+            # pylint: disable=too-many-function-args
+            c0 = arith_d.ConstantOp(IntegerType.get_signless(1), 0, ip=ctx.get_ip())
+            # predicate=0 means "eq"
+            predicate = IntegerAttr.get(IntegerType.get_signless(64), 0)
+            return arith_d.CmpIOp(predicate, value.result, c0, ip=ctx.get_ip())
         # ast.UAdd
         return value
 

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1,11 +1,10 @@
 # Copyright Allo authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import os
 import numpy as np
 import pytest
 import allo
-from allo.ir.types import int8, int32, float32, index
+from allo.ir.types import bool, int8, int32, float32, index
 import allo.backend.hls as hls
 
 
@@ -281,6 +280,33 @@ def test_unary():
     print(s.module)
     mod = s.build()
     np.testing.assert_allclose(mod(), kernel())
+
+
+def test_not():
+    def kernel[Ty](flag: bool) -> "Ty":
+        X: Ty
+        if not flag:
+            X = 1
+        else:
+            X = 0
+        return X
+
+    s = allo.customize(kernel, instantiate=[int8])
+    print(s.module)
+    mod = s.build()
+    assert mod(True) == 0
+    assert mod(False) == 1
+
+
+def test_complex_not():
+    def kernel[Ty](inp: Ty) -> "Ty":
+        return 3 if not (inp + 1 > 5) else 4
+
+    s = allo.customize(kernel, instantiate=[int8])
+    print(s.module)
+    mod = s.build()
+    assert mod(4) == 3
+    assert mod(5) == 4
 
 
 def test_rhs_binaryop():


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR fixes #173.

### Proposed Solutions ###
As MLIR does not have a `NOT` operation, we need to use `xori` or `cmpi` to achieve the equivalent functionality. This PR use `flag == 0` to simulate `not flag`.

### Examples ###
```python
def test_not():
    def kernel[Ty](flag: bool) -> "Ty":
        X: Ty
        if not flag:
            X = 1
        else:
            X = 0
        return X

    s = allo.customize(kernel, instantiate=[int8])
    print(s.module)
    mod = s.build()
    assert mod(True) == 0
    assert mod(False) == 1
```

```mlir
module {
  func.func @kernel(%arg0: i1) -> i8 attributes {itypes = "s", otypes = "s"} {
    %alloc = memref.alloc() {name = "X"} : memref<1xi8>
    %false = arith.constant false
    %0 = arith.cmpi eq, %arg0, %false : i1
    scf.if %0 {
      %c1_i32 = arith.constant 1 : i32
      %2 = arith.trunci %c1_i32 : i32 to i8
      affine.store %2, %alloc[0] {to = "X"} : memref<1xi8>
    } else {
      %c0_i32 = arith.constant 0 : i32
      %2 = arith.trunci %c0_i32 : i32 to i8
      affine.store %2, %alloc[0] {to = "X"} : memref<1xi8>
    }
    %1 = affine.load %alloc[0] {from = "X"} : memref<1xi8>
    return %1 : i8
  }
}
```


## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [x] Code is well-documented
