### PR TITLE
[Types] Large bitwidth

### DIFF
--- a/allo/ir/types.py
+++ b/allo/ir/types.py
@@ -17,9 +17,9 @@ class AlloType:
         if not isinstance(fracs, numbers.Integral):
             raise DTypeError("Number of fractional bits must be an integer.")
         if bits > 512:
-            raise DTypeWarning(
+            DTypeWarning(
                 "NumPy does not support bitwidths larger than 512, so you cannot use NumPy for simulation, but you can still generate the corresponding MLIR module."
-            )
+            ).warn()
         if fracs > 255:
             raise DTypeError("The maximum supported fractional bitwidth is 255 bits.")
         self.bits = bits

--- a/allo/ir/types.py
+++ b/allo/ir/types.py
@@ -7,7 +7,7 @@ from collections import OrderedDict
 
 from hcl_mlir.ir import IntegerType, IndexType, F16Type, F32Type, F64Type
 from hcl_mlir.dialects import hcl as hcl_d
-from hcl_mlir.exceptions import DTypeError
+from hcl_mlir.exceptions import DTypeError, DTypeWarning
 
 
 class AlloType:
@@ -16,8 +16,10 @@ class AlloType:
             raise DTypeError("Bitwidth must be an integer.")
         if not isinstance(fracs, numbers.Integral):
             raise DTypeError("Number of fractional bits must be an integer.")
-        if bits > 2047:
-            raise DTypeError("The maximum supported total bitwidth is 2047 bits.")
+        if bits > 512:
+            raise DTypeWarning(
+                "NumPy does not support bitwidths larger than 512, so you cannot use NumPy for simulation, but you can still generate the corresponding MLIR module."
+            )
         if fracs > 255:
             raise DTypeError("The maximum supported fractional bitwidth is 255 bits.")
         self.bits = bits

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -249,7 +249,7 @@ def test_bert():
         return ffn_ln_outp
 
     np_out = bert_layer(X, Wq, Wk, Wv, Wp, W1, W2, gamma1, beta1, gamma2, beta2)
-    np.testing.assert_allclose(allo_out, np_out, atol=1e-3)
+    np.testing.assert_allclose(allo_out, np_out, atol=1e-2, rtol=1e-2)
     print("Passed!")
     print(s.build(target="vhls"))
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -41,6 +41,22 @@ def test_int32_float32_casting():
     assert mod(1) == kernel(1)
 
 
+def test_large_bitwidth():
+    def kernel(a: Int(65536)[1], b: Int(345)[1], c: Int(65536)[1]):
+        c[0] = a[0] + b[0]
+
+    s = allo.customize(kernel)
+    print(s.module)
+    # Note: Not supported by NumPy
+    # mod = s.build()
+    # a = np.array([0x3F3F3F3F], dtype=np.int64)
+    # b = np.array([501], dtype=np.int64)
+    # c = np.array([0], dtype=np.int64)
+    # mod(a, b, c)
+    # assert c[0] == a[0] + b[0]
+    # print("Passed!")
+
+
 def test_load_type():
     def kernel(A: allo.ir.types.Float(32)[32, 32]) -> Int(32)[32, 32]:
         B: int32[32, 32] = 0


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR adds examples for large bitwidth (#168), although it still cannot be simulated by NumPy. Future direction for this is to leverage numpy structure to simulate large bitwidth integers.


### Examples ###
```python
def test_large_bitwidth():
    def kernel(a: Int(65536)[1], b: Int(345)[1], c: Int(65536)[1]):
        c[0] = a[0] + b[0]

    s = allo.customize(kernel)
    print(s.module)
    # Note: Not supported by NumPy
    # mod = s.build()
    # a = np.array([0x3F3F3F3F], dtype=np.int64)
    # b = np.array([501], dtype=np.int64)
    # c = np.array([0], dtype=np.int64)
    # mod(a, b, c)
    # assert c[0] == a[0] + b[0]
    # print("Passed!")
```
```mlir
module {
  func.func @kernel(%arg0: i65536, %arg1: i345) -> i65536 attributes {itypes = "ss", otypes = "s"} {
    %0 = arith.extsi %arg0 : i65536 to i65537
    %1 = arith.extsi %arg1 : i345 to i65537
    %2 = arith.addi %0, %1 : i65537
    %3 = arith.trunci %2 : i65537 to i65536
    return %3 : i65536
  }
}
```

## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [x] Code is well-documented
