### PR TITLE
[BugFix] Fix incorrect size-1 array reduction

### DIFF
--- a/allo/ir/infer.py
+++ b/allo/ir/infer.py
@@ -391,8 +391,6 @@ class TypeInferer(ASTVisitor):
                         size = (upper - lower) // step
                         if size > 0:
                             shape.append(size)
-            if sum(shape) == len(shape):  # all ones
-                shape = tuple()
             node.shape = tuple(shape)
             node.dtype = ctx.buffers[node.value.id].dtype
         elif len(value.shape) == 0 and isinstance(

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -638,5 +638,16 @@ def test_comments():
     print(allo.customize(top, verbose=True).build()(np.array([5], dtype=np.int8)))
 
 
+def test_size1_array():
+    def kernel[Ty](X: "Ty[1]"):
+        a: Ty
+
+    def top[Ty](X_buf: "Ty[2, 2, 1]"):
+        kernel[Ty](X_buf[0, 0])
+
+    s = allo.customize(top, instantiate=[int8], verbose=True)
+    print(s.module)
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR fixes #170.

### Examples ###
```python
def test_size1_array():
    def kernel[Ty](X: "Ty[1]"):
        a: Ty

    def top[Ty](X_buf: "Ty[2, 2, 1]"):
        kernel[Ty](X_buf[0, 0])

    s = allo.customize(top, instantiate=[int8], verbose=True)
    print(s.module)
```
```mlir
module {
  func.func @kernel(%arg0: memref<1xi8, strided<[1], offset: ?>>) attributes {itypes = "s", otypes = ""} {
    %alloc = memref.alloc() {name = "a"} : memref<1xi8>
    return
  }
  func.func @top(%arg0: memref<2x2x1xi8>) attributes {itypes = "s", otypes = ""} {
    %c0_i32 = arith.constant 0 : i32
    %0 = arith.index_cast %c0_i32 : i32 to index
    %c0_i32_0 = arith.constant 0 : i32
    %1 = arith.index_cast %c0_i32_0 : i32 to index
    %subview = memref.subview %arg0[%0, %1, 0] [1, 1, 1] [1, 1, 1] {from = "X_buf"} : memref<2x2x1xi8> to memref<1xi8, strided<[1], offset: ?>>
    call @kernel(%subview) : (memref<1xi8, strided<[1], offset: ?>>) -> ()
    return
  }
}
```


## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [x] Code is well-documented
