### PR TITLE
[IR] Fix integer negation and negative for loop steps

### DIFF
--- a/allo/ir/builder.py
+++ b/allo/ir/builder.py
@@ -673,15 +673,16 @@ class ASTTransformer(ASTBuilder):
                     ctx, value, node.operand.dtype, node.dtype
                 )
                 return arith_d.SubIOp(
+                    # pylint: disable=too-many-function-args
                     arith_d.ConstantOp(node.dtype.build(), 0, ip=ctx.get_ip()).result,
                     value.result,
                     ip=ctx.get_ip(),
                 )
-            else:
-                value = ASTTransformer.build_cast_op(
-                    ctx, value, node.operand.dtype, node.dtype
-                )
-                return arith_d.NegFOp(value.result, ip=ctx.get_ip())
+            # float
+            value = ASTTransformer.build_cast_op(
+                ctx, value, node.operand.dtype, node.dtype
+            )
+            return arith_d.NegFOp(value.result, ip=ctx.get_ip())
         if isinstance(node.op, ast.Not):
             if not (
                 isinstance(value.result.type, IntegerType)

--- a/allo/ir/builder.py
+++ b/allo/ir/builder.py
@@ -255,6 +255,12 @@ class ASTTransformer(ASTBuilder):
                 ub_expr = build_stmt(
                     ctx, iter_args[1] if len(iter_args) >= 2 else iter_args[0]
                 )
+                # https://mlir.llvm.org/docs/Dialects/SCFDialect/#scffor-scfforop
+                # The step is a value of same type but required to be positive.
+                if step is not None and step <= 0:
+                    raise RuntimeError(
+                        "Step in for loop range should be positive, got: ", step
+                    )
                 step = build_stmt(
                     ctx, iter_args[2] if len(iter_args) >= 3 else ast.Constant(1)
                 )
@@ -661,10 +667,21 @@ class ASTTransformer(ASTBuilder):
     def build_UnaryOp(ctx, node):
         value = build_stmt(ctx, node.operand)
         if isinstance(node.op, ast.USub):
-            value = ASTTransformer.build_cast_op(
-                ctx, value, node.operand.dtype, node.dtype
-            )
-            return arith_d.NegFOp(value.result, ip=ctx.get_ip())
+            # MLIR does not provide integer negation
+            if isinstance(node.dtype, (Int, UInt)):
+                value = ASTTransformer.build_cast_op(
+                    ctx, value, node.operand.dtype, node.dtype
+                )
+                return arith_d.SubIOp(
+                    arith_d.ConstantOp(node.dtype.build(), 0, ip=ctx.get_ip()).result,
+                    value.result,
+                    ip=ctx.get_ip(),
+                )
+            else:
+                value = ASTTransformer.build_cast_op(
+                    ctx, value, node.operand.dtype, node.dtype
+                )
+                return arith_d.NegFOp(value.result, ip=ctx.get_ip())
         if isinstance(node.op, ast.Not):
             if not (
                 isinstance(value.result.type, IntegerType)

--- a/allo/ir/infer.py
+++ b/allo/ir/infer.py
@@ -245,7 +245,11 @@ class TypeInferer(ASTVisitor):
     def visit_UnaryOp(ctx, node):
         operand = visit_stmt(ctx, node.operand)
         node.shape = operand.shape
-        node.dtype = operand.dtype
+        if isinstance(operand.dtype, UInt):
+            # need to create a corresponding Int type
+            node.dtype = Int(operand.dtype.bits)
+        else:
+            node.dtype = operand.dtype
         return node
 
     @staticmethod

--- a/allo/ir/infer.py
+++ b/allo/ir/infer.py
@@ -245,9 +245,7 @@ class TypeInferer(ASTVisitor):
     def visit_UnaryOp(ctx, node):
         operand = visit_stmt(ctx, node.operand)
         node.shape = operand.shape
-        # A bit tricky here, since MLIR only has arith.negf op but not arith.negi
-        # https://mlir.llvm.org/docs/Dialects/ArithOps/#arithnegf-arithnegfop
-        node.dtype = float32
+        node.dtype = operand.dtype
         return node
 
     @staticmethod

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -661,5 +661,4 @@ def test_size1_array():
 
 
 if __name__ == "__main__":
-    # pytest.main([__file__])
-    test_negative_step_for()
+    pytest.main([__file__])

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -166,6 +166,17 @@ def test_scf_for():
     np.testing.assert_allclose(np_B, np_D)
 
 
+def test_negative_step_for():
+    N = 256
+
+    def kernel(x: int32[N], y: int32[N]):
+        for i in range(N - 1, -1, -1):
+            y[i] = x[i]
+
+    with pytest.raises(RuntimeError):
+        s = allo.customize(kernel)
+
+
 def test_nested_if():
     def kernel(a: int32, b: int32) -> int32:
         r: int32 = 0
@@ -650,4 +661,5 @@ def test_size1_array():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    # pytest.main([__file__])
+    test_negative_step_for()


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR fixes #153. Since MLIR does not provide an integer negation operation, we need to use subtraction `0-x` to achieve the same functionality. One tricky thing is that we need to carefully handle the negation of unsigned integers, which will turn into signed integers.

However, even fixing this, the for loop step cannot be a negative integer, as stated in the MLIR [scf.for](https://mlir.llvm.org/docs/Dialects/SCFDialect/#scffor-scfforop) operation. Therefore, we also don't plan to support negative steps, but directly error out. Otherwise, automatic compiler transformation will make users more confused.


## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [x] Code is well-documented
