### PR TITLE
[IR] Add tuple support in use-def chain analysis and type system

### DIFF
--- a/allo/ir/infer.py
+++ b/allo/ir/infer.py
@@ -385,7 +385,9 @@ class TypeInferer(ASTVisitor):
             elts = (
                 size.elts
                 if isinstance(size, ast.Tuple)
-                else size.dims if isinstance(size, ast.ExtSlice) else [size]
+                else size.dims
+                if isinstance(size, ast.ExtSlice)
+                else [size]
             )
             access_dim = len(elts)
             total_dim = len(value.shape)

--- a/allo/ir/use_def.py
+++ b/allo/ir/use_def.py
@@ -239,12 +239,18 @@ class UseDefChain(ast.NodeVisitor):
                 return subnode.id
             return get_name(subnode.value)
 
-        name = get_name(node.targets[0])
-        var = VarNode(self.path, name)
-        for parent in parents:
-            parent.add_user(var)
-        if self.get_name(name) not in self.buffers:
-            self.buffers[self.get_name(name)] = var
+        targets = []
+        if isinstance(node.targets[0], ast.Tuple):
+            targets = node.targets[0].elts
+        else:
+            targets = [node.targets[0]]
+        for target in targets:
+            name = get_name(target)
+            var = VarNode(self.path, name)
+            for parent in parents:
+                parent.add_user(var)
+            if self.get_name(name) not in self.buffers:
+                self.buffers[self.get_name(name)] = var
 
     def visit_AnnAssign(self, node):
         var = VarNode(self.path, node.target.id)

--- a/allo/ir/utils.py
+++ b/allo/ir/utils.py
@@ -143,8 +143,7 @@ class MockConstant(MockOp):
 
     @property
     def results(self):
-        # DO NOT USE THIS METHOD FOR ACCESSING RESULT!
-        return [None]
+        return [self.result]
 
 
 class MockScalar(MockOp):
@@ -185,5 +184,4 @@ class MockScalar(MockOp):
 
     @property
     def results(self):
-        # DO NOT USE THIS METHOD FOR ACCESSING RESULT!
-        return [None]
+        return [self.result]

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -660,5 +660,32 @@ def test_size1_array():
     print(s.module)
 
 
+def test_tuple():
+    def callee(a: float32, b: float32) -> (float32, float32):
+        c: float32 = a + b
+        d: float32 = a - b
+        return c, d
+
+    def kernel(A: float32[10], B: float32[10]) -> (float32[10], float32[10]):
+        C: float32[10] = 0
+        D: float32[10] = 0
+        for i in range(10):
+            C[i], D[i] = callee(A[i], B[i])
+        return C, D
+
+    s = allo.customize(kernel)
+    print(s.module)
+    mod = s.build()
+    np_A = np.random.random((10,)).astype(np.float32)
+    np_B = np.random.random((10,)).astype(np.float32)
+    np_C, np_D = mod(np_A, np_B)
+    np_C_ref = np.zeros((10,), dtype=np.float32)
+    np_D_ref = np.zeros((10,), dtype=np.float32)
+    for i in range(10):
+        np_C_ref[i], np_D_ref[i] = callee(np_A[i], np_B[i])
+    np.testing.assert_allclose(np_C, np_C_ref)
+    np.testing.assert_allclose(np_D, np_D_ref)
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR fixes #114.

### Examples ###
```python
def test_tuple():
    def callee(a: float32, b: float32) -> (float32, float32):
        c: float32 = a + b
        d: float32 = a - b
        return c, d

    def kernel(A: float32[10], B: float32[10]) -> (float32[10], float32[10]):
        C: float32[10] = 0
        D: float32[10] = 0
        for i in range(10):
            C[i], D[i] = callee(A[i], B[i])
        return C, D

    s = allo.customize(kernel)
    print(s.module)
    mod = s.build()
    np_A = np.random.random((10,)).astype(np.float32)
    np_B = np.random.random((10,)).astype(np.float32)
    np_C, np_D = mod(np_A, np_B)
    np_C_ref = np.zeros((10,), dtype=np.float32)
    np_D_ref = np.zeros((10,), dtype=np.float32)
    for i in range(10):
        np_C_ref[i], np_D_ref[i] = callee(np_A[i], np_B[i])
    np.testing.assert_allclose(np_C, np_C_ref)
    np.testing.assert_allclose(np_D, np_D_ref)
```
```mlir
module {
  func.func @callee(%arg0: f32, %arg1: f32) -> (f32, f32) attributes {itypes = "__", otypes = "__"} {
    %0 = arith.addf %arg0, %arg1 : f32
    %alloc = memref.alloc() {name = "c"} : memref<1xf32>
    affine.store %0, %alloc[0] {to = "c"} : memref<1xf32>
    %1 = arith.subf %arg0, %arg1 : f32
    %alloc_0 = memref.alloc() {name = "d"} : memref<1xf32>
    affine.store %1, %alloc_0[0] {to = "d"} : memref<1xf32>
    %2 = affine.load %alloc[0] {from = "c"} : memref<1xf32>
    %3 = affine.load %alloc_0[0] {from = "d"} : memref<1xf32>
    return %2, %3 : f32, f32
  }
  func.func @kernel(%arg0: memref<10xf32>, %arg1: memref<10xf32>) -> (memref<10xf32>, memref<10xf32>) attributes {itypes = "__", otypes = "__"} {
    %c0_i32 = arith.constant 0 : i32
    %0 = arith.sitofp %c0_i32 : i32 to f32
    %alloc = memref.alloc() {name = "C"} : memref<10xf32>
    linalg.fill ins(%0 : f32) outs(%alloc : memref<10xf32>)
    %c0_i32_0 = arith.constant 0 : i32
    %1 = arith.sitofp %c0_i32_0 : i32 to f32
    %alloc_1 = memref.alloc() {name = "D"} : memref<10xf32>
    linalg.fill ins(%1 : f32) outs(%alloc_1 : memref<10xf32>)
    affine.for %arg2 = 0 to 10 {
      %2 = affine.load %arg0[%arg2] {from = "A"} : memref<10xf32>
      %3 = affine.load %arg1[%arg2] {from = "B"} : memref<10xf32>
      %4:2 = func.call @callee(%2, %3) : (f32, f32) -> (f32, f32)
      affine.store %4#0, %alloc[%arg2] {to = "C"} : memref<10xf32>
      affine.store %4#1, %alloc_1[%arg2] {to = "D"} : memref<10xf32>
    } {loop_name = "i", op_name = "S_i_0"}
    return %alloc, %alloc_1 : memref<10xf32>, memref<10xf32>
  }
}
```

## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [x] Code is well-documented
