### PR TITLE
[dataflow][experimental] Add dataflow programming model (tiled kernels)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
           name: Formatting Check
           command: |
             source activate hcl-dev
-            python3 -m pip install black==23.11.0 pylint==3.0.2
+            python3 -m pip install black==24.8.0 pylint==3.0.2
             bash ./.circleci/task_lint.sh
       - run: 
           name: Allo Tests

--- a/allo/customize.py
+++ b/allo/customize.py
@@ -708,6 +708,7 @@ def customize(
     lower_linalg: bool = False,
     global_vars: dict = None,
     instantiate: list = None,
+    context: Context = None,
 ):
     # Get Python AST
     if isinstance(fn, str):
@@ -733,7 +734,7 @@ def customize(
     # Type construction
     ctx_type_inf = ASTContext(
         global_vars=global_vars.copy(),
-        mlir_ctx=Context(),
+        mlir_ctx=Context() if context is None else context,
         enable_tensor=enable_tensor,
         verbose=verbose,
     )
@@ -743,7 +744,7 @@ def customize(
     # Start building IR
     ctx = ASTContext(
         global_vars=global_vars,
-        mlir_ctx=Context(),
+        mlir_ctx=Context() if context is None else context,
         enable_tensor=enable_tensor,
         verbose=verbose,
     )

--- a/allo/dataflow.py
+++ b/allo/dataflow.py
@@ -1,0 +1,70 @@
+# Copyright Allo authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+# pylint: disable=no-name-in-module, unexpected-keyword-arg, no-value-for-parameter
+
+from types import FunctionType as PyFunctionType
+from hcl_mlir.ir import (
+    StringAttr,
+    InsertionPoint,
+    FlatSymbolRefAttr,
+    Location,
+    UnitAttr,
+)
+from hcl_mlir.dialects import func as func_d
+import numpy as np
+
+from .customize import customize, _get_global_vars
+
+
+def kernel(mapping=None):
+    def top():
+        # Just for locating insertion point
+        pass
+
+    def decorator(func):
+        # construct a common module
+        s_top = customize(top)
+        global_vars = _get_global_vars(func)
+        new_global_vars = global_vars.copy()
+        for var in global_vars.values():
+            # import functions from other files
+            if isinstance(var, PyFunctionType):
+                new_global_vars.update(_get_global_vars(var))
+        # call different PE kernels
+        with s_top.module.context, Location.unknown():
+            for dim in np.ndindex(*mapping):
+                global_vars = new_global_vars.copy()
+                global_vars.update({"df.pi": dim[0], "df.pj": dim[1]})
+                s = customize(
+                    func, global_vars=global_vars, context=s_top.module.context
+                )
+                new_func_name = func.__name__ + f"_{dim[0]}_{dim[1]}"
+                s.top_func.attributes["sym_name"] = StringAttr.get(new_func_name)
+                s.top_func.operation.clone(InsertionPoint(s_top.top_func))
+            top_func = func_d.FuncOp(
+                name="top", type=s.top_func.type, ip=InsertionPoint(s_top.top_func)
+            )
+            top_func.add_entry_block()
+            top_func.attributes["itypes"] = s.top_func.attributes["itypes"]
+            top_func.attributes["otypes"] = s.top_func.attributes["otypes"]
+            func_d.ReturnOp([], ip=InsertionPoint(top_func.entry_block))
+            for dim in np.ndindex(*mapping):
+                new_func_name = func.__name__ + f"_{dim[0]}_{dim[1]}"
+                func_d.CallOp(
+                    [],
+                    FlatSymbolRefAttr.get(new_func_name),
+                    top_func.arguments,
+                    ip=InsertionPoint.at_block_terminator(top_func.entry_block),
+                )
+            top_func.attributes["dataflow"] = UnitAttr.get()
+        s_top.top_func.operation.erase()
+        s_top.top_func = top_func
+        print(s_top.module)
+        exe = s_top.build()
+        return exe
+
+    return decorator
+
+
+def get_pid():
+    raise NotImplementedError("This function should be called in a kernel function.")

--- a/allo/ir/infer.py
+++ b/allo/ir/infer.py
@@ -21,6 +21,7 @@ from .types import (
     uint1,
     int32,
     float32,
+    Stream,
 )
 from .typing_rule import get_typing_rule
 from ..backend.ip import IPModule
@@ -67,6 +68,11 @@ class TypeInferer(ASTVisitor):
                 dtype = TypeInferer.visit_call_type(ctx, node.value)
             else:
                 dtype = ASTResolver.resolve(node.value, ctx.global_vars)
+            if dtype is Stream:
+                # create an actual class instance
+                dtype = Stream(ASTResolver.resolve(node.slice, ctx.global_vars))
+                shape = tuple()
+                return dtype, shape
             assert dtype is not None, f"Unsupported type {node.value.id}"
             size = node.slice.value if isinstance(node.slice, ast.Index) else node.slice
             elts = size.elts if isinstance(size, ast.Tuple) else [size]
@@ -280,13 +286,17 @@ class TypeInferer(ASTVisitor):
                 targets = node.targets[0].elts
             else:
                 targets = [node.targets[0]]
-            for target in targets:
+            for i, target in enumerate(targets):
                 if isinstance(target, ast.Name):
-                    ctx.buffers[target.id] = rhs
+                    target.dtype = rhs.dtype[i] if isinstance(rhs.dtype, tuple) else rhs.dtype
+                    # notice here needs to test whether dtype is a tuple instead of shape
+                    # as shape is always a tuple
+                    target.shape = rhs.shape[i] if isinstance(rhs.dtype, tuple) else rhs.shape
+                    ctx.buffers[target.id] = target
                 else:
                     lhs = visit_stmt(ctx, target)
-                node.dtype = rhs.dtype
-                node.shape = rhs.shape
+            node.dtype = rhs.dtype
+            node.shape = rhs.shape
             return rhs
         # store LHS
         lhs = visit_stmt(ctx, node.targets[0])
@@ -385,9 +395,7 @@ class TypeInferer(ASTVisitor):
             elts = (
                 size.elts
                 if isinstance(size, ast.Tuple)
-                else size.dims
-                if isinstance(size, ast.ExtSlice)
-                else [size]
+                else size.dims if isinstance(size, ast.ExtSlice) else [size]
             )
             access_dim = len(elts)
             total_dim = len(value.shape)
@@ -693,6 +701,11 @@ class TypeInferer(ASTVisitor):
                 node.dtype = None
                 return node
             fn_name = obj.__name__
+            if len(new_args) == 0:
+                # No argument
+                node.shape = (tuple(), tuple())
+                node.dtype = (Index(), Index())
+                return node
             if len(new_args[0].shape) == 0:
                 # element-wise operation
                 node.shape = tuple()

--- a/allo/ir/infer.py
+++ b/allo/ir/infer.py
@@ -288,10 +288,14 @@ class TypeInferer(ASTVisitor):
                 targets = [node.targets[0]]
             for i, target in enumerate(targets):
                 if isinstance(target, ast.Name):
-                    target.dtype = rhs.dtype[i] if isinstance(rhs.dtype, tuple) else rhs.dtype
+                    target.dtype = (
+                        rhs.dtype[i] if isinstance(rhs.dtype, tuple) else rhs.dtype
+                    )
                     # notice here needs to test whether dtype is a tuple instead of shape
                     # as shape is always a tuple
-                    target.shape = rhs.shape[i] if isinstance(rhs.dtype, tuple) else rhs.shape
+                    target.shape = (
+                        rhs.shape[i] if isinstance(rhs.dtype, tuple) else rhs.shape
+                    )
                     ctx.buffers[target.id] = target
                 else:
                     lhs = visit_stmt(ctx, target)

--- a/allo/ir/types.py
+++ b/allo/ir/types.py
@@ -5,7 +5,15 @@
 import numbers
 from collections import OrderedDict
 
-from hcl_mlir.ir import IntegerType, IndexType, F16Type, F32Type, F64Type
+from hcl_mlir.ir import (
+    IntegerType,
+    IndexType,
+    F16Type,
+    F32Type,
+    F64Type,
+    MemRefType,
+    StringAttr,
+)
 from hcl_mlir.dialects import hcl as hcl_d
 from hcl_mlir.exceptions import DTypeError, DTypeWarning
 
@@ -163,6 +171,26 @@ class Struct(AlloType):
 
     def build(self):
         raise NotImplementedError("TODO")
+
+
+class Stream(AlloType):
+    def __init__(self, dtype, depth=2, size=1):
+        assert isinstance(dtype, AlloType), f"dtype must be an AlloType, got {dtype}"
+        self.dtype = dtype
+        self.depth = depth
+        self.size = size
+        super().__init__(0, 0, f"stream<{dtype}>")
+
+    def build(self):
+        return MemRefType.get(
+            (self.size,),
+            self.dtype.build(),
+            None,
+            StringAttr.get(f"stream:{self.depth}"),
+        )
+
+    def __repr__(self):
+        return f"Stream({self.dtype})"
 
 
 bool = Int(1)

--- a/tests/dataflow/test_identical_kernel.py
+++ b/tests/dataflow/test_identical_kernel.py
@@ -4,6 +4,7 @@
 from allo.ir.types import float32
 import allo.dataflow as df
 import numpy as np
+import pytest
 
 M, N, K = 32, 32, 32
 P0, P1 = 2, 2
@@ -19,9 +20,14 @@ def gemm(A: float32[M, K], B: float32[K, N], C: float32[M, N]):
                 C[i, j] += A[i, k] * B[k, j]
 
 
-A = np.random.rand(M, K).astype(np.float32)
-B = np.random.rand(K, N).astype(np.float32)
-C = np.zeros((M, N), dtype=np.float32)
-gemm(A, B, C)
-np.testing.assert_allclose(C, np.dot(A, B), rtol=1e-5, atol=1e-5)
-print("Success!")
+def test_tiled_gemm():
+    A = np.random.rand(M, K).astype(np.float32)
+    B = np.random.rand(K, N).astype(np.float32)
+    C = np.zeros((M, N), dtype=np.float32)
+    gemm(A, B, C)
+    np.testing.assert_allclose(C, np.dot(A, B), rtol=1e-5, atol=1e-5)
+    print("Success!")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/dataflow/test_identical_kernel.py
+++ b/tests/dataflow/test_identical_kernel.py
@@ -1,0 +1,27 @@
+# Copyright Allo authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from allo.ir.types import float32
+import allo.dataflow as df
+import numpy as np
+
+M, N, K = 32, 32, 32
+P0, P1 = 2, 2
+Mt, Nt = M // P0, N // P1
+
+
+@df.kernel(mapping=[P0, P1])
+def gemm(A: float32[M, K], B: float32[K, N], C: float32[M, N]):
+    pi, pj = df.get_pid()
+    for i in range(pi * Mt, (pi + 1) * Mt):
+        for j in range(pj * Nt, (pj + 1) * Nt):
+            for k in range(K):
+                C[i, j] += A[i, k] * B[k, j]
+
+
+A = np.random.rand(M, K).astype(np.float32)
+B = np.random.rand(K, N).astype(np.float32)
+C = np.zeros((M, N), dtype=np.float32)
+gemm(A, B, C)
+np.testing.assert_allclose(C, np.dot(A, B), rtol=1e-5, atol=1e-5)
+print("Success!")

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -119,7 +119,7 @@ def sdp(Q, K, V, H, D):
         V_h = V[:, i * h_d : (i + 1) * h_d]
         # compute attention
         attention = np.matmul(Q_h, K_h.T)
-        Y = np.exp(attention) / np.exp(attention).sum(axis=1, keepdims=True)
+        Y = np_softmax(attention)
         context_i = np.matmul(Y, V_h)
         context[:, i * h_d : (i + 1) * h_d] = context_i
     return context


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR proposes a new tiled-based programming model in Allo. Check out the following example. It does not contain inter-tile communication.


### Examples ###
```python
from allo.ir.types import float32
import allo.dataflow as df
import numpy as np

M, N, K = 32, 32, 32
P0, P1 = 2, 2
Mt, Nt = M // P0, N // P1


@df.kernel(mapping=[P0, P1])
def gemm(A: float32[M, K], B: float32[K, N], C: float32[M, N]):
    pi, pj = df.get_pid()
    for i in range(pi * Mt, (pi + 1) * Mt):
        for j in range(pj * Nt, (pj + 1) * Nt):
            for k in range(K):
                C[i, j] += A[i, k] * B[k, j]


A = np.random.rand(M, K).astype(np.float32)
B = np.random.rand(K, N).astype(np.float32)
C = np.zeros((M, N), dtype=np.float32)
gemm(A, B, C)
np.testing.assert_allclose(C, np.dot(A, B), rtol=1e-5, atol=1e-5)
print("Success!")
```
```mlir
module {
  func.func @gemm_0_0(%arg0: memref<32x32xf32>, %arg1: memref<32x32xf32>, %arg2: memref<32x32xf32>) attributes {itypes = "___", otypes = ""} {
    //...
  }
  func.func @gemm_0_1(%arg0: memref<32x32xf32>, %arg1: memref<32x32xf32>, %arg2: memref<32x32xf32>) attributes {itypes = "___", otypes = ""} {
    //...
  }
  func.func @gemm_1_0(%arg0: memref<32x32xf32>, %arg1: memref<32x32xf32>, %arg2: memref<32x32xf32>) attributes {itypes = "___", otypes = ""} {
    //...
  }
  func.func @gemm_1_1(%arg0: memref<32x32xf32>, %arg1: memref<32x32xf32>, %arg2: memref<32x32xf32>) attributes {itypes = "___", otypes = ""} {
    //...
  }
  func.func @top(%arg0: memref<32x32xf32>, %arg1: memref<32x32xf32>, %arg2: memref<32x32xf32>) attributes {dataflow, itypes = "___", otypes = ""} {
    call @gemm_0_0(%arg0, %arg1, %arg2) : (memref<32x32xf32>, memref<32x32xf32>, memref<32x32xf32>) -> ()
    call @gemm_0_1(%arg0, %arg1, %arg2) : (memref<32x32xf32>, memref<32x32xf32>, memref<32x32xf32>) -> ()
    call @gemm_1_0(%arg0, %arg1, %arg2) : (memref<32x32xf32>, memref<32x32xf32>, memref<32x32xf32>) -> ()
    call @gemm_1_1(%arg0, %arg1, %arg2) : (memref<32x32xf32>, memref<32x32xf32>, memref<32x32xf32>) -> ()
    return
  }
}

```


## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [x] Code is well-documented
