### PR TITLE
[backend] Support csim read/write to the same argument

### DIFF
--- a/tests/test_vhls.py
+++ b/tests/test_vhls.py
@@ -107,10 +107,7 @@ def test_vitis_io_stream():
 def test_csim_write_back():
     N = 256
 
-    def compute(
-        x: int32[N],
-        y: int32[N]
-    ):
+    def compute(x: int32[N], y: int32[N]):
         for i in range(N):
             y[i] = x[i]
 

--- a/tests/test_vhls.py
+++ b/tests/test_vhls.py
@@ -104,5 +104,25 @@ def test_vitis_io_stream():
         hls_mod()
 
 
+def test_csim_write_back():
+    N = 256
+
+    def compute(
+        x: int32[N],
+        y: int32[N]
+    ):
+        for i in range(N):
+            y[i] = x[i]
+
+    s = allo.customize(compute)
+    if hls.is_available("vitis_hls"):
+        mod = s.build(target="vitis_hls", mode="csim", project="test.prj")
+        A = np.random.randint(0, 10, size=(N)).astype(np.int32)
+        B = np.zeros((N), dtype=np.int32)
+        mod(A, B)
+        np.testing.assert_allclose(A, B, rtol=1e-5)
+        print("Passed!")
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR fixes #154. However, we currently suppose there is only one return argument (the last input). If there are multiple outputs or the output is not the last argument, this PR may still perform incorrectly. To make it fully correct, we need to perform read/write analysis on the buffers, to see which arguments have both read and write access.

### Examples ###
```python
def test_csim_write_back():
    N = 256

    def compute(x: int32[N], y: int32[N]):
        for i in range(N):
            y[i] = x[i]

    s = allo.customize(compute)
    if hls.is_available("vitis_hls"):
        mod = s.build(target="vitis_hls", mode="csim", project="test.prj")
        A = np.random.randint(0, 10, size=(N)).astype(np.int32)
        B = np.zeros((N), dtype=np.int32)
        mod(A, B)
        np.testing.assert_allclose(A, B, rtol=1e-5)
        print("Passed!")
```

```cpp
void compute(
  int32_t *v0,
  int32_t *v1
) {	// L2
  #pragma HLS interface m_axi port=v0 offset=slave bundle=gmem0
  #pragma HLS interface m_axi port=v1 offset=slave bundle=gmem1
  int32_t buf0[256];	//
  l_S_buf0_buf0_l_0: for (int buf0_l_0 = 0; buf0_l_0 < 256; buf0_l_0++) {	//
  #pragma HLS pipeline II=1 rewind
    int32_t v4 = v0[buf0_l_0];	//
    buf0[buf0_l_0] = v4;	//
  }
  int32_t buf1[256];	//
  l_S_buf1_buf1_l_0: for (int buf1_l_0 = 0; buf1_l_0 < 256; buf1_l_0++) {	//
  #pragma HLS pipeline II=1 rewind
    int32_t v7 = v1[buf1_l_0];	//
    buf1[buf1_l_0] = v7;	//
  }
  l_S_i_0_i: for (int i = 0; i < 256; i++) {	// L3
    int32_t v9 = buf0[i];	// L4
    buf1[i] = v9;	// L5
  }
  l_S_result2_result2_l_0: for (int result2_l_0 = 0; result2_l_0 < 256; result2_l_0++) {	//
  #pragma HLS pipeline II=1 rewind
    int32_t v11 = buf1[result2_l_0];	//
    v1[result2_l_0] = v11;	//
  }
}
```


## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [x] Code is well-documented
