### PR TITLE
[dataflow][experimental] Add stream type and support producer-consumer patterns

### DIFF
--- a/allo/backend/hls.py
+++ b/allo/backend/hls.py
@@ -175,26 +175,27 @@ class HLSModule:
                 buffers = generate_input_output_buffers(
                     self.func, flatten=True, mappings=mappings
                 )
-                if "dataflow" in self.func.attributes:
-                    assert func_args is not None, "Need to specify func_args"
-                    for inp in buffers["inputs"]:
-                        prim.to(
-                            self.module,
-                            inp,
-                            "",
-                            depth=4,
-                            func_args=func_args,
-                            top_func_name=top_func_name,
-                        )
-                    for out in buffers["outputs"]:
-                        prim.to(
-                            self.module,
-                            out,
-                            "",
-                            depth=4,
-                            func_args=func_args,
-                            top_func_name=top_func_name,
-                        )
+                # TODO: Fix dataflow!
+                # if "dataflow" in self.func.attributes:
+                #     assert func_args is not None, "Need to specify func_args"
+                #     for inp in buffers["inputs"]:
+                #         prim.to(
+                #             self.module,
+                #             inp,
+                #             "",
+                #             depth=4,
+                #             func_args=func_args,
+                #             top_func_name=top_func_name,
+                #         )
+                #     for out in buffers["outputs"]:
+                #         prim.to(
+                #             self.module,
+                #             out,
+                #             "",
+                #             depth=4,
+                #             func_args=func_args,
+                #             top_func_name=top_func_name,
+                #         )
             self.module = decompose_library_function(self.module)
             _mlir_lower_pipeline(self.module, lower_linalg=True)
             # Run through lowering passes

--- a/allo/backend/hls.py
+++ b/allo/backend/hls.py
@@ -1,6 +1,6 @@
 # Copyright Allo authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=consider-using-with, no-name-in-module
+# pylint: disable=consider-using-with, no-name-in-module, unused-argument
 
 import os
 import re
@@ -30,7 +30,8 @@ from ..passes import (
 )
 from ..harness.makefile_gen.makegen import generate_makefile
 from ..ir.transform import find_func_in_module
-from .. import primitives as prim
+
+# from .. import primitives as prim
 
 
 def is_available(backend="vivado_hls"):
@@ -172,7 +173,8 @@ class HLSModule:
                     mappings = configs.get("mappings", None)
                 else:
                     mappings = None
-                buffers = generate_input_output_buffers(
+                # buffers = generate_input_output_buffers(
+                generate_input_output_buffers(
                     self.func, flatten=True, mappings=mappings
                 )
                 # TODO: Fix dataflow!

--- a/allo/dataflow.py
+++ b/allo/dataflow.py
@@ -30,7 +30,7 @@ def move_stream_to_interface(func):
             stream_ops.append(op)
             stream_types.append(MemRefType(op.result.type))
     if len(stream_ops) == 0:
-        return func
+        return func, stream_types
     in_types = func.attributes["function_type"].value.inputs
     out_types = func.attributes["function_type"].value.results
     in_types += stream_types

--- a/allo/dataflow.py
+++ b/allo/dataflow.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=no-name-in-module, unexpected-keyword-arg, no-value-for-parameter
 
+import functools
 from types import FunctionType as PyFunctionType
 from hcl_mlir.ir import (
     StringAttr,
@@ -22,9 +23,14 @@ def move_stream_to_interface(func):
     stream_ops = []
     stream_types = []
     for op in func.entry_block.operations:
-        if isinstance(op, memref_d.AllocOp) and "stream" in MemRefType(op.result.type).memory_space.value:
+        if (
+            isinstance(op, memref_d.AllocOp)
+            and "stream" in MemRefType(op.result.type).memory_space.value
+        ):
             stream_ops.append(op)
             stream_types.append(MemRefType(op.result.type))
+    if len(stream_ops) == 0:
+        return func
     in_types = func.attributes["function_type"].value.inputs
     out_types = func.attributes["function_type"].value.results
     in_types += stream_types
@@ -35,11 +41,15 @@ def move_stream_to_interface(func):
         ip=InsertionPoint(func),
     )
     func_op.add_entry_block()
+    func_op.attributes["itypes"] = func.attributes["itypes"]
+    func_op.attributes["otypes"] = func.attributes["otypes"]
     # copy function operations
     cnt_stream = 0
     for op in func.entry_block.operations:
         if op in stream_ops:
-            op.result.replace_all_uses_with(func_op.arguments[len(func_op.entry_block.arguments) - 1 + cnt_stream])
+            op.result.replace_all_uses_with(
+                func_op.arguments[len(func_op.entry_block.arguments) - 1 + cnt_stream]
+            )
             cnt_stream += 1
             continue
         op.operation.clone(InsertionPoint(func_op.entry_block))
@@ -54,57 +64,60 @@ def kernel(mapping=None):
         # Just for locating insertion point
         pass
 
-    def decorator(func):
-        # construct a common module
-        s_top = customize(top)
-        global_vars = _get_global_vars(func)
-        new_global_vars = global_vars.copy()
-        for var in global_vars.values():
-            # import functions from other files
-            if isinstance(var, PyFunctionType):
-                new_global_vars.update(_get_global_vars(var))
-        # call different PE kernels
-        with s_top.module.context, Location.unknown():
-            assert len(mapping) <= 2, "Only support 1D/2D mapping now."
-            for dim in np.ndindex(*mapping):
-                global_vars = new_global_vars.copy()
-                if len(dim) == 1:
-                    global_vars.update({"df.pi": dim[0]})
-                    new_func_name = func.__name__ + f"_{dim[0]}"
-                else:
-                    global_vars.update({"df.pi": dim[0], "df.pj": dim[1]})
-                    new_func_name = func.__name__ + f"_{dim[0]}_{dim[1]}"
-                s = customize(
-                    func, global_vars=global_vars, context=s_top.module.context
+    def actual_decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            # *args and **kwargs are the actual arguments that are passed into the kernel function
+            # construct a common module
+            s_top = customize(top)
+            global_vars = _get_global_vars(func)
+            new_global_vars = global_vars.copy()
+            for var in global_vars.values():
+                # import functions from other files
+                if isinstance(var, PyFunctionType):
+                    new_global_vars.update(_get_global_vars(var))
+            # call different PE kernels
+            with s_top.module.context, Location.unknown():
+                assert len(mapping) <= 2, "Only support 1D/2D mapping now."
+                for dim in np.ndindex(*mapping):
+                    global_vars = new_global_vars.copy()
+                    if len(dim) == 1:
+                        global_vars.update({"df.pi": dim[0]})
+                        new_func_name = func.__name__ + f"_{dim[0]}"
+                    else:
+                        global_vars.update({"df.pi": dim[0], "df.pj": dim[1]})
+                        new_func_name = func.__name__ + f"_{dim[0]}_{dim[1]}"
+                    s = customize(
+                        func, global_vars=global_vars, context=s_top.module.context
+                    )
+                    s.top_func = move_stream_to_interface(s.top_func)
+                    s.top_func.attributes["sym_name"] = StringAttr.get(new_func_name)
+                    s.top_func.operation.clone(InsertionPoint(s_top.top_func))
+                top_func = func_d.FuncOp(
+                    name="top", type=s.top_func.type, ip=InsertionPoint(s_top.top_func)
                 )
-                s.top_func = move_stream_to_interface(s.top_func)
-                print(s.module)
-                sys.exit()
-                s.top_func.attributes["sym_name"] = StringAttr.get(new_func_name)
-                s.top_func.operation.clone(InsertionPoint(s_top.top_func))
-            top_func = func_d.FuncOp(
-                name="top", type=s.top_func.type, ip=InsertionPoint(s_top.top_func)
-            )
-            top_func.add_entry_block()
-            top_func.attributes["itypes"] = s.top_func.attributes["itypes"]
-            top_func.attributes["otypes"] = s.top_func.attributes["otypes"]
-            func_d.ReturnOp([], ip=InsertionPoint(top_func.entry_block))
-            for dim in np.ndindex(*mapping):
-                new_func_name = func.__name__ + f"_{'_'.join(map(str, dim))}"
-                func_d.CallOp(
-                    [],
-                    FlatSymbolRefAttr.get(new_func_name),
-                    top_func.arguments,
-                    ip=InsertionPoint.at_block_terminator(top_func.entry_block),
-                )
-            top_func.attributes["dataflow"] = UnitAttr.get()
-        s_top.top_func.operation.erase()
-        s_top.top_func = top_func
-        print(s_top.module)
-        exe = s_top.build()
-        return exe
+                top_func.add_entry_block()
+                top_func.attributes["itypes"] = s.top_func.attributes["itypes"]
+                top_func.attributes["otypes"] = s.top_func.attributes["otypes"]
+                func_d.ReturnOp([], ip=InsertionPoint(top_func.entry_block))
+                for dim in np.ndindex(*mapping):
+                    new_func_name = func.__name__ + f"_{'_'.join(map(str, dim))}"
+                    func_d.CallOp(
+                        [],
+                        FlatSymbolRefAttr.get(new_func_name),
+                        top_func.arguments,
+                        ip=InsertionPoint.at_block_terminator(top_func.entry_block),
+                    )
+                top_func.attributes["dataflow"] = UnitAttr.get()
+            s_top.top_func.operation.erase()
+            s_top.top_func = top_func
+            print(s_top.module)
+            exe = s_top.build()
+            return exe(*args, **kwargs)
 
-    return decorator
+        return wrapper
+
+    return actual_decorator
 
 
 def get_pid():
@@ -113,3 +126,18 @@ def get_pid():
 
 def pipe():
     raise NotImplementedError("This function should be called in a kernel function.")
+
+
+def build(funcs):
+    def top():
+        # Just for locating insertion point
+        pass
+
+    # construct a common module
+    s_top = customize(top)
+    with s_top.module.context, Location.unknown():
+        for func in funcs:
+            s = customize(func.__wrapped__, context=s_top.module.context)
+            s.top_func = move_stream_to_interface(s.top_func)
+            s.top_func.operation.clone(InsertionPoint(s_top.top_func))
+    print(s_top.module)

--- a/allo/dataflow.py
+++ b/allo/dataflow.py
@@ -169,7 +169,13 @@ def build(funcs):
                 [top_func.arguments[i]] + [func_info["producer"][0]],
                 ip=InsertionPoint.at_block_terminator(top_func.entry_block),
             )
-        s_top.top_func.attributes["dataflow"] = UnitAttr.get()
+        # top_func.attributes["dataflow"] = UnitAttr.get()
         s_top.top_func.operation.erase()
         s_top.top_func = top_func
     print(s_top.module)
+    hls_mod = s_top.build(
+        target="vitis_hls",
+        mode="csim",
+        project=f"top.prj",
+    )
+    return hls_mod

--- a/allo/dataflow.py
+++ b/allo/dataflow.py
@@ -101,6 +101,7 @@ def kernel(mapping=None):
                 top_func.attributes["otypes"] = s.top_func.attributes["otypes"]
                 func_d.ReturnOp([], ip=InsertionPoint(top_func.entry_block))
                 for dim in np.ndindex(*mapping):
+                    # pylint: disable=bad-builtin
                     new_func_name = func.__name__ + f"_{'_'.join(map(str, dim))}"
                     func_d.CallOp(
                         [],
@@ -162,7 +163,7 @@ def build(funcs):
             )
             func_info[func_name] = [new_op.result]
             break
-        for i, (func_name, stream_op) in enumerate(func_info.items()):
+        for i, (func_name, _) in enumerate(func_info.items()):
             func_d.CallOp(
                 [],
                 FlatSymbolRefAttr.get(func_name),
@@ -176,6 +177,6 @@ def build(funcs):
     hls_mod = s_top.build(
         target="vitis_hls",
         mode="csim",
-        project=f"top.prj",
+        project="top.prj",
     )
     return hls_mod

--- a/allo/dataflow.py
+++ b/allo/dataflow.py
@@ -169,7 +169,7 @@ def build(funcs):
                 [top_func.arguments[i]] + [func_info["producer"][0]],
                 ip=InsertionPoint.at_block_terminator(top_func.entry_block),
             )
-        # top_func.attributes["dataflow"] = UnitAttr.get()
+        top_func.attributes["dataflow"] = UnitAttr.get()
         s_top.top_func.operation.erase()
         s_top.top_func = top_func
     print(s_top.module)

--- a/allo/ir/builder.py
+++ b/allo/ir/builder.py
@@ -1557,6 +1557,7 @@ class ASTTransformer(ASTBuilder):
         ctx.pop_ip()
         return module
 
+    # pylint: disable=too-many-return-statements
     @staticmethod
     def build_Call(ctx, node):
         original_func_id = ctx.func_id
@@ -1595,7 +1596,7 @@ class ASTTransformer(ASTBuilder):
                 if node.func.attr in {"T", "reverse"}:
                     # x.T or x.reverse
                     return build_stmt(ctx, node.func)
-                elif node.func.attr == "put":
+                if node.func.attr == "put":
                     stmts = build_stmts(ctx, node.args)
                     affine_map = AffineMap.get(
                         dim_count=0, symbol_count=0, exprs=[AffineConstantExpr.get(0)]
@@ -1609,18 +1610,17 @@ class ASTTransformer(ASTBuilder):
                         ip=ctx.get_ip(),
                     )
                     return
-                elif node.func.attr == "get":
+                if node.func.attr == "get":
                     affine_map = AffineMap.get(
                         dim_count=0, symbol_count=0, exprs=[AffineConstantExpr.get(0)]
                     )
                     affine_attr = AffineMapAttr.get(affine_map)
-                    op = affine_d.AffineLoadOp(
+                    return affine_d.AffineLoadOp(
                         ctx.buffers[node.func.value.id].result,
                         [],
                         affine_attr,
                         ip=ctx.get_ip(),
                     )
-                    return op
             if node.func.id in {"float", "int"}:
                 # Python-Builtin functions
                 stmts = build_stmts(ctx, node.args)
@@ -1682,7 +1682,7 @@ class ASTTransformer(ASTBuilder):
                     MockConstant(ctx.global_vars["df.pi"], ctx, dtype=Index()),
                     MockConstant(ctx.global_vars["df.pj"], ctx, dtype=Index()),
                 )
-            elif fn_name == "pipe":
+            if fn_name == "pipe":
                 return Stream(node.dtype)
             arg_type = new_args[0].result.type
             if isinstance(arg_type, (F32Type, IntegerType)):

--- a/allo/ir/infer.py
+++ b/allo/ir/infer.py
@@ -690,6 +690,10 @@ class TypeInferer(ASTVisitor):
                     node.shape = ctx.buffers[node.func.value.id].shape
                     # get element type of Stream
                     node.dtype = ctx.buffers[node.func.value.id].dtype.dtype
+                else:
+                    raise RuntimeError(
+                        f"Unsupported function call or attribute method {node.func.attr}"
+                    )
             elif node.func.id in {"float", "int"}:
                 # Python-Builtin functions
                 assert (

--- a/allo/ir/infer.py
+++ b/allo/ir/infer.py
@@ -639,6 +639,7 @@ class TypeInferer(ASTVisitor):
         node.shape = None
         return node
 
+    # pylint: disable=too-many-branches
     @staticmethod
     def visit_Call(ctx, node):
         original_func_id = ctx.func_id

--- a/tests/dataflow/test_producer_consumer.py
+++ b/tests/dataflow/test_producer_consumer.py
@@ -4,7 +4,9 @@
 import allo
 from allo.ir.types import float32, Stream
 import allo.dataflow as df
+import allo.backend.hls as hls
 import numpy as np
+import pytest
 
 Ty = float32
 M, N, K = 16, 16, 16
@@ -30,9 +32,15 @@ def consumer(B: Ty[M, N]):
         B[i, j] = data + 1
 
 
-A = np.random.rand(M, N).astype(np.float32)
-B = np.zeros((M, N), dtype=np.float32)
-top = df.build([producer, consumer])
-top(A, B)
-np.testing.assert_allclose(A + 1, B)
-print("Passed!")
+def test_producer_consumer():
+    A = np.random.rand(M, N).astype(np.float32)
+    B = np.zeros((M, N), dtype=np.float32)
+    top = df.build([producer, consumer])
+    if hls.is_available("vitis_hls"):
+        top(A, B)
+        np.testing.assert_allclose(A + 1, B)
+        print("Passed!")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/dataflow/test_producer_consumer.py
+++ b/tests/dataflow/test_producer_consumer.py
@@ -10,14 +10,14 @@ Ty = float32
 M, N, K = 16, 16, 16
 
 
-# @df.kernel(mapping=[1])
-# def producer(A: Ty[M, N]):
-#     pipe: Stream[Ty] = df.pipe(src="producer", dst="consumer")
-#     for i, j in allo.grid(M, N):
-#         # load data
-#         out: Ty = A[i, j]
-#         # send data
-#         pipe.put(out)
+@df.kernel(mapping=[1])
+def producer(A: Ty[M, N]):
+    pipe: Stream[Ty] = df.pipe(src="producer", dst="consumer")
+    for i, j in allo.grid(M, N):
+        # load data
+        out: Ty = A[i, j]
+        # send data
+        pipe.put(out)
 
 
 @df.kernel(mapping=[1])
@@ -31,9 +31,8 @@ def consumer(B: Ty[M, N]):
 
 
 A = np.random.rand(M, N).astype(np.float32)
-# producer(A)
-consumer(A)
-# B = np.zeros((M, N), dtype=np.float32)
-# top = df.build([producer, consumer])
-# top(A, B)
-# np.assert_allclose(A + 1, B)
+B = np.zeros((M, N), dtype=np.float32)
+top = df.build([producer, consumer])
+top(A, B)
+np.testing.assert_allclose(A + 1, B)
+print("Passed!")

--- a/tests/dataflow/test_producer_consumer.py
+++ b/tests/dataflow/test_producer_consumer.py
@@ -1,0 +1,39 @@
+# Copyright Allo authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import allo
+from allo.ir.types import float32, Stream
+import allo.dataflow as df
+import numpy as np
+
+Ty = float32
+M, N, K = 16, 16, 16
+
+
+# @df.kernel(mapping=[1])
+# def producer(A: Ty[M, N]):
+#     pipe: Stream[Ty] = df.pipe(src="producer", dst="consumer")
+#     for i, j in allo.grid(M, N):
+#         # load data
+#         out: Ty = A[i, j]
+#         # send data
+#         pipe.put(out)
+
+
+@df.kernel(mapping=[1])
+def consumer(B: Ty[M, N]):
+    pipe: Stream[Ty] = df.pipe(src="producer", dst="consumer")
+    for i, j in allo.grid(M, N):
+        # receive data
+        data = pipe.get()
+        # computation
+        B[i, j] = data + 1
+
+
+A = np.random.rand(M, N).astype(np.float32)
+# producer(A)
+consumer(A)
+# B = np.zeros((M, N), dtype=np.float32)
+# top = df.build([producer, consumer])
+# top(A, B)
+# np.assert_allclose(A + 1, B)

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -64,7 +64,7 @@ def test_linalg_matmul():
     def kernel3(A: int32[M, K], B: int32[K, N]) -> int32[M, N]:
         return allo.matmul_error(A, B)
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(RuntimeError):
         s = allo.customize(kernel3)
 
     def kernel4(A: int32[M, K], B: int32[K, N]) -> int32[M, N]:


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR adds stream type and supports producer-consumer communication patterns.

### Examples ###
```python
import allo
from allo.ir.types import float32, Stream
import allo.dataflow as df
import numpy as np

Ty = float32
M, N, K = 16, 16, 16

@df.kernel(mapping=[1])
def producer(A: Ty[M, N]):
    pipe: Stream[Ty] = df.pipe(src="producer", dst="consumer")
    for i, j in allo.grid(M, N):
        # load data
        out: Ty = A[i, j]
        # send data
        pipe.put(out)

@df.kernel(mapping=[1])
def consumer(B: Ty[M, N]):
    pipe: Stream[Ty] = df.pipe(src="producer", dst="consumer")
    for i, j in allo.grid(M, N):
        # receive data
        data = pipe.get()
        # computation
        B[i, j] = data + 1

A = np.random.rand(M, N).astype(np.float32)
B = np.zeros((M, N), dtype=np.float32)
top = df.build([producer, consumer])
top(A, B)
np.testing.assert_allclose(A + 1, B)
print("Passed!")
```
```mlir
module {
  func.func @producer(%arg0: memref<16x16xf32>, %arg1: memref<1xf32, "stream:2">) attributes {itypes = "_", otypes = ""} {
    affine.for %arg2 = 0 to 16 {
      affine.for %arg3 = 0 to 16 {
        %0 = affine.load %arg0[%arg2, %arg3] {from = "A"} : memref<16x16xf32>
        %alloc = memref.alloc() {name = "out"} : memref<1xf32>
        affine.store %0, %alloc[0] {to = "out"} : memref<1xf32>
        %1 = affine.load %alloc[0] {from = "out"} : memref<1xf32>
        affine.store %1, %arg1[0] : memref<1xf32, "stream:2">
      } {loop_name = "j"}
    } {loop_name = "i", op_name = "S_i_j_0"}
    return
  }
  func.func @consumer(%arg0: memref<16x16xf32>, %arg1: memref<1xf32, "stream:2">) attributes {itypes = "_", otypes = ""} {
    affine.for %arg2 = 0 to 16 {
      affine.for %arg3 = 0 to 16 {
        %0 = affine.load %arg1[0] {name = "data"} : memref<1xf32, "stream:2">
        %c1_i32 = arith.constant 1 : i32
        %1 = arith.sitofp %c1_i32 : i32 to f32
        %2 = arith.addf %0, %1 : f32
        affine.store %2, %arg0[%arg2, %arg3] {to = "B"} : memref<16x16xf32>
      } {loop_name = "j"}
    } {loop_name = "i", op_name = "S_i_j_0"}
    return
  }
  func.func @top(%arg0: memref<16x16xf32>, %arg1: memref<16x16xf32>) attributes {dataflow, itypes = "_", otypes = ""} {
    %alloc = memref.alloc() : memref<1xf32, "stream:2">
    call @producer(%arg0, %alloc) : (memref<16x16xf32>, memref<1xf32, "stream:2">) -> ()
    call @consumer(%arg1, %alloc) : (memref<16x16xf32>, memref<1xf32, "stream:2">) -> ()
    return
  }
}
```


## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [x] Code is well-documented
