### PR TITLE
[dataflow][experimental] Support systolic pattern

### DIFF
--- a/allo/ir/builder.py
+++ b/allo/ir/builder.py
@@ -778,7 +778,11 @@ class ASTTransformer(ASTBuilder):
                             f"Variable `{target.id}` has already been defined, please use a different name"
                         )
                     ctx.buffers[target.id] = rhs[idx] if isinstance(rhs, tuple) else rhs
-                    if node.value.func.attr == "get_pid":
+                    if (
+                        isinstance(node.value, ast.Call)
+                        and isinstance(node.value.func, ast.Attribute)
+                        and node.value.func.attr == "get_pid"
+                    ):
                         ctx.global_vars[ast.unparse(target)] = ctx.global_vars[
                             f"df.p{idx}"
                         ]

--- a/allo/ir/builder.py
+++ b/allo/ir/builder.py
@@ -1695,8 +1695,15 @@ class ASTTransformer(ASTBuilder):
             if fn_name == "pipe":
                 src = ASTResolver.resolve_constant(node.keywords[0].value, ctx)
                 dst = ASTResolver.resolve_constant(node.keywords[1].value, ctx)
-                src = ctx.top_func.attributes["sym_name"].value + f"_{src[0]}_{src[1]}"
-                dst = ctx.top_func.attributes["sym_name"].value + f"_{dst[0]}_{dst[1]}"
+                if not (isinstance(src, str) and isinstance(dst, str)):
+                    src = (
+                        ctx.top_func.attributes["sym_name"].value
+                        + f"_{src[0]}_{src[1]}"
+                    )
+                    dst = (
+                        ctx.top_func.attributes["sym_name"].value
+                        + f"_{dst[0]}_{dst[1]}"
+                    )
                 memref_type = node.dtype.build()
                 stream_op = memref_d.AllocOp(memref_type, [], [], ip=ctx.get_ip())
                 stream_op.attributes["src"] = StringAttr.get(src)

--- a/allo/ir/infer.py
+++ b/allo/ir/infer.py
@@ -297,7 +297,11 @@ class TypeInferer(ASTVisitor):
                         rhs.shape[i] if isinstance(rhs.dtype, tuple) else rhs.shape
                     )
                     ctx.buffers[target.id] = target
-                    if node.value.func.attr == "get_pid":
+                    if (
+                        isinstance(node.value, ast.Call)
+                        and isinstance(node.value.func, ast.Attribute)
+                        and node.value.func.attr == "get_pid"
+                    ):
                         ctx.global_vars[ast.unparse(target)] = ctx.global_vars[
                             f"df.p{i}"
                         ]

--- a/allo/ir/infer.py
+++ b/allo/ir/infer.py
@@ -297,6 +297,10 @@ class TypeInferer(ASTVisitor):
                         rhs.shape[i] if isinstance(rhs.dtype, tuple) else rhs.shape
                     )
                     ctx.buffers[target.id] = target
+                    if node.value.func.attr == "get_pid":
+                        ctx.global_vars[ast.unparse(target)] = ctx.global_vars[
+                            f"df.p{i}"
+                        ]
                 else:
                     lhs = visit_stmt(ctx, target)
             node.dtype = rhs.dtype

--- a/allo/ir/use_def.py
+++ b/allo/ir/use_def.py
@@ -247,7 +247,11 @@ class UseDefChain(ast.NodeVisitor):
         for i, target in enumerate(targets):
             name = get_name(target)
             var = VarNode(self.path, name)
-            if isinstance(node.value, ast.Call) and node.value.func.attr == "get_pid":
+            if (
+                isinstance(node.value, ast.Call)
+                and isinstance(node.value.func, ast.Attribute)
+                and node.value.func.attr == "get_pid"
+            ):
                 self.global_vars[ast.unparse(target)] = self.global_vars[f"df.p{i}"]
             for parent in parents:
                 parent.add_user(var)

--- a/allo/ir/use_def.py
+++ b/allo/ir/use_def.py
@@ -244,9 +244,11 @@ class UseDefChain(ast.NodeVisitor):
             targets = node.targets[0].elts
         else:
             targets = [node.targets[0]]
-        for target in targets:
+        for i, target in enumerate(targets):
             name = get_name(target)
             var = VarNode(self.path, name)
+            if isinstance(node.value, ast.Call) and node.value.func.attr == "get_pid":
+                self.global_vars[ast.unparse(target)] = self.global_vars[f"df.p{i}"]
             for parent in parents:
                 parent.add_user(var)
             if self.get_name(name) not in self.buffers:

--- a/allo/ir/utils.py
+++ b/allo/ir/utils.py
@@ -53,11 +53,12 @@ def _get_global_vars(_func):
 
 def get_global_vars(func):
     global_vars =_get_global_vars(func)
+    new_global_vars = global_vars.copy()
     for var in global_vars.values():
         # import functions from other files
         if isinstance(var, PyFunctionType):
-            global_vars.update(_get_global_vars(var))
-    return global_vars
+            new_global_vars.update(_get_global_vars(var))
+    return new_global_vars
 
 
 def get_extra_type_hints(dtype: AlloType):

--- a/allo/ir/utils.py
+++ b/allo/ir/utils.py
@@ -3,6 +3,9 @@
 # pylint: disable=no-name-in-module
 
 import ast
+import inspect
+from collections.abc import Callable
+from types import FunctionType as PyFunctionType
 from hcl_mlir.ir import (
     MemRefType,
     IntegerType,
@@ -22,6 +25,39 @@ from hcl_mlir.dialects import (
 )
 from .types import AlloType, Int, UInt, Fixed, UFixed, Index
 from .symbol_resolver import ASTResolver
+
+
+def _get_global_vars(_func):
+    if isinstance(_func, Callable):
+        # Discussions: https://github.com/taichi-dev/taichi/issues/282
+        global_vars = _func.__globals__.copy()
+    else:
+        global_vars = {}
+
+    # Get back to the outer-most scope (user-defined function)
+    # Mainly used to get the annotation definitions (shape and type),
+    # which are probably not defined in __globals__
+    for name, var in inspect.stack()[2][0].f_locals.items():
+        if isinstance(var, (int, float, AlloType)) or inspect.isfunction(var):
+            global_vars[name] = var
+
+    if isinstance(_func, Callable):
+        freevar_names = _func.__code__.co_freevars
+        closure = _func.__closure__
+        if closure:
+            freevar_values = [x.cell_contents for x in closure]
+            for name, value in zip(freevar_names, freevar_values):
+                global_vars[name] = value
+    return global_vars
+
+
+def get_global_vars(func):
+    global_vars =_get_global_vars(func)
+    for var in global_vars.values():
+        # import functions from other files
+        if isinstance(var, PyFunctionType):
+            global_vars.update(_get_global_vars(var))
+    return global_vars
 
 
 def get_extra_type_hints(dtype: AlloType):

--- a/allo/ir/utils.py
+++ b/allo/ir/utils.py
@@ -52,7 +52,7 @@ def _get_global_vars(_func):
 
 
 def get_global_vars(func):
-    global_vars =_get_global_vars(func)
+    global_vars = _get_global_vars(func)
     new_global_vars = global_vars.copy()
     for var in global_vars.values():
         # import functions from other files

--- a/allo/ir/utils.py
+++ b/allo/ir/utils.py
@@ -37,7 +37,7 @@ def _get_global_vars(_func):
     # Get back to the outer-most scope (user-defined function)
     # Mainly used to get the annotation definitions (shape and type),
     # which are probably not defined in __globals__
-    for name, var in inspect.stack()[2][0].f_locals.items():
+    for name, var in inspect.stack()[3][0].f_locals.items():
         if isinstance(var, (int, float, AlloType)) or inspect.isfunction(var):
             global_vars[name] = var
 

--- a/allo/ir/visitor.py
+++ b/allo/ir/visitor.py
@@ -64,6 +64,7 @@ class ASTContext:
         self.ext_libs = []
         # metaprogramming
         self.meta_if_stack = []
+        self.has_return = False
 
     def copy(self):
         ctx = ASTContext(

--- a/tests/dataflow/test_no_communication.py
+++ b/tests/dataflow/test_no_communication.py
@@ -3,6 +3,7 @@
 
 from allo.ir.types import float32
 import allo.dataflow as df
+import allo.backend.hls as hls
 import numpy as np
 import pytest
 
@@ -24,9 +25,10 @@ def test_tiled_gemm():
     A = np.random.rand(M, K).astype(np.float32)
     B = np.random.rand(K, N).astype(np.float32)
     C = np.zeros((M, N), dtype=np.float32)
-    gemm(A, B, C)
-    np.testing.assert_allclose(C, np.dot(A, B), rtol=1e-5, atol=1e-5)
-    print("Success!")
+    if hls.is_available("vitis_hls"):
+        gemm(A, B, C)
+        np.testing.assert_allclose(C, np.dot(A, B), rtol=1e-5, atol=1e-5)
+        print("Success!")
 
 
 if __name__ == "__main__":

--- a/tests/dataflow/test_systolic.py
+++ b/tests/dataflow/test_systolic.py
@@ -6,10 +6,11 @@ from allo.ir.types import float32, Stream
 import allo.dataflow as df
 import numpy as np
 
-M, N, K = 16, 16, 16
+M, N, K = 2, 2, 2
+P0, P1 = M, N
 
 
-@df.kernel(mapping=[2, 2])
+@df.kernel(mapping=[P0, P1])
 def gemm(A: float32[M, K], B: float32[K, N], C: float32[M, N]):
     i, j = df.get_pid()
     in_A: Stream[float32] = df.pipe(src=(i, j - 1), dst=(i, j))
@@ -42,3 +43,5 @@ A = np.random.rand(M, K).astype(np.float32)
 B = np.random.rand(K, N).astype(np.float32)
 C = np.zeros((M, N), dtype=np.float32)
 gemm(A, B, C)
+np.testing.assert_allclose(C, np.dot(A, B), atol=1e-5)
+print("Passed!")


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR enhances the composability of dataflow programs. It can now automatically analyze the connection between kernels and generate the correct top-level functions with complex communication patterns (e.g., systolic array).

### Examples ###
```python
import allo
from allo.ir.types import float32, Stream
import allo.dataflow as df
import allo.backend.hls as hls
import numpy as np
import pytest

M, N, K = 1, 1, 1
P0, P1 = M + 1, N + 1

@df.kernel(mapping=[P0, P1])
def gemm(A: float32[M, K], B: float32[K, N], C: float32[M, N]):
    i, j = df.get_pid()
    in_A: Stream[float32] = df.pipe(src=(i, j - 1), dst=(i, j))
    in_B: Stream[float32] = df.pipe(src=(i - 1, j), dst=(i, j))
    out_A: Stream[float32] = df.pipe(src=(i, j), dst=(i, j + 1))
    out_B: Stream[float32] = df.pipe(src=(i, j), dst=(i + 1, j))
    # periperals kernels
    with allo.meta_if(i == 0 and j == 0):
        pass
    with allo.meta_elif(j == 0):
        # i > 0
        for k in range(K):
            out_A.put(A[i - 1, k])
    with allo.meta_elif(i == 0):
        # j > 0
        for k in range(K):
            out_B.put(B[k, j - 1])
    # main body
    with allo.meta_else():
        c: float32 = 0
        for k in range(K):
            a: float32 = in_A.get()
            b: float32 = in_B.get()
            c += a * b
            out_A.put(a)
            out_B.put(b)
        C[i - 1, j - 1] = c


A = np.random.rand(M, K).astype(np.float32)
B = np.random.rand(K, N).astype(np.float32)
C = np.zeros((M, N), dtype=np.float32)
gemm(A, B, C)
np.testing.assert_allclose(C, np.dot(A, B), atol=1e-5)
print("Passed!")
```
```mlir
module {
  func.func @gemm_0_0(%arg0: memref<1x1xf32>, %arg1: memref<1x1xf32>, %arg2: memref<1x1xf32>, %arg3: memref<1xf32, "stream:2">, %arg4: memref<1xf32, "stream:2">, %arg5: memref<1xf32, "stream:2">, %arg6: memref<1xf32, "stream:2">) {
    return
  }
  func.func @gemm_0_1(%arg0: memref<1x1xf32>, %arg1: memref<1x1xf32>, %arg2: memref<1x1xf32>, %arg3: memref<1xf32, "stream:2">, %arg4: memref<1xf32, "stream:2">, %arg5: memref<1xf32, "stream:2">, %arg6: memref<1xf32, "stream:2">) {
    affine.for %arg7 = 0 to 1 {
      %0 = affine.load %arg1[%arg7, 0] {from = "B"} : memref<1x1xf32>
      affine.store %0, %arg6[0] : memref<1xf32, "stream:2">
    } {loop_name = "k", op_name = "S_k_0"}
    return
  }
  func.func @gemm_1_0(%arg0: memref<1x1xf32>, %arg1: memref<1x1xf32>, %arg2: memref<1x1xf32>, %arg3: memref<1xf32, "stream:2">, %arg4: memref<1xf32, "stream:2">, %arg5: memref<1xf32, "stream:2">, %arg6: memref<1xf32, "stream:2">) {
    affine.for %arg7 = 0 to 1 {
      %0 = affine.load %arg0[0, %arg7] {from = "A"} : memref<1x1xf32>
      affine.store %0, %arg5[0] : memref<1xf32, "stream:2">
    } {loop_name = "k", op_name = "S_k_0"}
    return
  }
  func.func @gemm_1_1(%arg0: memref<1x1xf32>, %arg1: memref<1x1xf32>, %arg2: memref<1x1xf32>, %arg3: memref<1xf32, "stream:2">, %arg4: memref<1xf32, "stream:2">, %arg5: memref<1xf32, "stream:2">, %arg6: memref<1xf32, "stream:2">) {
    %c0_i32 = arith.constant 0 : i32
    %0 = arith.sitofp %c0_i32 : i32 to f32
    %alloc = memref.alloc() {name = "c"} : memref<1xf32>
    affine.store %0, %alloc[0] {to = "c"} : memref<1xf32>
    affine.for %arg7 = 0 to 1 {
      %2 = affine.load %arg3[0] : memref<1xf32, "stream:2">
      %alloc_0 = memref.alloc() {name = "a"} : memref<1xf32>
      affine.store %2, %alloc_0[0] {to = "a"} : memref<1xf32>
      %3 = affine.load %arg4[0] : memref<1xf32, "stream:2">
      %alloc_1 = memref.alloc() {name = "b"} : memref<1xf32>
      affine.store %3, %alloc_1[0] {to = "b"} : memref<1xf32>
      %4 = affine.load %alloc_0[0] {from = "a"} : memref<1xf32>
      %5 = affine.load %alloc_1[0] {from = "b"} : memref<1xf32>
      %6 = arith.mulf %4, %5 : f32
      %7 = affine.load %alloc[0] {from = "c"} : memref<1xf32>
      %8 = arith.addf %7, %6 : f32
      affine.store %8, %alloc[0] {to = "c"} : memref<1xf32>
      %9 = affine.load %alloc_0[0] {from = "a"} : memref<1xf32>
      affine.store %9, %arg5[0] : memref<1xf32, "stream:2">
      %10 = affine.load %alloc_1[0] {from = "b"} : memref<1xf32>
      affine.store %10, %arg6[0] : memref<1xf32, "stream:2">
    } {loop_name = "k", op_name = "S_k_0"}
    %1 = affine.load %alloc[0] {from = "c"} : memref<1xf32>
    affine.store %1, %arg2[0, 0] {to = "C"} : memref<1x1xf32>
    return
  }
  func.func @top(%arg0: memref<1x1xf32>, %arg1: memref<1x1xf32>, %arg2: memref<1x1xf32>) attributes {dataflow} {
    %alloc = memref.alloc() {dst = "gemm_0_0", src = "gemm_0_-1"} : memref<1xf32, "stream:2">
    %alloc_0 = memref.alloc() {dst = "gemm_0_0", src = "gemm_-1_0"} : memref<1xf32, "stream:2">
    %alloc_1 = memref.alloc() {dst = "gemm_0_1", src = "gemm_0_0"} : memref<1xf32, "stream:2">
    %alloc_2 = memref.alloc() {dst = "gemm_1_0", src = "gemm_0_0"} : memref<1xf32, "stream:2">
    call @gemm_0_0(%arg0, %arg1, %arg2, %alloc, %alloc_0, %alloc_1, %alloc_2) : (memref<1x1xf32>, memref<1x1xf32>, memref<1x1xf32>, memref<1xf32, "stream:2">, memref<1xf32, "stream:2">, memref<1xf32, "stream:2">, memref<1xf32, "stream:2">) -> ()
    %alloc_3 = memref.alloc() {dst = "gemm_0_1", src = "gemm_-1_1"} : memref<1xf32, "stream:2">
    %alloc_4 = memref.alloc() {dst = "gemm_0_2", src = "gemm_0_1"} : memref<1xf32, "stream:2">
    %alloc_5 = memref.alloc() {dst = "gemm_1_1", src = "gemm_0_1"} : memref<1xf32, "stream:2">
    call @gemm_0_1(%arg0, %arg1, %arg2, %alloc_1, %alloc_3, %alloc_4, %alloc_5) : (memref<1x1xf32>, memref<1x1xf32>, memref<1x1xf32>, memref<1xf32, "stream:2">, memref<1xf32, "stream:2">, memref<1xf32, "stream:2">, memref<1xf32, "stream:2">) -> ()
    %alloc_6 = memref.alloc() {dst = "gemm_1_0", src = "gemm_1_-1"} : memref<1xf32, "stream:2">
    %alloc_7 = memref.alloc() {dst = "gemm_1_1", src = "gemm_1_0"} : memref<1xf32, "stream:2">
    %alloc_8 = memref.alloc() {dst = "gemm_2_0", src = "gemm_1_0"} : memref<1xf32, "stream:2">
    call @gemm_1_0(%arg0, %arg1, %arg2, %alloc_6, %alloc_2, %alloc_7, %alloc_8) : (memref<1x1xf32>, memref<1x1xf32>, memref<1x1xf32>, memref<1xf32, "stream:2">, memref<1xf32, "stream:2">, memref<1xf32, "stream:2">, memref<1xf32, "stream:2">) -> ()
    %alloc_9 = memref.alloc() {dst = "gemm_1_2", src = "gemm_1_1"} : memref<1xf32, "stream:2">
    %alloc_10 = memref.alloc() {dst = "gemm_2_1", src = "gemm_1_1"} : memref<1xf32, "stream:2">
    call @gemm_1_1(%arg0, %arg1, %arg2, %alloc_7, %alloc_5, %alloc_9, %alloc_10) : (memref<1x1xf32>, memref<1x1xf32>, memref<1x1xf32>, memref<1xf32, "stream:2">, memref<1xf32, "stream:2">, memref<1xf32, "stream:2">, memref<1xf32, "stream:2">) -> ()
    return
  }
}
```

## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [x] Code is well-documented
