### PR TITLE
[dataflow][experimental] Add tiled systolic array example

### DIFF
--- a/allo/dataflow.py
+++ b/allo/dataflow.py
@@ -3,6 +3,7 @@
 # pylint: disable=no-name-in-module, unexpected-keyword-arg, no-value-for-parameter
 
 import functools
+import gc
 from hcl_mlir.ir import (
     StringAttr,
     InsertionPoint,
@@ -138,6 +139,9 @@ def kernel(mapping=None):
                 assert len(mapping) <= 2, "Only support 1D/2D mapping now."
                 all_stream_info = {}
                 for dim in np.ndindex(*mapping):
+                    # A randomly crashed bug
+                    # https://github.com/cornell-zhang/allo/issues/196
+                    gc.collect()
                     if len(dim) == 1:
                         global_vars.update({"df.p0": dim[0]})
                         new_func_name = func.__name__ + f"_{dim[0]}"

--- a/allo/dataflow.py
+++ b/allo/dataflow.py
@@ -113,7 +113,6 @@ def _build_top(s_top, input_types, stream_info):
     top_func.attributes["dataflow"] = UnitAttr.get()
     s_top.top_func.operation.erase()
     s_top.top_func = top_func
-    print(s_top.module)
     hls_mod = s_top.build(
         target="vitis_hls",
         mode="csim",
@@ -181,7 +180,6 @@ def build(funcs):
             input_types += s.top_func.attributes["function_type"].value.inputs
             s.top_func, stream_info = move_stream_to_interface(s.top_func)
             all_stream_info[func.__name__] = (stream_info, start_idx, size)
-            print(s.module)
             s.top_func.operation.clone(InsertionPoint(s_top.top_func))
         hls_mod = _build_top(s_top, input_types, all_stream_info)
     return hls_mod

--- a/allo/ir/infer.py
+++ b/allo/ir/infer.py
@@ -509,6 +509,13 @@ class TypeInferer(ASTVisitor):
             )
             node.value.shape = node.np_values.shape
             node.value.dtype = target_dtype
+        elif (
+            isinstance(node.value, ast.Call)
+            and isinstance(node.value.func, ast.Attribute)
+            and node.value.func.attr == "pipe"
+        ):
+            node.value.shape = target_shape
+            node.value.dtype = target_dtype
         else:
             visit_stmt(ctx, node.value)
         ctx.buffers[node.target.id] = node
@@ -733,8 +740,8 @@ class TypeInferer(ASTVisitor):
                     node.shape = (tuple(), tuple())
                     node.dtype = (Index(), Index())
                 else:
-                    node.shape = tuple()
-                    node.dtype = Stream(float32)
+                    node.shape = None
+                    node.dtype = None
                 return node
             if len(new_args[0].shape) == 0:
                 # element-wise operation

--- a/tests/dataflow/test_tiled_systolic.py
+++ b/tests/dataflow/test_tiled_systolic.py
@@ -8,8 +8,8 @@ import allo.backend.hls as hls
 import numpy as np
 import pytest
 
-M, N, K = 36, 36, 36
-Mt, Nt = 6, 6
+M, N, K = 8, 8, 8
+Mt, Nt = 2, 2
 P0, P1 = Mt + 1, Nt + 1
 
 
@@ -41,6 +41,13 @@ def gemm(A: int32[M, K], B: int32[K, N], C: int32[M, N]):
                     out_A.put(a)
                     out_B.put(b)
                 C[m * Mt + i - 1, n * Nt + j - 1] = c
+            # drain
+            with allo.meta_if(i == Mt and j > 0):
+                for k in range(K):
+                    b: int32 = out_B.get()
+            with allo.meta_if(j == Nt and i > 0):
+                for k in range(K):
+                    a: int32 = out_A.get()
 
 
 def test_tiled_systolic():

--- a/tests/dataflow/test_tiled_systolic.py
+++ b/tests/dataflow/test_tiled_systolic.py
@@ -8,8 +8,12 @@ import allo.backend.hls as hls
 import numpy as np
 import pytest
 
-M, N, K = 8, 8, 8
-Mt, Nt = 2, 2
+# M, N, K = 512, 512, 512
+# Mt, Nt = 16, 16
+M, N, K = 16, 16, 16
+Mt, Nt = 4, 4
+# M, N, K = 4, 4, 4
+# Mt, Nt = 1, 1
 P0, P1 = Mt + 1, Nt + 1
 
 
@@ -54,11 +58,11 @@ def test_tiled_systolic():
     A = np.random.randint(0, 10, (M, K)).astype(np.int32)
     B = np.random.randint(0, 10, (K, N)).astype(np.int32)
     C = np.zeros((M, N), dtype=np.int32)
-    gemm(A, B, C)
-    np.testing.assert_allclose(C, np.dot(A, B), atol=1e-5)
-    print("Passed!")
+    if hls.is_available("vitis_hls"):
+        gemm(A, B, C)
+        np.testing.assert_allclose(C, np.dot(A, B), atol=1e-5)
+        print("Passed!")
 
 
 if __name__ == "__main__":
-    # pytest.main([__file__])
-    test_tiled_systolic()
+    pytest.main([__file__])

--- a/tests/dataflow/test_tiled_systolic.py
+++ b/tests/dataflow/test_tiled_systolic.py
@@ -1,0 +1,57 @@
+# Copyright Allo authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import allo
+from allo.ir.types import int32, Stream
+import allo.dataflow as df
+import allo.backend.hls as hls
+import numpy as np
+import pytest
+
+M, N, K = 36, 36, 36
+Mt, Nt = 6, 6
+P0, P1 = Mt + 1, Nt + 1
+
+
+@df.kernel(mapping=[P0, P1])
+def gemm(A: int32[M, K], B: int32[K, N], C: int32[M, N]):
+    # A[Mt, K] * B[K, Nt] = C[Mt, Nt]
+    i, j = df.get_pid()
+    in_A: Stream[int32] = df.pipe(src=(i, j - 1), dst=(i, j))
+    in_B: Stream[int32] = df.pipe(src=(i - 1, j), dst=(i, j))
+    out_A: Stream[int32] = df.pipe(src=(i, j), dst=(i, j + 1))
+    out_B: Stream[int32] = df.pipe(src=(i, j), dst=(i + 1, j))
+    for m in range(M // Mt):
+        for n in range(N // Nt):
+            with allo.meta_if(i == 0 and j == 0):
+                pass
+            with allo.meta_elif(j == 0):
+                for k in range(K):
+                    out_A.put(A[m * Mt + i - 1, k])
+            with allo.meta_elif(i == 0):
+                for k in range(K):
+                    out_B.put(B[k, n * Nt + j - 1])
+            # main body
+            with allo.meta_else():
+                c: int32 = 0
+                for k in range(K):
+                    a: int32 = in_A.get()
+                    b: int32 = in_B.get()
+                    c += a * b
+                    out_A.put(a)
+                    out_B.put(b)
+                C[m * Mt + i - 1, n * Nt + j - 1] = c
+
+
+def test_tiled_systolic():
+    A = np.random.randint(0, 10, (M, K)).astype(np.int32)
+    B = np.random.randint(0, 10, (K, N)).astype(np.int32)
+    C = np.zeros((M, N), dtype=np.int32)
+    gemm(A, B, C)
+    np.testing.assert_allclose(C, np.dot(A, B), atol=1e-5)
+    print("Passed!")
+
+
+if __name__ == "__main__":
+    # pytest.main([__file__])
+    test_tiled_systolic()

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -125,5 +125,31 @@ def test_meta_if():
     print(s.module)
 
 
+def test_double_meta_if():
+    M, N = 32, 32
+
+    def top(A: int32[M]):
+        with allo.meta_if(M == 1):
+            for i in range(M):
+                A[i] = A[i] // 2
+        with allo.meta_elif(M == 64):
+            for i in range(M):
+                A[i] = A[i] * 2
+        with allo.meta_else():
+            for i in range(M):
+                A[i] = A[i] + 1
+        with allo.meta_if(N == 32):
+            for i in range(M):
+                A[i] = A[i] - 1
+
+    s = allo.customize(top)
+    print(s.module)
+    mod = s.build()
+    np_A = np.random.randn(M).astype(np.int32)
+    np_golden = np_A.copy()
+    mod(np_A)
+    np.testing.assert_allclose(np_A, np_golden, rtol=1e-4, atol=1e-4)
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR adds a tiled systolic array example to support larger GEMM computation. See `tests/dataflow/test_tiled_systolic.py`. The program has been verified under csim. However, there is still a randomly crashed bug that cannot be easily resolved (#196).

### Examples ###
```python
@df.kernel(mapping=[P0, P1])
def gemm(A: int32[M, K], B: int32[K, N], C: int32[M, N]):
    # A[Mt, K] * B[K, Nt] = C[Mt, Nt]
    i, j = df.get_pid()
    in_A: Stream[int32] = df.pipe(src=(i, j - 1), dst=(i, j))
    in_B: Stream[int32] = df.pipe(src=(i - 1, j), dst=(i, j))
    out_A: Stream[int32] = df.pipe(src=(i, j), dst=(i, j + 1))
    out_B: Stream[int32] = df.pipe(src=(i, j), dst=(i + 1, j))
    for m in range(M // Mt):
        for n in range(N // Nt):
            with allo.meta_if(i == 0 and j == 0):
                pass
            with allo.meta_elif(j == 0):
                for k in range(K):
                    out_A.put(A[m * Mt + i - 1, k])
            with allo.meta_elif(i == 0):
                for k in range(K):
                    out_B.put(B[k, n * Nt + j - 1])
            # main body
            with allo.meta_else():
                c: int32 = 0
                for k in range(K):
                    a: int32 = in_A.get()
                    b: int32 = in_B.get()
                    c += a * b
                    out_A.put(a)
                    out_B.put(b)
                C[m * Mt + i - 1, n * Nt + j - 1] = c
            # drain
            with allo.meta_if(i == Mt and j > 0):
                for k in range(K):
                    b: int32 = out_B.get()
            with allo.meta_if(j == Nt and i > 0):
                for k in range(K):
                    a: int32 = out_A.get()
```


## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [x] Code is well-documented
