### PR TITLE
[dataflow][experimental] Support 1D mesh and add cooperative GEMV example

### DIFF
--- a/allo/ir/builder.py
+++ b/allo/ir/builder.py
@@ -1717,6 +1717,10 @@ class ASTTransformer(ASTBuilder):
                     op = linalg_d.fill(op.result, outs=[alloc_op.result])
                     return op.owner if ctx.enable_tensor else alloc_op
             if fn_name == "get_pid":
+                # 1D mesh
+                if "df.p1" not in ctx.global_vars:
+                    return (MockConstant(ctx.global_vars["df.p0"], ctx, dtype=Index()),)
+                # 2D mesh
                 return (
                     MockConstant(ctx.global_vars["df.p0"], ctx, dtype=Index()),
                     MockConstant(ctx.global_vars["df.p1"], ctx, dtype=Index()),

--- a/tests/dataflow/test_cooperative_gemv.py
+++ b/tests/dataflow/test_cooperative_gemv.py
@@ -1,0 +1,57 @@
+# Copyright Allo authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from allo.ir.types import float32, Stream
+import allo.dataflow as df
+import allo.backend.hls as hls
+import numpy as np
+
+Ty = float32
+M, N = 16, 16
+P0 = 2
+Mt = M // P0
+
+
+@df.kernel(mapping=[P0])
+def gemv0(A: Ty[M, N], x: Ty[N]):
+    pi = df.get_pid()
+    pipe: Stream[Ty[Mt]] = df.pipe(src="gemv0", dst="gemv1")
+    y_out: Ty[Mt] = 0
+    for m in range(pi * Mt, (pi + 1) * Mt):
+        y_acc: Ty = 0
+        for n in range(N // 2):
+            y_acc += A[m, n] * x[n]
+        y_out[m - pi * Mt] = y_acc
+    pipe.put(y_out)
+
+
+@df.kernel(mapping=[P0])
+def gemv1(A: Ty[M, N], x: Ty[N], y: Ty[M]):
+    pi = df.get_pid()
+    pipe: Stream[Ty[Mt]] = df.pipe(src="gemv0", dst="gemv1")
+    y_out: Ty[Mt] = 0
+    for m in range(pi * Mt, (pi + 1) * Mt):
+        y_acc: Ty = 0
+        for n in range(N // 2, N):
+            y_acc += A[m, n] * x[n]
+        y_out[m - pi * Mt] = y_acc
+    y_prev: Ty[Mt] = pipe.get()
+    for m in range(pi * Mt, (pi + 1) * Mt):
+        y[m] = y_out[m - pi * Mt] + y_prev[m - pi * Mt]
+
+
+def test_cooperative_gemv():
+    A = np.random.rand(M, N).astype(np.float32)
+    B = np.random.rand(
+        N,
+    ).astype(np.float32)
+    C = np.zeros((M,), dtype=np.float32)
+    top = df.build([gemv0, gemv1])
+    if hls.is_available("vitis_hls"):
+        top(A, B, C)
+        np.testing.assert_allclose(C, np.dot(A, B), atol=1e-5)
+        print("Passed!")
+
+
+if __name__ == "__main__":
+    test_cooperative_gemv()


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR adds support for 1D mesh mapping and uses cooperative GEMV as an example to demonstrate 1D task partitioning. This is an example pattern on the [Cerebras tutorial](https://sdk.cerebras.net/csl/tutorials/gemv-06-routes-1/) webpage.


### Examples ###
```python
@df.kernel(mapping=[P0])
def gemv0(A: Ty[M, N], x: Ty[N]):
    pi = df.get_pid()
    pipe: Stream[Ty[Mt]] = df.pipe(src="gemv0", dst="gemv1")
    y_out: Ty[Mt] = 0
    for m in range(pi * Mt, (pi + 1) * Mt):
        y_acc: Ty = 0
        for n in range(N // 2):
            y_acc += A[m, n] * x[n]
        y_out[m - pi * Mt] = y_acc
    pipe.put(y_out)


@df.kernel(mapping=[P0])
def gemv1(A: Ty[M, N], x: Ty[N], y: Ty[M]):
    pi = df.get_pid()
    pipe: Stream[Ty[Mt]] = df.pipe(src="gemv0", dst="gemv1")
    y_out: Ty[Mt] = 0
    for m in range(pi * Mt, (pi + 1) * Mt):
        y_acc: Ty = 0
        for n in range(N // 2, N):
            y_acc += A[m, n] * x[n]
        y_out[m - pi * Mt] = y_acc
    y_prev: Ty[Mt] = pipe.get()
    for m in range(pi * Mt, (pi + 1) * Mt):
        y[m] = y_out[m - pi * Mt] + y_prev[m - pi * Mt]
```


## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [x] Code is well-documented
