### PR TITLE
[docs][runtime] Update docs and add csyn support to Vitis HLS

### DIFF
--- a/allo/backend/report.py
+++ b/allo/backend/report.py
@@ -454,7 +454,9 @@ def parse_xml(path, prod_name, top="top", print_flag=False):
     est_resources = area_estimate["Resources"]
     avail_resources = area_estimate["AvailableResources"]
     resources = {}
-    for name in ("BRAM_18K", "DSP48E", "FF", "LUT"):
+    for name in ("BRAM_18K", "DSP48E", "DSP", "FF", "LUT", "URAM"):
+        if name not in est_resources:
+            continue
         item = [est_resources[name], avail_resources[name]]
         item.append(f"{round(int(item[0]) / int(item[1]) * 100)}%")
         resources[name] = item.copy()

--- a/allo/harness/vitis/run.tcl
+++ b/allo/harness/vitis/run.tcl
@@ -22,11 +22,11 @@ add_files kernel.cpp
 add_files -tb host.cpp -cflags "-std=gnu++0x"
 
 open_solution "solution1"
-# Use Zynq device
-set_part {xc7z020clg484-1}
+# Target device is Alveo U280
+set_part {xcu280-fsvh2892-2L-e}
 
-# Target clock period is 10ns
-create_clock -period 10
+# Target frequency is 300 MHz
+create_clock -period 3.33
 
 # Directives 
 

--- a/docs/source/developer/index.rst
+++ b/docs/source/developer/index.rst
@@ -62,7 +62,7 @@ Basically, the development workflow is as follows:
 3. Commit the changes to your *local* branch (``git commit -m "commit message"``)
 4. Push the changes to your *fork* (``git push origin <branch_name>``)
 5. Make sure your changes do not break the existing facilities, see `Integration Tests <#integration-tests>`_ for more details
-6. Create a `PR <https://github.com/cornell-zhang/allo/pulls>`_ from your fork to the ``main`` branch of the Allo repository (see `here <https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork>`_ for more details)
+6. Create a `Pull Request (PR) <https://github.com/cornell-zhang/allo/pulls>`_ from your fork to the ``main`` branch of the Allo repository (see `here <https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork>`_ for more details)
 7. Wait for the PR to be reviewed
 8. If there are any changes requested, make the changes and push to your fork
 9. Once the PR is approved, it will be merged into the ``main`` branch
@@ -77,12 +77,12 @@ make sure you have passed the tests locally before creating a PR or pushing to y
 There are several tests for our project:
 
 1. **License header check**: make sure all the source files have the license header, which is important for open source projects.
-2. **Code style check**: make sure the code style is consistent with the `PEP8 <https://www.python.org/dev/peps/pep-0008/>`_ standard. We use ``black`` for Python formatting, which should has been installed in your environment during the setup. ``clang-format`` is used for C/C++ formatting.
+2. **Code style check**: make sure the Python code style is consistent with the `PEP8 <https://www.python.org/dev/peps/pep-0008/>`_ standard. We use ``black`` for Python formatting, which should has been installed in your environment during the setup. For the MLIR part, we use ``clang-format`` for C/C++ formatting.
 3. **Linting check**: make sure the code is `linted <https://www.perforce.com/blog/qac/what-lint-code-and-what-linting-and-why-linting-important>`_ correctly. We use ``pylint`` for Python linting, which should also been installed during the setup.
 4. **Unit tests**: make sure the changes will not break the existing facilities. We use ``pytest`` for Python unit tests, and the test cases are under the ``tests`` folder.
 
-If you are making changes to the code, please make sure to run those tests before pushing to your fork.
-To run the tests, you can run the following command from the root of the repository:
+If you are making changes to the code, please make sure to run those tests and checking before pushing to your fork.
+To run the format checker, you can execute the following command from the root of the repository:
 
 .. code-block:: bash
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -27,14 +27,14 @@ Allo is an Accelerator Design Language (ADL) and compiler that facilitates the c
 
 .. toctree::
    :maxdepth: 1
-   :caption: Getting Started
+   :caption: **Getting Started**
 
    setup/index.rst
 
 
 .. toctree::
    :maxdepth: 1
-   :caption: Tutorials
+   :caption: **Tutorials**
 
    gallery/tutorial_01_get_started.rst
    gallery/tutorial_02_vhls.rst
@@ -42,7 +42,7 @@ Allo is an Accelerator Design Language (ADL) and compiler that facilitates the c
 
 .. toctree::
    :maxdepth: 1
-   :caption: Developer Guide
+   :caption: **Developer Guide**
 
    developer/index.rst
    gallery/developer_01_ir_builder.rst
@@ -51,6 +51,6 @@ Allo is an Accelerator Design Language (ADL) and compiler that facilitates the c
 
 .. toctree::
    :maxdepth: 1
-   :caption: Reference
+   :caption: **Reference**
 
    genindex

--- a/docs/source/setup/index.rst
+++ b/docs/source/setup/index.rst
@@ -111,7 +111,7 @@ We also provide a script to set up the backend LLVM compiler. You can simply run
 
 .. code-block:: console
 
-  $ source /work/shared/common/allo/setup-py312.sh
+  $ source /work/shared/common/allo/setup-llvm19.sh
 
 .. note::
 

--- a/tutorials/developer_01_ir_builder.py
+++ b/tutorials/developer_01_ir_builder.py
@@ -22,7 +22,7 @@ from allo.ir.types import int32
 # leverage the `parsing <https://en.wikipedia.org/wiki/Parsing>`_ technique to
 # translate the Python code to an MLIR program. Therefore, the first
 # step is to parse the Python code to the
-# `AST <https://en.wikipedia.org/wiki/Abstract_syntax_tree>`_ representation.
+# `Abstract Syntax Tree (AST) <https://en.wikipedia.org/wiki/Abstract_syntax_tree>`_ representation.
 
 M, N = 1024, 1024
 
@@ -69,7 +69,7 @@ astpretty.pprint(tree, indent=2, show_offsets=False)
 #    We also wrap the above functions in ``allo.customize``, you can
 #    directly call ``s = allo.customize(matrix_add, verbose=True)`` to obtain
 #    the AST of the function. The entry point of the ``customize`` function is
-#    located in `allo/customize.py <https://github.com/cornell-zhang/allo/blob/3cd1680f929f84e88bd2bbff4909bf13d95696f3/allo/customize.py#L339>`_.
+#    located in `allo/customize.py <https://github.com/cornell-zhang/allo/blob/main/allo/customize.py>`_.
 
 ##############################################################################
 # Traverse the AST
@@ -170,7 +170,7 @@ astpretty.pprint(tree, indent=2, show_offsets=False)
 # support different loop structures, so we need to further dispatch the ``For`` node to the corresponding
 # builder function. For example, here we use ``allo.grid``, so it will be dispatched to ``build_grid_for``.
 #
-# We provide some helper functions in ``allo/ir/transform.py`` to make the IR creation easier.
+# We provide some helper functions in `allo/ir/transform.py <https://github.com/cornell-zhang/allo/blob/main/allo/ir/transform.py>`_ to make the IR creation easier.
 # In this case, we can just call ``build_for_loops`` and pass in the bounds and the names of the loops
 # to create a loop nest.
 # Before building the loop body, we need to update the insertion point:
@@ -188,9 +188,9 @@ astpretty.pprint(tree, indent=2, show_offsets=False)
 ##############################################################################
 # Other Nodes
 # ^^^^^^^^^^^
-# The build process is similar for other nodes, so I will not go into them one by one.
+# The build process is similar for other nodes, so we will not go into them one by one.
 # Please refer to the `source code <https://github.com/cornell-zhang/allo/blob/main/allo/ir/builder.py>`_ for more details.
 # After building the IR, you can call ``s.module`` to see the effect.
 #
 # Most of the MLIR operations can be found on this `webpage <https://mlir.llvm.org/docs/Dialects/>`_, and now
-# you can follow the definitions and add more amazing facilities to the new Allo frontend!
+# you can follow the definitions and add more amazing facilities to the new Allo compiler!

--- a/tutorials/developer_02_mlir.py
+++ b/tutorials/developer_02_mlir.py
@@ -67,6 +67,21 @@ print(mod)
 # The first line gives the error message and the exact location (line 8, column 3) of the error.
 # Then we know that there is a problem in the return value of our MLIR code, which helps us debug the program.
 #
+# To further check what causes the error, we can print out the generic form of the MLIR program.
+
+# %%
+mod.operation.print(
+    large_elements_limit=2,
+    enable_debug_info=True,
+    pretty_debug_info=True,
+    print_generic_op_form=True,
+    use_local_scope=True,
+)
+
+# %%
+# The generic form of the MLIR program is a more detailed representation of the MLIR program.
+# However, if you see this form in your customized MLIR pass, it means your generated IR may not pass the MLIR verifier.
+
 # We also wrap the LLVM execution engine in allo, so we can directly invoke it to execute the MLIR program.
 # The ``LLVMMoudle`` class takes the MLIR module and the name of the top function as input.
 # Then we can directly invoke the module with random inputs, and see if the result is correct.
@@ -142,7 +157,9 @@ print(mod)
 #
 # .. code-block::
 #
-#    python3: llvm-project/mlir/lib/Dialect/Linalg/Transforms/Loops.cpp:209: mlir::FailureOr<llvm::SmallVector<mlir::Operation*, 4> > linalgOpToLoopsImpl(mlir::PatternRewriter&, mlir::linalg::LinalgOp) [with LoopTy = mlir::AffineForOp]: Assertion `linalgOp.hasBufferSemantics() && "expected linalg op with buffer semantics"' failed.
+#    python3: llvm-project/mlir/lib/Dialect/Linalg/Transforms/Loops.cpp:209:
+#             mlir::FailureOr<llvm::SmallVector<mlir::Operation*, 4> > linalgOpToLoopsImpl(mlir::PatternRewriter&, mlir::linalg::LinalgOp)
+#             [with LoopTy = mlir::AffineForOp]: Assertion `linalgOp.hasBufferSemantics() && "expected linalg op with buffer semantics"' failed.
 
 # %%
 # Unfortunately, the program cannot be lowered to LLVM dialect, because we have not added

--- a/tutorials/tutorial_01_get_started.py
+++ b/tutorials/tutorial_01_get_started.py
@@ -161,7 +161,7 @@ mod = s.build(target="llvm")
 # directly feed them into the executable. Allo will automatically handle the
 # input data and generate corresponding internal wrappers for LLVM to execute,
 # but we still need to make sure the data types are consistent. By default,
-# ``np.random.randint`` will generate np.int64 data type, while we use ``int32``
+# ``np.random.randint`` will generate ``np.int64`` data type, while we use ``int32``
 # when defining our kernel function, so we need to explicitly cast the data type
 # to ``np.int32``.
 
@@ -184,3 +184,4 @@ np_C = mod(np_A, np_B)
 
 golden_C = np.matmul(np_A, np_B)
 np.testing.assert_allclose(np_C, golden_C, rtol=1e-5, atol=1e-5)
+print("Results are correct!")

--- a/tutorials/tutorial_02_vhls.py
+++ b/tutorials/tutorial_02_vhls.py
@@ -125,7 +125,7 @@ print(code)
 # We can see that the generated code preserves the same structure as the IR, and inserts
 # necessary headers and pragmas for Vivado/Vitis HLS. The generated code can be directly passed
 # to Vivado/Vitis HLS to generate RTL designs.
-# 
+#
 # .. note::
 #
 #    Vivado HLS was the previous name of Vitis HLS (before 2020.1). The previous HLS code

--- a/tutorials/tutorial_02_vhls.py
+++ b/tutorials/tutorial_02_vhls.py
@@ -2,14 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Vivado HLS Backend
-==================
+Vivado/Vitis HLS Backend
+========================
 
 **Author**: Hongzheng Chen (hzchen@cs.cornell.edu)
 
 
 In this tutorial, we will demonstrate how to leverage the Allo DSL to generate
-Vivado HLS code for FPGA.
+`Vivado/Vitis HLS <https://www.amd.com/en/products/software/adaptive-socs-and-fpgas/vitis/vitis-hls.html>`_ C++ code for FPGA.
 
 Import Allo
 -----------
@@ -112,85 +112,78 @@ s.pipeline("j")
 print(s.module)
 
 ##############################################################################
-# Codegen for Vivado HLS
-# ----------------------
+# Codegen for Vivado/Vitis HLS
+# ----------------------------
 # Similar to the CPU execution, we only need to change the target of the ``.build()`` function
 # in order to target different backends. Here, we use ``vhls`` as the target to generate
-# Vivado HLS code, which will returns the generated code as a string.
+# Vivado/Vitis HLS code, which will directly returns the generated code as a string.
 
 code = s.build(target="vhls")
 print(code)
 
 # %%
 # We can see that the generated code preserves the same structure as the IR, and inserts
-# necessary headers and pragmas for Vivado HLS. The generated code can be directly passed
-# to Vivado HLS to generate RTL designs.
+# necessary headers and pragmas for Vivado/Vitis HLS. The generated code can be directly passed
+# to Vivado/Vitis HLS to generate RTL designs.
+# 
+# .. note::
+#
+#    Vivado HLS was the previous name of Vitis HLS (before 2020.1). The previous HLS code
+#    can still run on the latest Vitis HLS, but the performance of the generated RTL design
+#    and the estimated reports may be different, as the newer version of Vitis HLS provides better
+#    automatic optimizations.
 
 # %%
-# We also provide an easy way to invoke Vivado HLS from Allo. Users can simply provide
-# the synthesis mode that are supported by Vivado HLS (e.g., ``csim``, ``csyn``, ``cosim``,
-# and ``impl``), and the target project folder name. Allo will automatically generate
+# We also provide an easy way to invoke Vitis HLS from Allo. Users can simply provide
+# the synthesis mode that are supported by Vitis HLS (e.g., ``csim``, ``csyn``, ``sw_emu``,
+# ``hw_emu``, and ``hw``), and the target project folder name. Allo will automatically generate
 # the HLS project and invoke the compiler to generate the RTL design.
 
-mod = s.build(target="vhls", mode="csyn", project="gemm.prj")
+mod = s.build(target="vitis_hls", mode="csyn", project="gemm.prj")
 
 # %%
 # You will see a ``gemm.prj`` folder is generated in the current directory:
 #
 # - ``host.cpp``: The host (CPU) code that invokes the generated accelerator.
 # - ``kernel.cpp``: The generated accelerator code.
-# - ``run.tcl``: The Vivado HLS script that can be used to generate the Vivado HLS project.
+# - ``run.tcl``: The Vivado HLS script that can be used to run the Vivado HLS project.
 # - ``Makefile``: Defined some shorthands for compiling the project.
 #
-# To run Vivado HLS, you can simply invoke the built module without passing any arguments into it.
+# To run Vitis HLS, you can simply invoke the built module without passing any arguments into it.
 #
 # .. note::
 #
-#    You need to configure the Vivado HLS environment before running the generated code.
-#    We have the Vivado environment configured in the ``brg-zhang`` server, so you can directly
-#    ``source /work/shared/common/allo/vitis_2019.2_opt.sh`` to set up the environment.
+#    You need to configure the Vitis HLS environment before running the generated code.
+#    We have the Vitis environment configured on the Zhang group server, so you can directly
+#    ``source /work/shared/common/allo/vitis_2022.1_opt.sh`` to set up the environment.
 #
 # .. code-block:: python
 #
 #    mod()
 
 # %%
-# After executing the above command, you will see the following output:
+# After executing the above command, you can check the following report under ``gemm.prj/out.prj/solution1/syn/report/csynth.rpt``.
 #
 # .. code-block:: python
 #
-#    +-------------------+-----------------------------------+
-#    | HLS Version       | Vivado HLS 2019.2.1               |
-#    | Product family    | zynq                              |
-#    | Target device     | xc7z020-clg484-1                  |
-#    | Top Model Name    | gemm                              |
-#    +-------------------+-----------------------------------+
-#    | Target CP         | 10.00 ns                          |
-#    | Estimated CP      | 8.052 ns                          |
-#    | Latency (cycles)  | Min 1077958658; Max 1077958658    |
-#    | Interval (cycles) | Min 1077958659; Max 1077958659    |
-#    | Resources         | Type        Used    Total    Util |
-#    |                   | --------  ------  -------  ------ |
-#    |                   | BRAM_18K       2      280      1% |
-#    |                   | DSP48E         5      220      2% |
-#    |                   | FF           862   106400      1% |
-#    |                   | LUT         1375    53200      3% |
-#    +-------------------+-----------------------------------+
-#    +---------------+--------------+------------+---------------------+---------------+------------------+
-#    |               |   Trip Count |    Latency |   Iteration Latency |   Pipeline II |   Pipeline Depth |
-#    |---------------+--------------+------------+---------------------+---------------+------------------|
-#    | Loop1         |         1024 |    2099200 |                2050 |           N/A |              N/A |
-#    | + Loop1.1     |         1024 |       2048 |                   2 |           N/A |              N/A |
-#    | l_S_i_j_i     |         1024 | 1075859456 |             1050644 |           N/A |              N/A |
-#    | + l_j_init    |         1024 |       1024 |                 N/A |             1 |                1 |
-#    | + l_S_k_k_l_j |      1048576 |    1048588 |                 N/A |             1 |               14 |
-#    | + l_j_back    |         1024 |       1025 |                 N/A |             1 |                3 |
-#    +---------------+--------------+------------+---------------------+---------------+------------------+
-#    * Units in clock cycles
+#    +--------------------------------------------------+------------+-----------+----------+------------+---------+
+#    |                      Modules                     |  Latency   |  Latency  | Iteration|            |   Trip  |
+#    |                      & Loops                     |  (cycles)  |    (ns)   |  Latency |  Interval  |  Count  |
+#    +--------------------------------------------------+------------+-----------+----------+------------+---------+
+#    |+ gemm                                            |  1080059934|  3.597e+09|         -|  1080059935|        -|
+#    | + gemm_Pipeline_VITIS_LOOP_44_1_VITIS_LOOP_45_2  |     1048578|  3.492e+06|         -|     1048578|        -|
+#    |  o VITIS_LOOP_44_1_VITIS_LOOP_45_2               |     1048576|  3.492e+06|         2|           1|  1048576|
+#    | o l_S_buf0_buf0_l_0_l_buf0_l_1                   |     1048576|  3.492e+06|         2|           1|  1048576|
+#    | o l_S_buf1_buf1_l_0_l_buf1_l_1                   |     1048576|  3.492e+06|         2|           1|  1048576|
+#    | o l_S_i_j_0_i                                    |  1075865600|  3.583e+09|   1050650|           -|     1024|
+#    |  + gemm_Pipeline_l_j_init                        |        1026|  3.417e+03|         -|        1026|        -|
+#    |   o l_j_init                                     |        1024|  3.410e+03|         1|           1|     1024|
+#    |  + gemm_Pipeline_l_S_k_0_k_l_j                   |     1048591|  3.492e+06|         -|     1048591|        -|
+#    |   o l_S_k_0_k_l_j                                |     1048589|  3.492e+06|        15|           1|  1048576|
+#    |  + gemm_Pipeline_l_j_back                        |        1027|  3.420e+03|         -|        1027|        -|
+#    |   o l_j_back                                     |        1025|  3.413e+03|         3|           1|     1024|
+#    | o l_S_result2_result2_l_0_l_result2_l_1          |     1048578|  3.492e+06|         4|           1|  1048576|
+#    +--------------------------------------------------+------------+-----------+----------+------------+---------+
 #
-# From the above output, we can clearly see that all the loops inside the GEMM kernel are pipelined
-# with II=1.
-#
-# .. note::
-#
-#   The results are also printed to a file named ``report.json`` for further analysis.
+# From the above output, we can clearly see that all the loops inside the GEMM kernel (marked as ``o``) are pipelined
+# with Initiation Interval (II) equal to 1. You can also find more detailed information under the ``report`` folder.


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
As the title mentions, now we can use `s.build(target="vitis_hls", mode="csyn")` to only invoke HLS.

## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [x] Code is well-documented
