### PR TITLE
[Backend] Fix scalar interface in HLS

### DIFF
--- a/allo/backend/hls.py
+++ b/allo/backend/hls.py
@@ -136,12 +136,16 @@ def separate_header(hls_code, top=None):
             arg_type = line.strip()
             _, var = arg_type.rsplit(" ", 1)
             comma = "," if var[-1] == "," else ""
-            var = var.split("[")[0]
             ele_type = arg_type.split("[")[0].split(" ")[0].strip()
             allo_type = c2allo_type[ele_type]
             shape = tuple(s.split("]")[0] for s in arg_type.split("[")[1:])
             args.append((allo_type, shape))
-            sig_str += "  " + ele_type + " *" + var + f"{comma}\n"
+            if "[" in var:  # array
+                var = var.split("[")[0]
+                sig_str += "  " + ele_type + " *" + var + f"{comma}\n"
+            else:  # scalar
+                var = var.split(",")[0]
+                sig_str += "  " + ele_type + " " + var + f"{comma}\n"
     sig_str += '} // extern "C"\n'
     sig_str += "\n#endif // KERNEL_H\n"
     return sig_str, args

--- a/allo/backend/ip.py
+++ b/allo/backend/ip.py
@@ -72,8 +72,9 @@ class IPModule:
         self.args = []
         for arg_type in arg_types:
             arg_type = arg_type.strip()
-            if "[" not in arg_type:
-                self.args.append((arg_type, ()))
+            if "[" not in arg_type or "[]" in arg_type:
+                # scalar
+                self.args.append((arg_type.split("[")[0], ()))
                 continue
             ele_type = arg_type.split("[")[0].strip()
             # pylint: disable=eval-used

--- a/allo/backend/vitis.py
+++ b/allo/backend/vitis.py
@@ -300,10 +300,11 @@ def postprocess_hls_code(hls_code, top=None):
             if "[" in var:  # array
                 var = var.split("[")[0]
                 out_str += "  " + dtype + " *" + var + f"{comma}\n"
+                # only add array to interface
+                func_args.append(var)
             else:  # scalar
                 var = var.split(",")[0]
                 out_str += "  " + dtype + " " + var + f"{comma}\n"
-            func_args.append(var)
         elif line.startswith("#endif"):
             out_str += '} // extern "C"\n\n'
             out_str += line + "\n"

--- a/allo/backend/vitis.py
+++ b/allo/backend/vitis.py
@@ -297,8 +297,12 @@ def postprocess_hls_code(hls_code, top=None):
         elif func_decl:
             dtype, var = line.strip().rsplit(" ", 1)
             comma = "," if var[-1] == "," else ""
-            var = var.split("[")[0]
-            out_str += "  " + dtype + " *" + var + f"{comma}\n"
+            if "[" in var:  # array
+                var = var.split("[")[0]
+                out_str += "  " + dtype + " *" + var + f"{comma}\n"
+            else:  # scalar
+                var = var.split(",")[0]
+                out_str += "  " + dtype + " " + var + f"{comma}\n"
             func_args.append(var)
         elif line.startswith("#endif"):
             out_str += '} // extern "C"\n\n'

--- a/allo/passes.py
+++ b/allo/passes.py
@@ -117,6 +117,9 @@ def generate_input_output_buffers(top_func, flatten=False, mappings=None):
         new_in_types = []
         in_bufs = []
         for i, arg in enumerate(top_func.arguments):
+            if not isinstance(arg.type, MemRefType):
+                new_in_types.append(arg.type)
+                continue
             buf = create_buffer(
                 arg, f"buf{i}", ip=first_op, flatten=flatten, mapping=mappings[i]
             )
@@ -140,6 +143,9 @@ def generate_input_output_buffers(top_func, flatten=False, mappings=None):
                     mappings += [None] * len(op.operands)
                 if len(op.operands) > 0:
                     for i, arg in enumerate(op.operands):
+                        if not isinstance(arg.type, MemRefType):
+                            new_out_types.append(arg.type)
+                            continue
                         buf = create_buffer(
                             arg,
                             f"result{i+len(top_func.arguments)}",

--- a/tests/test_vhls.py
+++ b/tests/test_vhls.py
@@ -137,6 +137,22 @@ def test_pointer_generation():
         print("Passed!")
 
 
+def test_scalar_not_array():
+    def top(inst: bool, C: int32[3]):
+        flag: bool = inst[0]
+        if flag:
+            C[0] = C[0] + 1
+
+    s = allo.customize(top)
+    mod = s.build(target="vitis_hls", mode="csim", project="test_scalar.prj")
+    assert "bool v0," in mod.hls_code and ",," not in mod.hls_code
+    if hls.is_available("vitis_hls"):
+        C = np.array([1, 2, 3], dtype=np.int32)
+        mod(1, C)
+        np.testing.assert_allclose(C, [2, 2, 3], rtol=1e-5)
+        print("Passed!")
+
+
 def test_scalar():
     def case1(C: int32) -> int32:
         return C + 1

--- a/tests/test_vhls.py
+++ b/tests/test_vhls.py
@@ -137,5 +137,18 @@ def test_pointer_generation():
         print("Passed!")
 
 
+def test_scalar():
+    def case1(C: int32) -> int32:
+        return C + 1
+
+    s = allo.customize(case1)
+    mod = s.build()
+    assert mod(1) == 2
+    print("Passed CPU simulation!")
+    mod = s.build(target="vitis_hls", mode="csim", project="test_scalar.prj")
+    assert "int32_t *v1" in mod.hls_code
+    # Note: Should not expect it to run using csim! Need to generate correct binding for mutable scalars in PyBind.
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/test_vhls.py
+++ b/tests/test_vhls.py
@@ -1,10 +1,9 @@
 # Copyright Allo authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import os
 import pytest
 import allo
-from allo.ir.types import int32, float32
+from allo.ir.types import bool, int32, float32
 import numpy as np
 import allo.backend.hls as hls
 
@@ -118,6 +117,23 @@ def test_csim_write_back():
         B = np.zeros((N), dtype=np.int32)
         mod(A, B)
         np.testing.assert_allclose(A, B, rtol=1e-5)
+        print("Passed!")
+
+
+def test_pointer_generation():
+    def top(inst: bool[1], C: int32[3]):
+        flag: bool = inst[0]
+        if flag:
+            C[0] = C[0] + 1
+
+    s = allo.customize(top)
+    mod = s.build(target="vitis_hls", mode="csim", project="test_pointer.prj")
+    assert "bool v0," in mod.hls_code and ",," not in mod.hls_code
+    if hls.is_available("vitis_hls"):
+        inst = np.array([1], dtype=np.bool_)
+        C = np.array([1, 2, 3], dtype=np.int32)
+        mod(inst, C)
+        np.testing.assert_allclose(C, [2, 2, 3], rtol=1e-5)
         print("Passed!")
 
 


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR fixes #217 and #218. The problem does not come from the incorrect codegen but from the incorrect postprocessing of the HLS code.


### Examples ###
```python
def test_scalar_not_array():
    def top(inst: bool, C: int32[3]):
        flag: bool = inst[0]
        if flag:
            C[0] = C[0] + 1

    s = allo.customize(top)
    mod = s.build(target="vitis_hls", mode="csim", project="test_scalar.prj")
    assert "bool v0," in mod.hls_code and ",," not in mod.hls_code
    if hls.is_available("vitis_hls"):
        C = np.array([1, 2, 3], dtype=np.int32)
        mod(1, C)
        np.testing.assert_allclose(C, [2, 2, 3], rtol=1e-5)
        print("Passed!")
```

## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [x] Code is well-documented
