### PR TITLE
[Backend][Docs] Update Vitis HLS host code to support load/store data from/to files

### DIFF
--- a/allo/backend/hls.py
+++ b/allo/backend/hls.py
@@ -21,6 +21,7 @@ from .vitis import (
     generate_description_file,
     update_makefile,
     write_tensor_to_file,
+    read_tensor_from_file,
 )
 from .ip import IPModule, c2allo_type
 from .report import parse_xml
@@ -404,5 +405,10 @@ class HLSModule:
                 subprocess.Popen(cmd, shell=True).wait()
             else:
                 subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE).wait()
+            # suppose the last argument is the output tensor
+            args[-1][:] = read_tensor_from_file(
+                inputs[-1][0], inputs[-1][1], f"{self.project}/output.data"
+            )
+            return
         else:
             raise RuntimeError("Not implemented")

--- a/allo/backend/hls.py
+++ b/allo/backend/hls.py
@@ -399,12 +399,22 @@ class HLSModule:
                     f"in_data_{i}",
                     f"{self.project}/input_{i}.h",
                 )
-            cmd = f"cd {self.project}; make run TARGET={self.mode} PLATFORM=$XDEVICE"
-            print(cmd)
-            if shell:
-                subprocess.Popen(cmd, shell=True).wait()
+            # check if the build folder exists
+            bitstream_folder = f"{self.project}/build_dir.{self.mode}.{os.environ['XDEVICE'].rsplit('/')[-1].split('.')[0]}"
+            if not os.path.exists(bitstream_folder):
+                cmd = (
+                    f"cd {self.project}; make run TARGET={self.mode} PLATFORM=$XDEVICE"
+                )
+                print(cmd)
+                if shell:
+                    subprocess.Popen(cmd, shell=True).wait()
+                else:
+                    subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE).wait()
             else:
-                subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE).wait()
+                print("Build folder exists, skip building")
+                # run the executable
+                cmd = f"cd {self.project}; ./top ../{bitstream_folder}/top.xclbin"
+                subprocess.Popen(cmd, shell=True).wait()
             # suppose the last argument is the output tensor
             args[-1][:] = read_tensor_from_file(
                 inputs[-1][0], inputs[-1][1], f"{self.project}/output.data"

--- a/allo/backend/vitis.py
+++ b/allo/backend/vitis.py
@@ -3,9 +3,10 @@
 
 import json
 import textwrap
+import numpy as np
 
 from ..ir.transform import find_func_in_module
-from ..utils import get_func_inputs_outputs, get_clostest_pow2
+from ..utils import get_func_inputs_outputs, get_clostest_pow2, np_supported_types
 
 header = """
 //=============================================================================
@@ -408,3 +409,7 @@ def write_tensor_to_file(tensor, dtype, shape, name, file_path):
             f.write(f"[{', '.join(map(str, shape))}] = {{")
             f.write(", ".join([str(i) for i in tensor.flatten()]))
             f.write("};\n")
+
+
+def read_tensor_from_file(dtype, shape, file_path):
+    return np.fromfile(file_path, dtype=np_supported_types[dtype]).reshape(shape)

--- a/allo/backend/vitis.py
+++ b/allo/backend/vitis.py
@@ -74,6 +74,7 @@ def format_str(s, indent=4, strip=True):
 
 
 def codegen_host(top, module):
+    # Reference: https://github.com/Xilinx/Vitis_Accel_Examples/blob/main/sys_opt/kernel_swap/src/host.cpp
     func = find_func_in_module(module, top)
     inputs, outputs = get_func_inputs_outputs(func)
     # Get input/output types
@@ -257,15 +258,21 @@ def codegen_host(top, module):
         strip=False,
     )
     out_str += "\n"
-    buf_str = ", ".join([f"buffer_out{i}" for i in range(len(outputs))])
-    if buf_str != "":
-        out_str += format_str(
-            "// Copy Result from Device Global Memory to Host Local Memory\n",
-            strip=False,
-        )
+    out_str += format_str(
+        "// Copy Result from Device Global Memory to Host Local Memory\n",
+        strip=False,
+    )
+    if len(outputs) > 0:
         out_str += format_str(
             "OCL_CHECK(err, err = q.enqueueMigrateMemObjects({"
-            + buf_str
+            + ", ".join([f"buffer_out{i}" for i in range(len(outputs))])
+            + "}, CL_MIGRATE_MEM_OBJECT_HOST));\n",
+            strip=False,
+        )
+    else:
+        out_str += format_str(
+            "OCL_CHECK(err, err = q.enqueueMigrateMemObjects({"
+            + ", ".join([f"buffer_in{len(inputs) - 1}"])
             + "}, CL_MIGRATE_MEM_OBJECT_HOST));\n",
             strip=False,
         )

--- a/allo/backend/vitis.py
+++ b/allo/backend/vitis.py
@@ -414,4 +414,5 @@ def write_tensor_to_file(tensor, dtype, shape, name, file_path):
 
 
 def read_tensor_from_file(dtype, shape, file_path):
-    return np.fromfile(file_path, dtype=np_supported_types[dtype]).reshape(shape)
+    arr = np.fromfile(file_path, sep="\n", dtype=np_supported_types[dtype])
+    return arr.reshape(shape)

--- a/allo/backend/vitis.py
+++ b/allo/backend/vitis.py
@@ -74,6 +74,7 @@ def format_str(s, indent=4, strip=True):
     return textwrap.indent(textwrap.dedent(s), " " * indent)
 
 
+# pylint: disable=too-many-branches
 def codegen_host(top, module):
     # Reference: https://github.com/Xilinx/Vitis_Accel_Examples/blob/main/sys_opt/kernel_swap/src/host.cpp
     func = find_func_in_module(module, top)
@@ -406,6 +407,7 @@ def write_tensor_to_file(tensor, dtype, shape, name, file_path):
             f.write(f"const {ctype_map[dtype]} {name} = {tensor};\n")
         else:
             f.write(f"const {ctype_map[dtype]} {name}")
+            # pylint: disable=bad-builtin
             f.write(f"[{', '.join(map(str, shape))}] = {{")
             f.write(", ".join([str(i) for i in tensor.flatten()]))
             f.write("};\n")

--- a/tutorials/tutorial_02_vhls.py
+++ b/tutorials/tutorial_02_vhls.py
@@ -207,24 +207,24 @@ mod = s.build(target="vitis_hls", mode="csyn", project="gemm.prj")
 #    allo_C = np.zeros((M, N), dtype=np.float32)
 #    mod(np_A, np_B, allo_C)
 #    np.testing.assert_allclose(allo_C, np.matmul(np_A, np_B), rtol=1e-5, atol=1e-5)
-# 
+#
 # Finally, you should be able to see the generated bitstream under the ``gemm.prj/build_dir.hw.xilinx_u280_gen3x16_xdma_1_202211_1`` folder
 # (actual board name may be different), and the above test should pass.
 
 # %%
 # To get more detailed information on the resource usage and performance of the generated design,
 # you can check the following files:
-# 
+#
 # - ``gemm.prj/build_dir.hw.xilinx_u280_gen3x16_xdma_1_202211_1/top.xclbin``: The generated bitstream.
 # - ``gemm.prj/build_dir.hw.xilinx_u280_gen3x16_xdma_1_202211_1/top.link.xclbin.info``: Frequency of the actual design, which can be found in ``DATA_CLK``. By default, it is 300MHz.
 # - ``gemm.prj/_x.hw.xilinx_u280_gen3x16_xdma_1_202211_1/reports/top/hls_reports/top_csynth.rpt``: The HLS synthesis report.
 # - ``gemm.prj/_x.hw.xilinx_u280_gen3x16_xdma_1_202211_1/reports/link/imp/impl_1_full_util_routed.rpt``: The full utilization report after placement and routing. You can find the following resource usage:
-# 
+#
 #   - LUT: ``1. CLB Logic -- CLB LUTs``
 #   - FF: ``1. CLB Logic -- CLB Registers -- Register as Flip Flop``
 #   - BRAM: ``3. BLOCKRAM -- Block RAM Tile``
 #   - DSP: ``4. ARITHMETIC -- DSPs``
-# 
+#
 # - ``gemm.prj/_x.hw.xilinx_u280_gen3x16_xdma_1_202211_1/reports/link/imp/impl_1_slr_util_routed.rpt``: The per SLR utilization report after placement and routing.
 # - ``gemm.prj/_x.hw.xilinx_u280_gen3x16_xdma_1_202211_1/logs/top/top_vitis_hls.log``: The log file of the Vitis HLS.
 # - ``gemm.prj/_x.hw.xilinx_u280_gen3x16_xdma_1_202211_1/logs/link/v++.log``: The log file of the Vivado backend synthesis.

--- a/tutorials/tutorial_02_vhls.py
+++ b/tutorials/tutorial_02_vhls.py
@@ -187,3 +187,44 @@ mod = s.build(target="vitis_hls", mode="csyn", project="gemm.prj")
 #
 # From the above output, we can clearly see that all the loops inside the GEMM kernel (marked as ``o``) are pipelined
 # with Initiation Interval (II) equal to 1. You can also find more detailed information under the ``report`` folder.
+
+##############################################################################
+# On-board Execution
+# ------------------
+# After optimizing the design and make sure everything works correctly,
+# we can push the generated RTL design to the backend synthesis flow to generate
+# the bitstream for FPGA. In Allo, we can directly change the target to ``hw``
+# to launch the backend synthesis job. It may take several hours to generate the final
+# bitstream, so it would be better to run it using `tmux <https://github.com/tmux/tmux/wiki>`_.
+# Also, since the C design cannot support returning a new array, we need to
+# explicitly create an output array and pass it to the function.
+#
+# .. code-block:: python
+#
+#    mod = s.build(target="vitis_hls", mode="hw", project="gemm.prj")
+#    np_A = np.random.random((M, K)).astype(np.float32)
+#    np_B = np.random.random((K, N)).astype(np.float32)
+#    allo_C = np.zeros((M, N), dtype=np.float32)
+#    mod(np_A, np_B, allo_C)
+#    np.testing.assert_allclose(allo_C, np.matmul(np_A, np_B), rtol=1e-5, atol=1e-5)
+# 
+# Finally, you should be able to see the generated bitstream under the ``gemm.prj/build_dir.hw.xilinx_u280_gen3x16_xdma_1_202211_1`` folder
+# (actual board name may be different), and the above test should pass.
+
+# %%
+# To get more detailed information on the resource usage and performance of the generated design,
+# you can check the following files:
+# 
+# - ``gemm.prj/build_dir.hw.xilinx_u280_gen3x16_xdma_1_202211_1/top.xclbin``: The generated bitstream.
+# - ``gemm.prj/build_dir.hw.xilinx_u280_gen3x16_xdma_1_202211_1/top.link.xclbin.info``: Frequency of the actual design, which can be found in ``DATA_CLK``. By default, it is 300MHz.
+# - ``gemm.prj/_x.hw.xilinx_u280_gen3x16_xdma_1_202211_1/reports/top/hls_reports/top_csynth.rpt``: The HLS synthesis report.
+# - ``gemm.prj/_x.hw.xilinx_u280_gen3x16_xdma_1_202211_1/reports/link/imp/impl_1_full_util_routed.rpt``: The full utilization report after placement and routing. You can find the following resource usage:
+# 
+#   - LUT: ``1. CLB Logic -- CLB LUTs``
+#   - FF: ``1. CLB Logic -- CLB Registers -- Register as Flip Flop``
+#   - BRAM: ``3. BLOCKRAM -- Block RAM Tile``
+#   - DSP: ``4. ARITHMETIC -- DSPs``
+# 
+# - ``gemm.prj/_x.hw.xilinx_u280_gen3x16_xdma_1_202211_1/reports/link/imp/impl_1_slr_util_routed.rpt``: The per SLR utilization report after placement and routing.
+# - ``gemm.prj/_x.hw.xilinx_u280_gen3x16_xdma_1_202211_1/logs/top/top_vitis_hls.log``: The log file of the Vitis HLS.
+# - ``gemm.prj/_x.hw.xilinx_u280_gen3x16_xdma_1_202211_1/logs/link/v++.log``: The log file of the Vivado backend synthesis.


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR fixes #162. It adds support to streamline the bitstream execution process from Python. Now users can directly pass in Numpy array and call the module/bitstream just like what they do for software testing.

This PR also fixes a bug of passing in scalars in the host code (related to #219).

### Examples ###
```python
import allo
from allo.ir.types import bool, int32
import numpy as np

def test_scalar_not_array():
    def top(inst: bool, C: int32[3]):
        flag: bool = inst[0]
        if flag:
            C[0] = C[0] + 1

    s = allo.customize(top)
    mod = s.build(target="vitis_hls", mode="hw", project="test_scalar.prj")
    C = np.array([1, 2, 3], dtype=np.int32)
    # execute the bitstream
    mod(1, C)
    np.testing.assert_allclose(C, [2, 2, 3], rtol=1e-5)
    print("Passed!")

test_scalar_not_array()
```


## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [x] Code is well-documented
