### PR TITLE
[IR] Implement scalar as rank-0 memref

### DIFF
--- a/allo/ir/builder.py
+++ b/allo/ir/builder.py
@@ -86,9 +86,7 @@ class ASTTransformer(ASTBuilder):
                 buffer.op.result if isinstance(buffer, MockScalar) else buffer.result
             )
             if not ctx.enable_tensor:
-                affine_map = AffineMap.get(
-                    dim_count=0, symbol_count=0, exprs=[AffineConstantExpr.get(0)]
-                )
+                affine_map = AffineMap.get(dim_count=0, symbol_count=0, exprs=[])
                 affine_attr = AffineMapAttr.get(affine_map)
                 store_op = affine_d.AffineStoreOp(
                     val.result, target, [], affine_attr, ip=ctx.get_ip()
@@ -1246,7 +1244,6 @@ class ASTTransformer(ASTBuilder):
         elif isinstance(node.dtype, Stream):
             ctx.buffers[node.target.id] = rhs
         else:
-            # TODO: figure out why zero-ranked cannot work
             ctx.buffers[node.target.id] = MockScalar(
                 node.target.id,
                 node.dtype,

--- a/allo/ir/utils.py
+++ b/allo/ir/utils.py
@@ -13,7 +13,6 @@ from .._mlir.ir import (
     IntegerAttr,
     FloatAttr,
     StringAttr,
-    AffineConstantExpr,
     AffineMap,
     AffineMapAttr,
 )

--- a/allo/ir/utils.py
+++ b/allo/ir/utils.py
@@ -188,11 +188,10 @@ class MockScalar(MockOp):
         self.name = name
         self.ctx = ctx
         self.value = value
-        shape = (1,)
         assert isinstance(dtype, AlloType), f"Expect AlloType, got {dtype}"
         self.dtype = dtype
         if not ctx.enable_tensor:
-            memref_type = MemRefType.get(shape, dtype.build())
+            memref_type = MemRefType.get((), dtype.build())
             alloc_op = memref_d.AllocOp(memref_type, [], [], ip=ctx.get_ip())
             alloc_op.attributes["name"] = StringAttr.get(name)
         else:
@@ -203,9 +202,7 @@ class MockScalar(MockOp):
     def result(self):
         # pylint: disable=no-else-return
         if not self.ctx.enable_tensor:
-            affine_map = AffineMap.get(
-                dim_count=0, symbol_count=0, exprs=[AffineConstantExpr.get(0)]
-            )
+            affine_map = AffineMap.get(dim_count=0, symbol_count=0, exprs=[])
             affine_attr = AffineMapAttr.get(affine_map)
             load = affine_d.AffineLoadOp(
                 self.dtype.build(),

--- a/mlir/lib/Translation/EmitIntelHLS.cpp
+++ b/mlir/lib/Translation/EmitIntelHLS.cpp
@@ -570,12 +570,8 @@ void ModuleEmitter::emitArrayDecl(Value array, bool isFunc, std::string name) {
         os << " */";
       } else {
         emitValue(array, 0, false, name);
-        if (arrayType.getShape().size() == 1 && arrayType.getShape()[0] == 1) {
-          // do nothing;
-        } else {
-          for (auto &shape : arrayType.getShape())
-            os << "[" << shape << "]";
-        }
+        for (auto &shape : arrayType.getShape())
+          os << "[" << shape << "]";
       }
     } else { // tensor
       emitValue(array, 0, false, name);
@@ -678,14 +674,10 @@ void ModuleEmitter::emitAffineLoad(AffineLoadOp op) {
   AffineExprEmitter affineEmitter(state, affineMap.getNumDims(),
                                   op.getMapOperands());
   auto arrayType = memref.getType().cast<ShapedType>();
-  if (arrayType.getShape().size() == 1 && arrayType.getShape()[0] == 1) {
-    // do nothing;
-  } else {
-    for (auto index : affineMap.getResults()) {
-      os << "[";
-      affineEmitter.emitAffineExpr(index);
-      os << "]";
-    }
+  for (auto index : affineMap.getResults()) {
+    os << "[";
+    affineEmitter.emitAffineExpr(index);
+    os << "]";
   }
   os << ";";
   emitInfoAndNewLine(op);
@@ -711,14 +703,10 @@ void ModuleEmitter::emitAffineStore(AffineStoreOp op) {
   AffineExprEmitter affineEmitter(state, affineMap.getNumDims(),
                                   op.getMapOperands());
   auto arrayType = memref.getType().cast<ShapedType>();
-  if (arrayType.getShape().size() == 1 && arrayType.getShape()[0] == 1) {
-    // do nothing;
-  } else {
-    for (auto index : affineMap.getResults()) {
-      os << "[";
-      affineEmitter.emitAffineExpr(index);
-      os << "]";
-    }
+  for (auto index : affineMap.getResults()) {
+    os << "[";
+    affineEmitter.emitAffineExpr(index);
+    os << "]";
   }
   os << " = ";
   emitValue(op.getValueToStore());

--- a/mlir/lib/Translation/EmitVivadoHLS.cpp
+++ b/mlir/lib/Translation/EmitVivadoHLS.cpp
@@ -922,14 +922,10 @@ void ModuleEmitter::emitAffineLoad(AffineLoadOp op) {
     emitValue(memref, 0, false, load_from_name); // comment
   }
   auto arrayType = memref.getType().cast<ShapedType>();
-  if (arrayType.getShape().size() == 1 && arrayType.getShape()[0] == 1) {
-    // do nothing;
-  } else {
-    for (auto index : affineMap.getResults()) {
-      os << "[";
-      affineEmitter.emitAffineExpr(index);
-      os << "]";
-    }
+  for (auto index : affineMap.getResults()) {
+    os << "[";
+    affineEmitter.emitAffineExpr(index);
+    os << "]";
   }
   os << ";";
   emitInfoAndNewLine(op);
@@ -972,14 +968,10 @@ void ModuleEmitter::emitAffineStore(AffineStoreOp op) {
     emitValue(memref, 0, false, store_to_name); // comment
   }
   auto arrayType = memref.getType().cast<ShapedType>();
-  if (arrayType.getShape().size() == 1 && arrayType.getShape()[0] == 1) {
-    // do nothing;
-  } else {
-    for (auto index : affineMap.getResults()) {
-      os << "[";
-      affineEmitter.emitAffineExpr(index);
-      os << "]";
-    }
+  for (auto index : affineMap.getResults()) {
+    os << "[";
+    affineEmitter.emitAffineExpr(index);
+    os << "]";
   }
   os << " = ";
   emitValue(op.getValueToStore());
@@ -1762,12 +1754,8 @@ void ModuleEmitter::emitArrayDecl(Value array, bool isFunc, std::string name) {
         os << " */";
       } else {
         emitValue(array, 0, false, name);
-        if (arrayType.getShape().size() == 1 && arrayType.getShape()[0] == 1) {
-          // do nothing;
-        } else {
-          for (auto &shape : arrayType.getShape())
-            os << "[" << shape << "]";
-        }
+        for (auto &shape : arrayType.getShape())
+          os << "[" << shape << "]";
       }
     } else { // tensor
       emitValue(array, 0, false, name);

--- a/mlir/lib/Translation/EmitVivadoHLS.cpp
+++ b/mlir/lib/Translation/EmitVivadoHLS.cpp
@@ -2127,7 +2127,8 @@ void ModuleEmitter::emitFunction(func::FuncOp func) {
     unsigned idx = 0;
     for (auto result : funcReturn.getOperands()) {
       if (std::find(args.begin(), args.end(), result) == args.end()) {
-        os << ",\n";
+        if (func.getArguments().size() > 0)
+          os << ",\n";
         indent();
 
         // TODO: a known bug, cannot return a value twice, e.g. return %0, %0

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -714,5 +714,20 @@ def test_minmax(T):
     assert "max" in mod.hls_code
 
 
+def test_scalar():
+    def kernel() -> int32:
+        a: int32 = 0
+        b: int32 = a + 1
+        return b
+
+    s = allo.customize(kernel)
+    print(s.module)
+    assert "%alloc[]" in str(s.module)
+    mod = s.build()
+    assert mod() == 1
+    mod = s.build(target="vhls")
+    assert "," not in mod.hls_code
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/test_vhls.py
+++ b/tests/test_vhls.py
@@ -167,18 +167,23 @@ def test_scalar():
 
 
 def test_size1_array():
-    def kernel(A: int32[1]) -> int32[1]:
+    def top(A: int32[1]) -> int32[1]:
         A[0] = A[0] + 1
         return A
 
-    s = allo.customize(kernel)
+    s = allo.customize(top)
     mod = s.build()
     np_A = np.array([1], dtype=np.int32)
     np.testing.assert_allclose(mod(np_A), [2], rtol=1e-5)
     print("Passed CPU simulation!")
-    mod = s.build(target="vhls")
+    mod = s.build(target="vitis_hls", mode="csim", project="test_size1_array.prj")
     print(mod.hls_code)
     assert "[1]" in mod.hls_code
+    if hls.is_available("vitis_hls"):
+        np_B = np.array([0], dtype=np.int32)
+        mod(np_A, np_B)
+        np.testing.assert_allclose(np_A, [2], rtol=1e-5)
+        print("Passed!")
 
 
 if __name__ == "__main__":

--- a/tests/test_vhls.py
+++ b/tests/test_vhls.py
@@ -166,5 +166,20 @@ def test_scalar():
     # Note: Should not expect it to run using csim! Need to generate correct binding for mutable scalars in PyBind.
 
 
+def test_size1_array():
+    def kernel(A: int32[1]) -> int32[1]:
+        A[0] = A[0] + 1
+        return A
+
+    s = allo.customize(kernel)
+    mod = s.build()
+    np_A = np.array([1], dtype=np.int32)
+    np.testing.assert_allclose(mod(np_A), [2], rtol=1e-5)
+    print("Passed CPU simulation!")
+    mod = s.build(target="vhls")
+    print(mod.hls_code)
+    assert "[1]" in mod.hls_code
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/test_vhls.py
+++ b/tests/test_vhls.py
@@ -121,9 +121,8 @@ def test_csim_write_back():
 
 
 def test_pointer_generation():
-    def top(inst: bool[1], C: int32[3]):
-        flag: bool = inst[0]
-        if flag:
+    def top(inst: bool, C: int32[3]):
+        if inst:
             C[0] = C[0] + 1
 
     s = allo.customize(top)


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
Previously Allo implemented scalar as size-1 rank-1 memref to avoid the limitation of the Python binding, but this introduced lots of problems when lowering to the HLS backend. As we have already updated to the latest LLVM, we can construct the correct rank-0 memref at the Python level to resolve this issue.

This corresponding HLS codegen also needs to be changed. Now only rank-0 memref will be generated as scalar.

### Examples ###
```python
def test_scalar():
    def kernel() -> int32:
        a: int32 = 0
        b: int32 = a + 1
        return b

    s = allo.customize(kernel)
    print(s.module)
    assert "%alloc[]" in str(s.module)
    mod = s.build()
    assert mod() == 1
    mod = s.build(target="vhls")
    assert "," not in mod.hls_code
```
```mlir
module {
  func.func @kernel() -> i32 attributes {itypes = "", otypes = "s"} {
    %alloc = memref.alloc() {name = "a"} : memref<i32>
    %c0_i32 = arith.constant 0 : i32
    affine.store %c0_i32, %alloc[] {to = "a"} : memref<i32>
    %0 = affine.load %alloc[] {from = "a"} : memref<i32>
    %1 = arith.extsi %0 : i32 to i33
    %c1_i32 = arith.constant 1 : i32
    %2 = arith.extsi %c1_i32 : i32 to i33
    %3 = arith.addi %1, %2 : i33
    %4 = arith.trunci %3 : i33 to i32
    %alloc_0 = memref.alloc() {name = "b"} : memref<i32>
    affine.store %4, %alloc_0[] {to = "b"} : memref<i32>
    %5 = affine.load %alloc_0[] {from = "b"} : memref<i32>
    %6 = affine.load %alloc_0[] {from = "b"} : memref<i32>
    return %6 : i32
  }
}
```

## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [x] Code is well-documented
