### PR TITLE
[Dataflow] Add 1D Systolic GEMM and 2D Systolic Smith-Waterman algorithm

### DIFF
--- a/tests/dataflow/test_1D_systolic.py
+++ b/tests/dataflow/test_1D_systolic.py
@@ -1,3 +1,6 @@
+# Copyright Allo authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import allo
 from allo.ir.types import float32, Stream
 import allo.dataflow as df

--- a/tests/dataflow/test_1D_systolic.py
+++ b/tests/dataflow/test_1D_systolic.py
@@ -1,0 +1,51 @@
+import allo
+from allo.ir.types import float32, Stream
+import allo.dataflow as df
+import allo.backend.hls as hls
+import numpy as np
+
+M, N, K = 16, 16, 16
+P0 = K + 1
+
+
+@df.kernel(mapping=[2, P0])
+def gemm(A: float32[M, K], B: float32[K, N], C: float32[M, N]):
+    i, j = df.get_pid()
+    in_A: Stream[float32] = df.pipe(src=(i, j - 1), dst=(i, j))
+    in_B: Stream[float32] = df.pipe(src=(i - 1, j), dst=(i, j))
+    out_B: Stream[float32] = df.pipe(src=(i, j), dst=(i + 1, j))
+    out_A: Stream[float32] = df.pipe(src=(i, j), dst=(i, j + 1))
+
+    with allo.meta_if(i == 0 and j == 0):
+        pass
+    with allo.meta_elif(i == 0):
+        for _ in range(M):
+            for k in range(K):
+                out_B.put(B[k, j - 1])
+    with allo.meta_elif(j == 0):
+        for m in range(M):
+            for k in range(K):
+                out_A.put(A[m, k])
+    with allo.meta_else():
+        for m in range(M):
+            c: float32 = 0
+            for _ in range(K):
+                a: float32 = in_A.get()
+                b: float32 = in_B.get()
+                c += a * b
+                out_A.put(a)
+            C[m, j - 1] = c
+
+
+def test_systolic():
+    A = np.random.rand(M, K).astype(np.float32)
+    B = np.random.rand(K, N).astype(np.float32)
+    C = np.zeros((M, N), dtype=np.float32)
+    if hls.is_available("vitis_hls"):
+        gemm(A, B, C)
+        np.testing.assert_allclose(C, np.dot(A, B), atol=1e-5)
+        print("Passed!")
+
+
+if __name__ == "__main__":
+    test_systolic()

--- a/tests/dataflow/test_Smith_Waterman_systolic.py
+++ b/tests/dataflow/test_Smith_Waterman_systolic.py
@@ -1,3 +1,6 @@
+# Copyright Allo authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import allo
 from allo.ir.types import int8, int32, Stream
 import allo.dataflow as df

--- a/tests/dataflow/test_Smith_Waterman_systolic.py
+++ b/tests/dataflow/test_Smith_Waterman_systolic.py
@@ -1,0 +1,90 @@
+import allo
+from allo.ir.types import int8, int32, Stream
+import allo.dataflow as df
+import allo.backend.hls as hls
+import numpy as np
+
+
+W: int32 = 2  # gap penalty score per length, assuming a linear increament
+
+max_size = 100
+M, N = np.random.randint(30, max_size), np.random.randint(30, max_size)
+P0, P1 = M + 1, N + 1
+
+Sim: int32 = 3
+Mis: int32 = -3
+
+
+def smith_waterman_score_matrix(seqA, seqB):
+    score_matrix = np.zeros((len(seqA) + 1, len(seqB) + 1), dtype=int)
+    for i in range(score_matrix.shape[0]):
+        for j in range(score_matrix.shape[1]):
+            if i == 0 or j == 0:
+                score_matrix[i][j] = 0
+            else:
+                similarity = Sim if seqA[i - 1] == seqB[j - 1] else Mis
+                score_matrix[i][j] = max(
+                    0,
+                    score_matrix[i - 1][j - 1] + similarity,
+                    max([score_matrix[a, j] - 2 * (i - a) for a in range(i)]),
+                    max([score_matrix[i, b] - 2 * (j - b) for b in range(j)]),
+                )
+
+    return score_matrix
+
+
+@df.kernel(mapping=[P0, P1])
+def Smith_Waterman(A: int8[M], B: int8[N], S: int32[P0, P1]):
+    i, j = df.get_pid()
+    # using float32 for the score matrix to avoid overflow
+    # or account for different scoring functions
+    in_A: Stream[int32] = df.pipe(src=(i, j - 1), dst=(i, j))
+    in_B: Stream[int32] = df.pipe(src=(i - 1, j), dst=(i, j))
+    in_C: Stream[int32] = df.pipe(src=(i - 1, j - 1), dst=(i, j))
+    out_B: Stream[int32] = df.pipe(src=(i, j), dst=(i + 1, j))
+    out_A: Stream[int32] = df.pipe(src=(i, j), dst=(i, j + 1))
+    out_C: Stream[int32] = df.pipe(src=(i, j), dst=(i + 1, j + 1))
+
+    with allo.meta_if(i == 0 and j == 0):
+        # Fill the first row and column with zeros
+        out_A.put(0)
+        out_B.put(0)
+        out_C.put(0)
+    with allo.meta_elif(i == 0):
+        out_A.put(0)
+        out_C.put(0)
+    with allo.meta_elif(j == 0):
+        out_B.put(0)
+        out_C.put(0)
+    with allo.meta_else():
+        a = in_A.get()
+        b = in_B.get()
+        c = in_C.get()
+        # Calculate the score for the current position
+        aligning: int32 = c + (Sim if A[i - 1] == B[j - 1] else Mis)
+        gap_A: int32 = a - W
+        gap_B: int32 = b - W
+        # Choose the maximum score
+        score: int32 = max(max(0, aligning), max(gap_A, gap_B))
+        S[i, j] = score
+        out_A.put(max(gap_A, score))
+        out_B.put(max(gap_B, score))
+        out_C.put(score)
+
+
+def test_systolic():
+    possible_chars = np.array(["A", "C", "G", "T"], dtype="c")
+    A = np.random.choice(possible_chars, size=M).view(np.int8)
+    B = np.random.choice(possible_chars, size=N).view(np.int8)
+    S = np.zeros((P0, P1), dtype=np.int32)
+    print("awaiting hls...")
+    if hls.is_available("vitis_hls"):
+        Smith_Waterman(A, B, S)
+        oracle = smith_waterman_score_matrix(A, B)
+        np.testing.assert_array_equal(S, oracle)
+        print("Passed!")
+
+
+if __name__ == "__main__":
+    for _ in range(10):
+        test_systolic()

--- a/tests/dataflow/test_smith_waterman_systolic.py
+++ b/tests/dataflow/test_smith_waterman_systolic.py
@@ -39,8 +39,6 @@ def smith_waterman_score_matrix(seqA, seqB):
 @df.kernel(mapping=[P0, P1])
 def Smith_Waterman(A: int8[M], B: int8[N], S: int32[P0, P1]):
     i, j = df.get_pid()
-    # using float32 for the score matrix to avoid overflow
-    # or account for different scoring functions
     in_A: Stream[int32] = df.pipe(src=(i, j - 1), dst=(i, j))
     in_B: Stream[int32] = df.pipe(src=(i - 1, j), dst=(i, j))
     in_C: Stream[int32] = df.pipe(src=(i - 1, j - 1), dst=(i, j))


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR adds examples of using dataflow to implement 1D Systolic GEMM and 2D Systolic Smith-Waterman algorithm

### Examples ###
`python3 python3 test_Smith_Waterman_systolic.py ` and ` python3 test_1D_systolic.py` should output `Passed!`


## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [x] Code is well-documented
