### PR TITLE
[IR] Add casting for min/max/put

### DIFF
--- a/allo/ir/infer.py
+++ b/allo/ir/infer.py
@@ -729,8 +729,10 @@ class TypeInferer(ASTVisitor):
                     len(node.args) == 2
                 ), "Only support two arguments for `min` and `max`"
                 new_args = visit_stmts(ctx, node.args)
+                typing_rule = get_typing_rule("minmax")
+                res_type = typing_rule(new_args[0].dtype, new_args[1].dtype)
+                node.dtype = res_type
                 node.shape = new_args[0].shape
-                node.dtype = new_args[0].dtype
             else:
                 raise RuntimeError(f"Unsupported function call {node.func.id}")
             return node

--- a/allo/ir/typing_rule.py
+++ b/allo/ir/typing_rule.py
@@ -735,4 +735,5 @@ registry = {
     ast.UAdd: intrin_rule(),
     ast.Invert: intrin_rule(),
     ast.IfExp: select_rule(),
+    "minmax": select_rule(),
 }

--- a/mlir/lib/Translation/Utils.cpp
+++ b/mlir/lib/Translation/Utils.cpp
@@ -45,9 +45,13 @@ SmallString<8> AlloEmitterBase::getName(Value val) {
         return SmallString<8>(std::to_string(boolAttr.getValue()));
 
       } else if (auto floatAttr = constAttr.dyn_cast<FloatAttr>()) {
+        // as 0.0 will be interpreted as double constant, we need to explicitly
+        // declare it as float32
+        int bitwidth = floatAttr.getType().cast<FloatType>().getWidth();
+        std::string prefix = (bitwidth == 32) ? "(float)" : "(double)";
         auto value = floatAttr.getValueAsDouble();
         if (std::isfinite(value))
-          return SmallString<8>(std::to_string(value));
+          return SmallString<8>(prefix + std::to_string(value));
         else if (value > 0)
           return SmallString<8>("INFINITY");
         else

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -714,6 +714,27 @@ def test_minmax(T):
     assert "max" in mod.hls_code
 
 
+def test_minmax_cast():
+    def kernel(A: int8[2]) -> int32[2]:
+        res: int32[2] = 0
+        res[0] = min(A[0], 0)
+        res[1] = max(A[1], 0.0)
+        return res
+
+    s = allo.customize(kernel)
+    print(s.module)
+    mod = s.build()
+    np_A = np.random.randint(-64, 64, size=(2,)).astype(np.int8)
+    allo_B = mod(np_A)
+    assert allo_B[0] == min(np_A[0], 0)
+    assert allo_B[1] == max(np_A[1], 0.0)
+    mod = s.build(target="vhls")
+    print(mod)
+    assert "min" in mod.hls_code
+    assert "max" in mod.hls_code
+    assert "(float)" in mod.hls_code
+
+
 def test_scalar():
     def kernel() -> int32:
         a: int32 = 0


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR adds casting operations for min/max/put. Specifically, the codegen for constant float values of HLS also changed, since `0.0` will be interpreted as double if not explicitly declaring the type.

### Examples ###
```python
def test_minmax_cast():
    def kernel(A: int8[2]) -> int32[2]:
        res: int32[2] = 0
        res[0] = min(A[0], 0)
        res[1] = max(A[1], 0.0)
        return res

    s = allo.customize(kernel)
    print(s.module)
    mod = s.build()
    np_A = np.random.randint(-64, 64, size=(2,)).astype(np.int8)
    allo_B = mod(np_A)
    assert allo_B[0] == min(np_A[0], 0)
    assert allo_B[1] == max(np_A[1], 0.0)
    mod = s.build(target="vhls")
    print(mod)
    assert "min" in mod.hls_code
    assert "max" in mod.hls_code
    assert "(float)" in mod.hls_code
```
```cpp
void kernel(
  int8_t v0[2],
  int32_t v1[2]
) {     // L2
  for (int v2 = 0; v2 < 2; v2++) {      // L5
    v1[v2] = 0; // L5
  }
  int8_t v3 = v0[0];    // L6
  int32_t v4 = v3;      // L7
  int32_t v5 = min(v4, 0);      // L9
  v1[0] = v5;   // L10
  int8_t v6 = v0[1];    // L11
  float v7 = v6;        // L12
  float v8 = max(v7, (float)0.000000);  // L14
  int32_t v9 = v8;      // L15
  v1[1] = v9;   // L16
}
```

## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [x] Code is well-documented
