### PR TITLE
[dataflow] Expose build target in df.build function

### DIFF
--- a/docs/source/developer/index.rst
+++ b/docs/source/developer/index.rst
@@ -76,7 +76,7 @@ make sure you have passed the tests locally before creating a PR or pushing to y
 
 There are several tests for our project:
 
-1. **License header check**: make sure all the source files have the license header, which is important for open source projects.
+1. **License header check**: make sure all the source files have the license header, which is important for open source projects. Please copy these `two lines <https://github.com/cornell-zhang/allo/blob/main/allo/__init__.py#L1-L2>`_ if you are creating a new Python file.
 2. **Code style check**: make sure the Python code style is consistent with the `PEP8 <https://www.python.org/dev/peps/pep-0008/>`_ standard. We use ``black`` for Python formatting, which should has been installed in your environment during the setup. For the MLIR part, we use ``clang-format`` for C/C++ formatting.
 3. **Linting check**: make sure the code is `linted <https://www.perforce.com/blog/qac/what-lint-code-and-what-linting-and-why-linting-important>`_ correctly. We use ``pylint`` for Python linting, which should also been installed during the setup.
 4. **Unit tests**: make sure the changes will not break the existing facilities. We use ``pytest`` for Python unit tests, and the test cases are under the ``tests`` folder.

--- a/docs/source/setup/index.rst
+++ b/docs/source/setup/index.rst
@@ -43,11 +43,12 @@ To simplify the installation process, we provide a docker image that has already
 Install from Source
 -------------------
 
-Please follow the instructions below to build the LLVM-19 project from source. You can also refer to the `official guide <https://mlir.llvm.org/getting_started/>`_ for more details. As the LLVM/MLIR API changes a lot, if you are using a different LLVM version, the Allo package may not work properly.
+Please follow the instructions below to build the LLVM-19 project from source. You can also refer to the `official guide <https://mlir.llvm.org/getting_started/>`_ for more details. As the LLVM/MLIR API changes a lot, if you are using a different LLVM version, the Allo package may not work properly. The LLVM version we used can be found in the `externals <https://github.com/cornell-zhang/allo/tree/main/externals>`_ folder.
 
 .. code-block:: bash
 
-    git submodule update --init --recursive && cd externals/llvm-project
+    git clone --recursive https://github.com/cornell-zhang/allo.git
+    cd allo/externals/llvm-project
     # Apply our patch
     git apply ../llvm_patch
     # Python 3.12 is required
@@ -62,13 +63,8 @@ Please follow the instructions below to build the LLVM-19 project from source. Y
         -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
         -DPython3_EXECUTABLE=`which python3`
     ninja
-
-Then clone the Allo repository to your local machine.
-
-.. code-block:: console
-  
-  $ git clone https://github.com/cornell-zhang/allo.git
-  $ cd allo
+    # export environment variable
+    export LLVM_BUILD_DIR=$(pwd)
 
 We recommend creating a new conda environment for Allo. Since we are using the latest Python features, the minimum Python version is **3.12**.
 
@@ -131,4 +127,4 @@ Now, you can run the following command to test if the installation is successful
 
   $ python3 -c "import allo as allo; import allo.ir as air"
 
-If you see no error message, then the installation is successful. Otherwise, please contact us for help.
+If you see no error messages, then the installation is successful. Otherwise, please contact us for help.

--- a/tests/dataflow/test_tiled_systolic.py
+++ b/tests/dataflow/test_tiled_systolic.py
@@ -61,6 +61,8 @@ def test_tiled_systolic():
         gemm(A, B, C)
         np.testing.assert_allclose(C, np.dot(A, B), atol=1e-5)
         print("Passed!")
+        mod = df.build(gemm, target="vitis_hls", mode="csyn", project="top.prj")
+        mod()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR exposes the build target in the `df.build` function as follows:

```python
 mod = df.build(gemm, target="vitis_hls", mode="csyn", project="top.prj")
```

so users can now directly generate the corresponding hardware design from a dataflow program.

Some documentations are also updated in this PR.

## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [x] Code is well-documented
