### PR TITLE
[Builder] Add `index` from/to `Float`/`Fixed`/`UFixed` type casting

### DIFF
--- a/allo/ir/builder.py
+++ b/allo/ir/builder.py
@@ -15,7 +15,6 @@ from .._mlir.ir import (
     RankedTensorType,
     ShapedType,
     IntegerType,
-    IndexType,
     F32Type,
     UnitAttr,
     IntegerAttr,
@@ -393,7 +392,9 @@ class ASTTransformer(ASTBuilder):
         elif isinstance(src_type, Float) and isinstance(res_type, Index):
             # FP to Index is not supported in MLIR
             # we need to cast to UInt first, then cast to Index
-            op = arith_d.FPToUIOp(IndexType.get(), op.result, ip=ctx.get_ip())
+            op = arith_d.FPToUIOp(
+                IntegerType.get_signless(32), op.result, ip=ctx.get_ip()
+            )
             opcls = arith_d.IndexCastOp  # proceed to build cast to index
         elif isinstance(src_type, Index) and isinstance(res_type, Float):
             op = arith_d.IndexCastOp(

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -14,6 +14,7 @@ from allo.ir.types import (
     uint1,
     int32,
     float32,
+    index,
 )
 import allo.ir.types as T
 
@@ -40,6 +41,44 @@ def test_int32_float32_casting():
     print(s.module)
     mod = s.build()
     assert mod(1) == kernel(1)
+
+
+def test_index_fixed_casting():
+    def test_one_cast(fixed):
+        def kernel(a: fixed) -> float32:
+            sum_val: fixed = 0.0
+            ret_val: float32 = 0.0
+            for step in range(10):
+                sum_val += step
+            ret_val = sum_val
+            return ret_val
+
+        s = allo.customize(kernel)
+        mod = s.build()
+        assert mod(1) == kernel(1)
+
+    for i in range(1, 20):
+        test_one_cast(Fixed(32, i))
+        test_one_cast(UFixed(32, i))
+
+
+def test_fixed_index_casting():
+
+    def test_one_cast(fixed):
+        def kernel(a: float32) -> int32:
+            a_fix: fixed = a
+            a_idx: index = a_fix
+            b: index = 2
+            ret: int32 = a_idx + b
+            return ret
+
+        s = allo.customize(kernel)
+        mod = s.build()
+        assert mod(2.0) == kernel(2.0)
+
+    for i in range(1, 20):
+        test_one_cast(Fixed(32, i))
+        test_one_cast(UFixed(32, i))
 
 
 def test_large_bitwidth():

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -45,11 +45,11 @@ def test_int32_float32_casting():
 
 def test_index_fixed_casting():
     def test_one_cast(fixed):
-        def kernel(a: fixed) -> float32:
-            sum_val: fixed = 0.0
+        def kernel(a: index) -> float32:
+            sum_val: fixed = a  # casting
             ret_val: float32 = 0.0
             for step in range(10):
-                sum_val += step
+                sum_val += step  # casting
             ret_val = sum_val
             return ret_val
 
@@ -79,6 +79,30 @@ def test_fixed_index_casting():
     for i in range(1, 20):
         test_one_cast(Fixed(32, i))
         test_one_cast(UFixed(32, i))
+
+
+def test_index_float_casting():
+    def kernel(a: index) -> float32:
+        sum_val: float32 = a  # casting
+        for step in range(10):
+            sum_val += step  # casting
+        return sum_val
+
+    s = allo.customize(kernel)
+    mod = s.build()
+    assert mod(1) == kernel(1)
+
+
+def test_float_index_casting():
+    def kernel(a: float32) -> int32:
+        a_idx: index = a  # casting
+        b: index = 2
+        ret: int32 = a_idx + b
+        return ret
+
+    s = allo.customize(kernel)
+    mod = s.build()
+    assert mod(2.0) == kernel(2.0)
 
 
 def test_large_bitwidth():


### PR DESCRIPTION
## Description ##
This PR introduces expanding support for casting between `Index`, `Fixed`, and `UFixed` types in the Allo IR. This enhancement allows for seamless conversions between these types, which broadens the flexibility of type handling in the IR layer.

### Problems ###
Previously, the Allo IR lacked direct support for conversions between `Index` and `Fixed/UFixed` types, limiting the flexibility in scenarios where such conversions are needed for operations. Attempting these conversions required workarounds or was unsupported, creating friction in code requiring dynamic type handling.

### Proposed Solutions ###
- Added `Index <-> Fixed/UFixed` single-step conversions in the `cast_map` within `ASTTransformer`.
- Implemented new casting operations `IntToFixedOp` and `FixedToIntOp` as intermediary conversions to facilitate direct type transformations.
- Updated the `IndexCastOp` to handle `Index -> Fixed/UFixed` conversions.

### Examples ###
Here’s a snippet of the updated behavior:

1. **Index to Fixed/UFixed Casting**:
   ```python
   def kernel(a: index) -> Fixed:
       a_fixed: Fixed = a
       return a_fixed
   ```

2. **Fixed/UFixed to Index Casting**:
   ```python
   def kernel(a: Fixed) -> index:
       a_idx: index = a
       return a_idx
   ```

Both conversions now produce correct IR output without errors, validating the new casting support.

## Checklist ##

- [x] PR's title starts with a category (e.g., [IR], [Builder])
- [x] Changes are complete (i.e., finished coding on this PR)
- [x] All changes have test coverage, with cases for both `Index -> Fixed/UFixed` and `Fixed/UFixed -> Index` conversions
- [x] Code is well-documented