### PR TITLE
[IR] Add shift left/right operations for fixed points

### DIFF
--- a/allo/ir/typing_rule.py
+++ b/allo/ir/typing_rule.py
@@ -615,13 +615,24 @@ def shift_rule():
         (Int, Index): lambda t1, t2: t1,
     }
     uint_rules = {
+        (UInt, Int): lambda t1, t2: t1,
         (UInt, UInt): lambda t1, t2: t1,
         (UInt, Index): lambda t1, t2: t1,
     }
     index_rules = {
         (Index, Index): lambda t1, t2: Index(),
     }
-    return TypingRule([int_rules, uint_rules, index_rules], commutative=True)
+    fixed_rules = {
+        (Fixed, Int): lambda t1, t2: t1,
+        (Fixed, UInt): lambda t1, t2: t1,
+        (Fixed, Index): lambda t1, t2: t1,
+    }
+    ufixed_rules = {
+        (UFixed, Int): lambda t1, t2: t1,
+        (UFixed, UInt): lambda t1, t2: t1,
+        (UFixed, Index): lambda t1, t2: t1,
+    }
+    return TypingRule([int_rules, uint_rules, index_rules, fixed_rules, ufixed_rules])
 
 
 def and_or_rule():

--- a/mlir/include/allo/Dialect/AlloOps.td
+++ b/mlir/include/allo/Dialect/AlloOps.td
@@ -709,6 +709,30 @@ def DivFixedOp : FixedBinaryOp<"div_fixed"> {
   let summary = "fixed point division operation";
 }
 
+def ShLFixedOp : Allo_Op<"shl_fixed"> {
+  let summary = "fixed point shift left operation";
+  let arguments = (ins
+      FixedLike:$lhs,
+      SignlessIntegerLike:$rhs
+  );
+  let results = (outs FixedLike:$result);
+  let assemblyFormat = [{
+    `(` $lhs `,` $rhs `)` `:` attr-dict `(` type($lhs) `,` type($rhs) `)` `->` type($result)
+  }];
+}
+
+def ShRFixedOp : Allo_Op<"shr_fixed"> {
+  let summary = "fixed point shift right operation";
+  let arguments = (ins
+      FixedLike:$lhs,
+      SignlessIntegerLike:$rhs
+  );
+  let results = (outs FixedLike:$result);
+  let assemblyFormat = [{
+    `(` $lhs `,` $rhs `)` `:` attr-dict `(` type($lhs) `,` type($rhs) `)` `->` type($result)
+  }];
+}
+
 def CmpFixedOp : Allo_Op<"cmp_fixed", [NoMemoryEffect, SameTypeOperands, TypesMatchWith<
     "result type has i1 element type and same shape as operands",
     "lhs", "result", "getI1SameShape($_self)">] # ElementwiseMappable.traits> {

--- a/mlir/include/allo/Dialect/Visitor.h
+++ b/mlir/include/allo/Dialect/Visitor.h
@@ -64,18 +64,21 @@ public:
             arith::MaximumFOp, arith::MinimumFOp,
             // Logical expressions.
             arith::XOrIOp, arith::AndIOp, arith::OrIOp, arith::ShLIOp,
-            arith::ShRSIOp, arith::ShRUIOp, allo::GetIntBitOp, allo::SetIntBitOp,
-            allo::GetIntSliceOp, allo::SetIntSliceOp, allo::BitReverseOp,
+            arith::ShRSIOp, arith::ShRUIOp, allo::GetIntBitOp,
+            allo::SetIntBitOp, allo::GetIntSliceOp, allo::SetIntSliceOp,
+            allo::BitReverseOp,
             // Special operations.
             func::CallOp, func::ReturnOp, arith::SelectOp, arith::ConstantOp,
             arith::TruncIOp, arith::TruncFOp, arith::ExtUIOp, arith::ExtSIOp,
             arith::ExtFOp, arith::IndexCastOp, arith::UIToFPOp, arith::SIToFPOp,
             arith::FPToSIOp, arith::FPToUIOp, arith::BitcastOp,
             allo::FixedToFloatOp, allo::FloatToFixedOp, allo::IntToFixedOp,
-            allo::FixedToIntOp, allo::FixedToFixedOp, UnrealizedConversionCastOp,
+            allo::FixedToIntOp, allo::FixedToFixedOp,
+            UnrealizedConversionCastOp,
             // Allo operations.
             allo::CreateLoopHandleOp, allo::CreateOpHandleOp, allo::AddFixedOp,
-            allo::SubFixedOp, allo::MulFixedOp, allo::DivFixedOp, allo::CmpFixedOp,
+            allo::SubFixedOp, allo::MulFixedOp, allo::DivFixedOp,
+            allo::CmpFixedOp, allo::ShLFixedOp, allo::ShRFixedOp,
             allo::MinFixedOp, allo::MaxFixedOp, allo::PrintOp>(
             [&](auto opNode) -> ResultType {
               return thisCast->visitOp(opNode, args...);
@@ -239,6 +242,8 @@ public:
   HANDLE(allo::MulFixedOp);
   HANDLE(allo::DivFixedOp);
   HANDLE(allo::CmpFixedOp);
+  HANDLE(allo::ShLFixedOp);
+  HANDLE(allo::ShRFixedOp);
   HANDLE(allo::MinFixedOp);
   HANDLE(allo::MaxFixedOp);
 

--- a/mlir/lib/Translation/EmitVivadoHLS.cpp
+++ b/mlir/lib/Translation/EmitVivadoHLS.cpp
@@ -483,6 +483,12 @@ public:
     return emitter.emitBinary(op, "/"), true;
   }
   bool visitOp(allo::CmpFixedOp op);
+  bool visitOp(allo::ShLFixedOp op) {
+    return emitter.emitBinary(op, "<<"), true;
+  }
+  bool visitOp(allo::ShRFixedOp op) {
+    return emitter.emitBinary(op, ">>"), true;
+  }
   bool visitOp(allo::MinFixedOp op) {
     return emitter.emitMaxMin(op, "min"), true;
   }

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -501,7 +501,7 @@ def test_boolean():
     s = allo.customize(kernel)
     print(s.module)
     mod = s.build()
-    np_A = np.random.randint(0, 2, size=(16)).astype(np.bool)
+    np_A = np.random.randint(0, 2, size=(16)).astype(np.bool_)
     np_B = mod(np_A)
     np.testing.assert_array_equal(np_A, np_B)
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -279,6 +279,23 @@ def test_fixed_compare():
     # FIXME: FixedType kernels cannot be lowered
 
 
+def test_fixed_shift():
+    # Example from https://docs.amd.com/r/en-US/ug1399-vitis-hls/Class-Methods-Operators-and-Data-Members
+    def kernel(A: Fixed(8, 3)[2]) -> float32[2]:
+        shl: Fixed(25, 10) = A[0] << 2
+        shr: Fixed(25, 10) = A[1] >> 2
+        res: float32[2] = 0.0
+        res[0] = float(shl)
+        res[1] = float(shr)
+        return res
+
+    s = allo.customize(kernel)
+    print(s.module)
+    mod = s.build()
+    A = np.array([5.375, 5.375], dtype=np.float32)
+    np.testing.assert_allclose(mod(A), [-10.5, 1.25], rtol=1e-5)
+
+
 def test_dynamic_type():
     def kernel[Ty]() -> int32:
         A: int32 = Ty.bits


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR tries to fix #241 by adding new shifting operations for fixed types. Reference example comes from the official [documentation](https://docs.amd.com/r/en-US/ug1399-vitis-hls/Class-Methods-Operators-and-Data-Members) of `ap_int`.

```python
def test_fixed_shift():
    # Example from 
    def kernel(A: Fixed(8, 3)[2]) -> float32[2]:
        shl: Fixed(25, 10) = A[0] << 2
        shr: Fixed(25, 10) = A[1] >> 2
        res: float32[2] = 0.0
        res[0] = float(shl)
        res[1] = float(shr)
        return res

    s = allo.customize(kernel)
    print(s.module)
    mod = s.build()
    A = np.array([5.375, 5.375], dtype=np.float32)
    np.testing.assert_allclose(mod(A), [-10.5, 1.25], rtol=1e-5)
```

```mlir
module {
  func.func @kernel(%arg0: memref<2x!allo.Fixed<8, 3>>) -> memref<2xf32> attributes {itypes = "s", otypes = "_"} {
    %0 = affine.load %arg0[0] {from = "A"} : memref<2x!allo.Fixed<8, 3>>
    %c2_i32 = arith.constant 2 : i32
    %1 = allo.shl_fixed(%0, %c2_i32) :(!allo.Fixed<8, 3>, i32) -> !allo.Fixed<8, 3>
    %2 = allo.fixed_to_fixed(%1) : !allo.Fixed<8, 3> -> !allo.Fixed<25, 10>
    %alloc = memref.alloc() {name = "shl"} : memref<!allo.Fixed<25, 10>>
    affine.store %2, %alloc[] {to = "shl"} : memref<!allo.Fixed<25, 10>>
    %3 = affine.load %arg0[1] {from = "A"} : memref<2x!allo.Fixed<8, 3>>
    %c2_i32_0 = arith.constant 2 : i32
    %4 = allo.shr_fixed(%3, %c2_i32_0) :(!allo.Fixed<8, 3>, i32) -> !allo.Fixed<8, 3>
    %5 = allo.fixed_to_fixed(%4) : !allo.Fixed<8, 3> -> !allo.Fixed<25, 10>
    %alloc_1 = memref.alloc() {name = "shr"} : memref<!allo.Fixed<25, 10>>
    affine.store %5, %alloc_1[] {to = "shr"} : memref<!allo.Fixed<25, 10>>
    %alloc_2 = memref.alloc() {name = "res"} : memref<2xf32>
    %cst = arith.constant 0.000000e+00 : f32
    linalg.fill ins(%cst : f32) outs(%alloc_2 : memref<2xf32>)
    %6 = affine.load %alloc[] {from = "shl"} : memref<!allo.Fixed<25, 10>>
    %7 = allo.fixed_to_float(%6) : !allo.Fixed<25, 10> -> f32
    affine.store %7, %alloc_2[0] {to = "res"} : memref<2xf32>
    %8 = affine.load %alloc_1[] {from = "shr"} : memref<!allo.Fixed<25, 10>>
    %9 = allo.fixed_to_float(%8) : !allo.Fixed<25, 10> -> f32
    affine.store %9, %alloc_2[1] {to = "res"} : memref<2xf32>
    return %alloc_2 : memref<2xf32>
  }
}
```

## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [x] Code is well-documented
