### PR TITLE
[Backend][AIE] Add vector support for AIE

### DIFF
--- a/tests/dataflow/test_vector_vector.py
+++ b/tests/dataflow/test_vector_vector.py
@@ -1,0 +1,48 @@
+# Copyright Allo authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import allo
+from allo.ir.types import int32, float32
+import allo.dataflow as df
+import numpy as np
+
+
+def _test_vector_vector_add():
+    Ty = int32
+    M = 1024
+
+    @df.kernel(mapping=[1])
+    def core(A: Ty[M], B: Ty[M], C: Ty[M]):
+        for i in range(M):
+            C[i] = A[i] + B[i]
+
+    top = df.build(core, target="aie")
+    A = np.random.randint(0, 100, M).astype(np.int32)
+    B = np.random.randint(0, 100, M).astype(np.int32)
+    C = np.zeros(M).astype(np.int32)
+    top(A, B, C)
+    np.testing.assert_allclose(C, A + B)
+    print("PASSED!")
+
+
+def _test_vector_vector_mul():
+    Ty = float32
+    M = 1024
+
+    @df.kernel(mapping=[1])
+    def core(A: Ty[M], B: Ty[M], C: Ty[M]):
+        for i in range(M):
+            C[i] = A[i] * B[i]
+
+    top = df.build(core, target="aie")
+    A = np.random.random(M).astype(np.float32)
+    B = np.random.random(M).astype(np.float32)
+    C = np.zeros(M).astype(np.float32)
+    top(A, B, C)
+    np.testing.assert_allclose(C, A * B, rtol=1e-5)
+    print("PASSED!")
+
+
+if __name__ == "__main__":
+    _test_vector_vector_add()
+    _test_vector_vector_mul()


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR adds examples on vector add/mul on Ryzen NPU.

### Examples ###
```python
def _test_vector_vector_mul():
    Ty = float32
    M = 1024

    @df.kernel(mapping=[1])
    def core(A: Ty[M], B: Ty[M], C: Ty[M]):
        for i in range(M):
            C[i] = A[i] * B[i]

    top = df.build(core, target="aie")
    A = np.random.random(M).astype(np.float32)
    B = np.random.random(M).astype(np.float32)
    C = np.zeros(M).astype(np.float32)
    top(A, B, C)
    np.testing.assert_allclose(C, A * B, rtol=1e-5)
    print("PASSED!")
```
```mlir
module {
  aie.device(npu1_1col) {
    %tile_shim = aie.tile(0, 0)
    %tile_mem = aie.tile(0, 1)
    %tile_comp = aie.tile(0, 2)
    aie.objectfifo @in_sh0(%tile_shim, {%tile_mem}, 2 : i32) : !aie.objectfifo<memref<1024xf32>>
    aie.objectfifo @in0(%tile_mem, {%tile_comp}, 2 : i32) : !aie.objectfifo<memref<1024xf32>>
    aie.objectfifo.link [@in_sh0] -> [@in0]([] [])
    aie.objectfifo @in_sh1(%tile_shim, {%tile_mem}, 2 : i32) : !aie.objectfifo<memref<1024xf32>>
    aie.objectfifo @in1(%tile_mem, {%tile_comp}, 2 : i32) : !aie.objectfifo<memref<1024xf32>>
    aie.objectfifo.link [@in_sh1] -> [@in1]([] [])
    aie.objectfifo @out(%tile_mem, {%tile_shim}, 2 : i32) : !aie.objectfifo<memref<1024xf32>>
    aie.objectfifo @out_sh(%tile_comp, {%tile_mem}, 2 : i32) : !aie.objectfifo<memref<1024xf32>>
    aie.objectfifo.link [@out_sh] -> [@out]([] [])
    %core_0_2 = aie.core(%tile_comp) {
      %c0 = arith.constant 0 : index
      %c1 = arith.constant 1 : index
      %c9223372036854775807 = arith.constant 9223372036854775807 : index
      scf.for %arg0 = %c0 to %c9223372036854775807 step %c1 {
        %fifo0 = aie.objectfifo.acquire @in0(Consume, 1) : !aie.objectfifosubview<memref<1024xf32>>
        %local0 = aie.objectfifo.subview.access %fifo0[0] : !aie.objectfifosubview<memref<1024xf32>> -> memref<1024xf32>
        %fifo1 = aie.objectfifo.acquire @in1(Consume, 1) : !aie.objectfifosubview<memref<1024xf32>>
        %local1 = aie.objectfifo.subview.access %fifo1[0] : !aie.objectfifosubview<memref<1024xf32>> -> memref<1024xf32>
        %fifo_out = aie.objectfifo.acquire @out_sh(Produce, 1) : !aie.objectfifosubview<memref<1024xf32>>
        %local_out = aie.objectfifo.subview.access %fifo_out[0] : !aie.objectfifosubview<memref<1024xf32>> -> memref<1024xf32>
        affine.for %arg3 = 0 to 1024 {
          %0 = affine.load %local0[%arg3] {from = "A"} : memref<1024xf32>
          %1 = affine.load %local1[%arg3] {from = "B"} : memref<1024xf32>
          %2 = arith.mulf %0, %1 : f32
          affine.store %2, %local_out[%arg3] {to = "C"} : memref<1024xf32>
        } {loop_name = "i", op_name = "S_i_0"}
        aie.objectfifo.release @in0(Consume, 1)
        aie.objectfifo.release @in1(Consume, 1)
        aie.objectfifo.release @out_sh(Produce, 1)
      }
      aie.end
    }
    aiex.runtime_sequence(%arg0: memref<1024xf32>, %arg1: memref<1024xf32>, %arg2: memref<1024xf32>) {
      aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][1, 1, 1, 1024][0, 0, 0, 1]) {id = 1 : i64, issue_token = true, metadata = @in_sh0} : memref<1024xf32>
      aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 0][1, 1, 1, 1024][0, 0, 0, 1]) {id = 1 : i64, issue_token = true, metadata = @in_sh1} : memref<1024xf32>
      aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 0, 0][1, 1, 1, 1024][0, 0, 0, 1]) {id = 0 : i64, metadata = @out} : memref<1024xf32>
      aiex.npu.dma_wait {symbol = @in_sh0}
      aiex.npu.dma_wait {symbol = @in_sh1}
      aiex.npu.dma_wait {symbol = @out}
    }
  }
}
```


## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [x] Code is well-documented
