### PR TITLE
[IR][dataflow] Add explicit stream type in MLIR

### DIFF
--- a/allo/ir/builder.py
+++ b/allo/ir/builder.py
@@ -1635,56 +1635,19 @@ class ASTTransformer(ASTBuilder):
                     return build_stmt(ctx, node.func)
                 if node.func.attr == "put":
                     stmts = build_stmts(ctx, node.args)
-                    cast = ASTTransformer.build_cast_op(
-                        ctx, stmts[0], node.args[0].dtype, node.func.value.dtype
+                    assert len(stmts) == 1, "Stream can only have one argument"
+                    allo_d.StreamPutOp(
+                        ctx.buffers[node.func.value.id].result,
+                        stmts[0].result,
+                        ip=ctx.get_ip(),
                     )
-                    if len(node.func.value.shape) == 0:
-                        affine_map = AffineMap.get(
-                            dim_count=0,
-                            symbol_count=0,
-                            exprs=[AffineConstantExpr.get(0)],
-                        )
-                        affine_attr = AffineMapAttr.get(affine_map)
-                        op = affine_d.AffineStoreOp(
-                            cast.result,
-                            ctx.buffers[node.func.value.id].result,
-                            [],
-                            affine_attr,
-                            ip=ctx.get_ip(),
-                        )
-                    else:
-                        store_tensor(
-                            cast.result,
-                            ctx.buffers[node.func.value.id].result,
-                            "put",
-                            ip=ctx.get_ip(),
-                            flatten=False,
-                        )
                     return
                 if node.func.attr == "get":
-                    # pylint: disable=no-else-return
-                    if len(node.func.value.shape) == 0:
-                        affine_map = AffineMap.get(
-                            dim_count=0,
-                            symbol_count=0,
-                            exprs=[AffineConstantExpr.get(0)],
-                        )
-                        affine_attr = AffineMapAttr.get(affine_map)
-                        return affine_d.AffineLoadOp(
-                            node.func.value.dtype.build(),
-                            ctx.buffers[node.func.value.id].result,
-                            [],
-                            affine_attr,
-                            ip=ctx.get_ip(),
-                        )
-                    else:
-                        return create_buffer(
-                            ctx.buffers[node.func.value.id].result,
-                            "get",
-                            ip=ctx.get_ip(),
-                            alloc_ip=None,
-                            flatten=False,
-                        )
+                    return allo_d.StreamGetOp(
+                        node.func.value.dtype.build(),
+                        ctx.buffers[node.func.value.id].result,
+                        ip=ctx.get_ip(),
+                    )
 
             if node.func.id in {"float", "int"}:
                 # Python-Builtin functions
@@ -1789,8 +1752,8 @@ class ASTTransformer(ASTBuilder):
                         ctx.top_func.attributes["sym_name"].value
                         + f"_{dst[0]}_{dst[1]}"
                     )
-                memref_type = node.dtype.build()
-                stream_op = memref_d.AllocOp(memref_type, [], [], ip=ctx.get_ip())
+                stream_type = allo_d.StreamType.get(node.dtype.dtype.build(), depth=2)
+                stream_op = allo_d.StreamConstructOp(stream_type, ip=ctx.get_ip())
                 stream_op.attributes["src"] = StringAttr.get(src)
                 stream_op.attributes["dst"] = StringAttr.get(dst)
                 return stream_op

--- a/allo/ir/infer.py
+++ b/allo/ir/infer.py
@@ -706,11 +706,12 @@ class TypeInferer(ASTVisitor):
                     node.func.value.shape = ctx.buffers[node.func.value.id].dtype.shape
                     node.func.value.dtype = ctx.buffers[node.func.value.id].dtype.dtype
                 elif node.func.attr == "get":
-                    # get dtype and shape inside Stream
+                    # return value
                     node.shape = ctx.buffers[node.func.value.id].dtype.shape
                     node.dtype = ctx.buffers[node.func.value.id].dtype.dtype
-                    node.func.value.shape = ctx.buffers[node.func.value.id].dtype.shape
-                    node.func.value.dtype = ctx.buffers[node.func.value.id].dtype.dtype
+                    # stream type itself
+                    node.func.value.shape = tuple()
+                    node.func.value.dtype = ctx.buffers[node.func.value.id].dtype
                 else:
                     raise RuntimeError(
                         f"Unsupported function call or attribute method {node.func.attr}"

--- a/allo/ir/types.py
+++ b/allo/ir/types.py
@@ -251,12 +251,9 @@ class Stream(AlloType):
         super().__init__(0, 0, f"stream<{dtype}>")
 
     def build(self):
-        return MemRefType.get(
-            self.shape if len(self.shape) > 0 else (1,),
-            self.dtype.build(),
-            None,
-            StringAttr.get(f"stream:{self.depth}"),
-        )
+        if len(self.shape) > 0:
+            return MemRefType.get(self.shape, self.dtype.build())
+        return self.dtype.build()
 
     def __repr__(self):
         shape = ", ".join(str(s) for s in self.shape)

--- a/allo/ir/types.py
+++ b/allo/ir/types.py
@@ -12,7 +12,6 @@ from .._mlir.ir import (
     F32Type,
     F64Type,
     MemRefType,
-    StringAttr,
 )
 from .._mlir.dialects import allo as allo_d
 from .._mlir.exceptions import DTypeError, DTypeWarning

--- a/mlir/include/allo-c/Dialect/AlloTypes.h
+++ b/mlir/include/allo-c/Dialect/AlloTypes.h
@@ -20,20 +20,29 @@ MLIR_CAPI_EXPORTED bool alloMlirTypeIsAOpHandle(MlirType type);
 MLIR_CAPI_EXPORTED MlirType alloMlirOpHandleTypeGet(MlirContext ctx);
 
 MLIR_CAPI_EXPORTED bool alloMlirTypeIsAFixedType(MlirType type);
-MLIR_CAPI_EXPORTED MlirType alloMlirFixedTypeGet(MlirContext ctx, size_t width, size_t frac);
+MLIR_CAPI_EXPORTED MlirType alloMlirFixedTypeGet(MlirContext ctx, size_t width,
+                                                 size_t frac);
 MLIR_CAPI_EXPORTED unsigned alloMlirFixedTypeGetWidth(MlirType type);
 MLIR_CAPI_EXPORTED unsigned alloMlirFixedTypeGetFrac(MlirType type);
 
 MLIR_CAPI_EXPORTED bool alloMlirTypeIsAUFixedType(MlirType type);
-MLIR_CAPI_EXPORTED MlirType alloMlirUFixedTypeGet(MlirContext ctx, size_t width, size_t frac);
+MLIR_CAPI_EXPORTED MlirType alloMlirUFixedTypeGet(MlirContext ctx, size_t width,
+                                                  size_t frac);
 MLIR_CAPI_EXPORTED unsigned alloMlirUFixedTypeGetWidth(MlirType type);
 MLIR_CAPI_EXPORTED unsigned alloMlirUFixedTypeGetFrac(MlirType type);
 
 MLIR_CAPI_EXPORTED bool alloMlirTypeIsAStructType(MlirType type);
-MLIR_CAPI_EXPORTED MlirType alloMlirStructTypeGet(MlirContext ctx, intptr_t numElements,
-                                            MlirType const *elements);
+MLIR_CAPI_EXPORTED MlirType alloMlirStructTypeGet(MlirContext ctx,
+                                                  intptr_t numElements,
+                                                  MlirType const *elements);
 MLIR_CAPI_EXPORTED MlirType alloMlirStructGetEleType(MlirType type, size_t pos);
 MLIR_CAPI_EXPORTED unsigned alloMlirStructTypeGetNumFields(MlirType type);
+
+MLIR_CAPI_EXPORTED bool alloMlirTypeIsAStreamType(MlirType type);
+MLIR_CAPI_EXPORTED MlirType alloMlirStreamTypeGet(MlirContext ctx,
+                                                  MlirType baseType,
+                                                  size_t depth);
+MLIR_CAPI_EXPORTED MlirType alloMlirStreamTypeGetBaseType(MlirType type);
 
 #ifdef __cplusplus
 }

--- a/mlir/include/allo/Dialect/AlloOps.td
+++ b/mlir/include/allo/Dialect/AlloOps.td
@@ -998,4 +998,35 @@ def IntToStructOp : Allo_Op<"int_to_struct"> {
   }];
 }
 
+//===----------------------------------------------------------------------===//
+// Stream operations
+//===----------------------------------------------------------------------===//
+
+def StreamConstructOp : Allo_Op<"stream_construct"> {
+  let summary = "Create a stream object";
+  let arguments = (ins );
+  let results = (outs Stream:$res);
+  let assemblyFormat = [{
+      `(` `)` attr-dict `:` qualified(type($res))
+  }];
+}
+
+def StreamGetOp : Allo_Op<"stream_get"> {
+  let summary = "Get an object from a stream";
+  let arguments = (ins Stream:$stream);
+  let results = (outs AnyType:$res);
+  let assemblyFormat = [{
+      `(` $stream `)` attr-dict `:` qualified(type($stream)) `->` type($res)
+  }];
+}
+
+def StreamPutOp : Allo_Op<"stream_put"> {
+  let summary = "Put an object into a stream";
+  let arguments = (ins Stream:$stream, AnyType:$data);
+  let results = (outs );
+  let assemblyFormat = [{
+      `(` $stream `,` $data `)` attr-dict `:` qualified(type($stream)) `contains` type($data)
+  }];
+}
+
 #endif // ALLO_OPS

--- a/mlir/include/allo/Dialect/AlloTypes.td
+++ b/mlir/include/allo/Dialect/AlloTypes.td
@@ -47,4 +47,11 @@ def Struct : Allo_Type<"Struct", [MemRefElementTypeInterface]> {
   bit hasCustomAssemblyFormat = 1;
 }
 
+def Stream : Allo_Type<"Stream", [MemRefElementTypeInterface]> {
+  let summary = "stream type";
+  let mnemonic = "stream";
+  let parameters = (ins AnyType:$baseType, "std::size_t":$depth);
+  let assemblyFormat = "`<` $baseType `,` $depth `>`";
+}
+
 #endif // ALLO_TYPES

--- a/mlir/include/allo/Dialect/Visitor.h
+++ b/mlir/include/allo/Dialect/Visitor.h
@@ -79,7 +79,8 @@ public:
             allo::CreateLoopHandleOp, allo::CreateOpHandleOp, allo::AddFixedOp,
             allo::SubFixedOp, allo::MulFixedOp, allo::DivFixedOp,
             allo::CmpFixedOp, allo::ShLFixedOp, allo::ShRFixedOp,
-            allo::MinFixedOp, allo::MaxFixedOp, allo::PrintOp>(
+            allo::MinFixedOp, allo::MaxFixedOp, allo::PrintOp,
+            allo::StreamConstructOp, allo::StreamGetOp, allo::StreamPutOp>(
             [&](auto opNode) -> ResultType {
               return thisCast->visitOp(opNode, args...);
             })
@@ -246,6 +247,11 @@ public:
   HANDLE(allo::ShRFixedOp);
   HANDLE(allo::MinFixedOp);
   HANDLE(allo::MaxFixedOp);
+
+  /// Stream operations.
+  HANDLE(allo::StreamConstructOp);
+  HANDLE(allo::StreamGetOp);
+  HANDLE(allo::StreamPutOp);
 
 #undef HANDLE
 };

--- a/mlir/lib/Bindings/AlloTypes.cpp
+++ b/mlir/lib/Bindings/AlloTypes.cpp
@@ -70,6 +70,7 @@ void mlir::python::populateAlloIRTypes(py::module &m) {
       .def_property_readonly(
           "frac", [](MlirType type) { return alloMlirUFixedTypeGetFrac(type); },
           "Returns the fraction of the fixed point type");
+
   mlir_type_subclass(m, "StructType", alloMlirTypeIsAStructType)
       .def_classmethod(
           "get",
@@ -91,4 +92,19 @@ void mlir::python::populateAlloIRTypes(py::module &m) {
             return types;
           },
           "Get a field type of a struct type by index.");
+
+  mlir_type_subclass(m, "StreamType", alloMlirTypeIsAStreamType)
+      .def_classmethod(
+          "get",
+          [](py::object cls, MlirType &baseType, size_t depth,
+             MlirContext ctx) {
+            return cls(alloMlirStreamTypeGet(ctx, baseType, depth));
+          },
+          "Get an instance of StreamType in given context.", py::arg("cls"),
+          py::arg("base_type"), py::arg("depth"),
+          py::arg("context") = py::none())
+      .def_property_readonly(
+          "base_type",
+          [](MlirType type) { return alloMlirStreamTypeGetBaseType(type); },
+          "Returns the base type of the stream object");
 }

--- a/mlir/lib/CAPI/Dialect/AlloTypes.cpp
+++ b/mlir/lib/CAPI/Dialect/AlloTypes.cpp
@@ -76,3 +76,15 @@ MlirType alloMlirStructGetEleType(MlirType type, size_t pos) {
 unsigned alloMlirStructTypeGetNumFields(MlirType type) {
   return unwrap(type).cast<allo::StructType>().getElementTypes().size();
 }
+
+bool alloMlirTypeIsAStreamType(MlirType type) {
+  return unwrap(type).isa<allo::StreamType>();
+}
+
+MlirType alloMlirStreamTypeGet(MlirContext ctx, MlirType baseType, size_t depth) {
+  return wrap(allo::StreamType::get(unwrap(ctx), unwrap(baseType), depth));
+}
+
+MlirType alloMlirStreamTypeGetBaseType(MlirType type) {
+  return wrap(unwrap(type).cast<allo::StreamType>().getBaseType());
+}

--- a/mlir/lib/CAPI/Dialect/AlloTypes.cpp
+++ b/mlir/lib/CAPI/Dialect/AlloTypes.cpp
@@ -81,7 +81,8 @@ bool alloMlirTypeIsAStreamType(MlirType type) {
   return unwrap(type).isa<allo::StreamType>();
 }
 
-MlirType alloMlirStreamTypeGet(MlirContext ctx, MlirType baseType, size_t depth) {
+MlirType alloMlirStreamTypeGet(MlirContext ctx, MlirType baseType,
+                               size_t depth) {
   return wrap(allo::StreamType::get(unwrap(ctx), unwrap(baseType), depth));
 }
 

--- a/tests/dataflow/test_producer_consumer.py
+++ b/tests/dataflow/test_producer_consumer.py
@@ -34,7 +34,12 @@ def consumer(B: Ty[M, N]):
 def test_producer_consumer():
     A = np.random.rand(M, N).astype(np.float32)
     B = np.zeros((M, N), dtype=np.float32)
-    top = df.build([producer, consumer])
+    top = df.build(
+        [producer, consumer],
+        target="vitis_hls",
+        mode="csim",
+        project="producer_consumer.prj",
+    )
     if hls.is_available("vitis_hls"):
         top(A, B)
         np.testing.assert_allclose(A + 1, B)


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR adds an explicit stream type (`stream<T>`) in the Allo-MLIR dialect to replace the original memref implementation. Specifically, three operations are added:
1. `allo.stream_construct()`: Create a new stream object
2. `allo.stream_get(%stream)`: Get data from a stream
3. `allo.stream_put(%stream, %data)`: Put data into a stream

The dataflow interface uses these operations to construct the IR. Now it can support declaring an array in a stream, which may be useful for DMA transmission. Also, we added codengen support to the HLS backend to generate these operations using `hls::stream`

### Examples ###
```mlir
module {
  func.func @producer_0(%arg0: memref<16x16xf32>, %arg1: !allo.stream<f32, 2>) attributes {stypes = "_g"} {
    affine.for %arg2 = 0 to 16 {
      affine.for %arg3 = 0 to 16 {
        %0 = affine.load %arg0[%arg2, %arg3] {from = "A"} : memref<16x16xf32>
        %alloc = memref.alloc() {name = "out"} : memref<f32>
        affine.store %0, %alloc[] {to = "out"} : memref<f32>
        %1 = affine.load %alloc[] {from = "out"} : memref<f32>
        allo.stream_put(%arg1, %1) : !allo.stream<f32, 2> contains f32
      } {loop_name = "j"}
    } {loop_name = "i", op_name = "S_i_j_0"}
    return
  }
  func.func @consumer_0(%arg0: memref<16x16xf32>, %arg1: !allo.stream<f32, 2>) attributes {stypes = "_g"} {
    %cst = arith.constant 1.000000e+00 : f32
    affine.for %arg2 = 0 to 16 {
      affine.for %arg3 = 0 to 16 {
        %0 = allo.stream_get(%arg1) {name = "data"} : !allo.stream<f32, 2> -> f32
        %1 = arith.addf %0, %cst : f32
        affine.store %1, %arg0[%arg2, %arg3] {to = "B"} : memref<16x16xf32>
      } {loop_name = "j"}
    } {loop_name = "i", op_name = "S_i_j_0"}
    return
  }
  func.func @top(%arg0: memref<16x16xf32>, %arg1: memref<16x16xf32>) attributes {dataflow} {
    %0 = allo.stream_construct() {dst = "consumer", src = "producer"} : !allo.stream<f32, 2>
    call @producer_0(%arg0, %0) : (memref<16x16xf32>, !allo.stream<f32, 2>) -> ()
    call @consumer_0(%arg1, %0) {last} : (memref<16x16xf32>, !allo.stream<f32, 2>) -> ()
    return
  }
}
```


## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [x] Code is well-documented
