### PR TITLE
[dataflow] Expose customize interface

### DIFF
--- a/allo/dataflow.py
+++ b/allo/dataflow.py
@@ -14,7 +14,7 @@ from ._mlir.ir import (
 )
 from ._mlir.dialects import func as func_d, allo as allo_d
 from ._mlir.passmanager import PassManager as mlir_pass_manager
-from .customize import customize
+from .customize import customize as _customize
 from .ir.utils import get_global_vars, get_all_funcs_except_top
 from .backend.aie import AIEModule
 from .ir.types import Stream
@@ -98,9 +98,10 @@ def move_stream_to_interface(s):
     return stream_info
 
 
-def remove_unused_func_ops(s, func_names):
-    for i in range(len(func_names) - 1, -1, -1):
-        func_op = s.module.body.operations[i]
+def remove_unused_func_ops(s):
+    for func_op in s.module.body.operations:
+        if not isinstance(func_op, func_d.FuncOp):
+            continue
         blocks = func_op.body.blocks
         if (
             len(blocks) == 1
@@ -125,7 +126,7 @@ def _build_top(s, stream_info):
         print("Error: failed to run MLIR lower pipeline, printing module...")
         print(s.module)
         raise e
-    remove_unused_func_ops(s, stream_info.keys())
+    remove_unused_func_ops(s)
 
     # create argument mapping
     funcs = get_all_funcs_except_top(s)
@@ -218,19 +219,25 @@ def region():
     return actual_decorator
 
 
-def build(func, target="vitis_hls", mode="csim", project="top.prj"):
+def customize(func):
     global_vars = get_global_vars(func)
-    s = customize(func, global_vars=global_vars)
+    s = _customize(func, global_vars=global_vars)
+    stream_info = move_stream_to_interface(s)
+    s = _build_top(s, stream_info)
+    print(s.module)
+    return s
+
+
+def build(func, target="vitis_hls", mode="csim", project="top.prj"):
     if target == "aie":
+        global_vars = get_global_vars(func)
+        s = _customize(func, global_vars=global_vars)
         mapping = func.mapping
-        print(s.module)
         mod = AIEModule(s.module, s.top_func_name, project, mapping)
         mod.build()
         return mod
     # FPGA backend
-    stream_info = move_stream_to_interface(s)
-    s = _build_top(s, stream_info)
-    print(s.module)
+    s = customize(func)
     hls_mod = s.build(
         target=target,
         mode=mode,

--- a/allo/dataflow.py
+++ b/allo/dataflow.py
@@ -102,7 +102,7 @@ def remove_unused_func_ops(s, func_names):
     for func_op in s.module.body.operations:
         if not (
             isinstance(func_op, func_d.FuncOp)
-            and func_op.attributes["sym_name"] in func_names
+            and func_op.attributes["sym_name"].value in func_names
         ):
             continue
         blocks = func_op.body.blocks

--- a/tests/dataflow/test_mlp.py
+++ b/tests/dataflow/test_mlp.py
@@ -71,12 +71,12 @@ def test_mlp():
         np.dot(np.maximum(np.dot(np.maximum(np.dot(X, np_W0), 0), np_W1), 0), np_W2), 0
     )
     mod = df.build(top)
-    allo_final_Y = np.zeros((BS, NUM_CLASSES), dtype=np.float32)
-    mod(X, allo_final_Y)
-    np.testing.assert_allclose(Y, allo_final_Y, rtol=1e-5)
-    print("PASSED!")
-    # hls
     if hls.is_available("vitis_hls"):
+        allo_final_Y = np.zeros((BS, NUM_CLASSES), dtype=np.float32)
+        mod(X, allo_final_Y)
+        np.testing.assert_allclose(Y, allo_final_Y, rtol=1e-5)
+        print("PASSED!")
+        # hls
         s = df.customize(top)
         s.pipeline("linear1_0:j")
         s.pipeline("linear2_0:j")

--- a/tests/dataflow/test_mlp.py
+++ b/tests/dataflow/test_mlp.py
@@ -1,0 +1,92 @@
+# Copyright Allo authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from allo.ir.types import float32
+import allo.dataflow as df
+import allo.backend.hls as hls
+import numpy as np
+
+Ty = float32
+BS = 2
+M0, M1, M2 = 256, 128, 64
+NUM_CLASSES = 2
+
+np_W0 = np.random.rand(M0, M1).astype(np.float32)
+np_W1 = np.random.rand(M1, M2).astype(np.float32)
+np_W2 = np.random.rand(M2, NUM_CLASSES).astype(np.float32)
+
+
+@df.region()
+def top():
+    Z0 = df.pipe(dtype=Ty, shape=(), depth=4)
+    Z1 = df.pipe(dtype=Ty, shape=(), depth=4)
+
+    @df.kernel(mapping=[1])
+    def linear1(X: Ty[BS, M0]):
+        # BS*M0 * M0*M1 = BS*M1
+        W0: Ty[M0, M1] = np_W0
+        for i in range(BS):
+            buf: Ty[M1] = 0
+            for k in range(M0):
+                # reorder reduction loop outside, and pipeline
+                x: Ty = X[i, k]
+                for j in range(M1):
+                    buf[j] += x * W0[k, j]
+            for j_back in range(M1):
+                # relu
+                Z0.put(max(buf[j_back], 0))
+
+    @df.kernel(mapping=[1])
+    def linear2():
+        # BS*M1 * M1*M2 = BS*M2
+        W1: Ty[M1, M2] = np_W1
+        for i in range(BS):
+            buf: Ty[M2] = 0
+            for k in range(M1):
+                # reorder reduction loop outside, and pipeline
+                x: Ty = Z0.get()
+                for j in range(M2):
+                    buf[j] += x * W1[k, j]
+            for j_back in range(M2):
+                Z1.put(max(buf[j_back], 0))
+
+    @df.kernel(mapping=[1])
+    def linear3(Z2: Ty[BS, NUM_CLASSES]):
+        # BS*M2 * M2*NUM_CLASSES = BS*NUM_CLASSES
+        W2: Ty[M2, NUM_CLASSES] = np_W2
+        for i in range(BS):
+            buf: Ty[NUM_CLASSES] = 0
+            for k in range(M2):
+                # reorder reduction loop outside, and pipeline
+                x: Ty = Z1.get()
+                for j in range(NUM_CLASSES):
+                    buf[j] += x * W2[k, j]
+            for j_back in range(NUM_CLASSES):
+                Z2[i, j_back] = max(buf[j_back], 0)
+
+
+def test_mlp():
+    X = np.random.rand(BS, M0).astype(np.float32)
+    Y = np.maximum(
+        np.dot(np.maximum(np.dot(np.maximum(np.dot(X, np_W0), 0), np_W1), 0), np_W2), 0
+    )
+    mod = df.build(top)
+    allo_final_Y = np.zeros((BS, NUM_CLASSES), dtype=np.float32)
+    mod(X, allo_final_Y)
+    np.testing.assert_allclose(Y, allo_final_Y, rtol=1e-5)
+    print("PASSED!")
+    # hls
+    if hls.is_available("vitis_hls"):
+        s = df.customize(top)
+        s.pipeline("linear1_0:j")
+        s.pipeline("linear2_0:j")
+        s.pipeline("linear3_0:j")
+        print(s.module)
+        mod = s.build(
+            target="vitis_hls", mode="csyn", project="df-mlp3-relu-on-chip.prj"
+        )
+        mod()
+
+
+if __name__ == "__main__":
+    test_mlp()

--- a/tests/dataflow/test_mlp.py
+++ b/tests/dataflow/test_mlp.py
@@ -82,10 +82,9 @@ def test_mlp():
         s.pipeline("linear2_0:j")
         s.pipeline("linear3_0:j")
         print(s.module)
-        mod = s.build(
-            target="vitis_hls", mode="csyn", project="df-mlp3-relu-on-chip.prj"
-        )
-        mod()
+        mod = s.build(target="vitis_hls", mode="hw", project="df-mlp3-relu-on-chip.prj")
+        mod(X, allo_final_Y)
+        np.testing.assert_allclose(Y, allo_final_Y, rtol=1e-5)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR exposes the `customize` interface to the dataflow programs, so users can leverage the dataflow interface with the decoupled customizations at the same time. A three-layer MLP example is also provided.

### Examples ###
```python
@df.region()
def top():
    ...

s = df.customize(top)
s.pipeline("linear1_0:j")
print(s.module)
mod = s.build(target="vitis_hls", mode="hw", project="df-mlp3-relu-on-chip.prj")
```

## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [x] Code is well-documented
