### PR TITLE
[dataflow][backend] Add IO analysis pass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,4 @@ docs/source/gallery
 log
 
 _tmp
+*.txt

--- a/allo/backend/hls.py
+++ b/allo/backend/hls.py
@@ -182,7 +182,6 @@ class HLSModule:
                 generate_input_output_buffers(
                     self.module,
                     top_func_name,
-                    func_args,
                     flatten=True,
                     mappings=mappings,
                 )

--- a/allo/backend/hls.py
+++ b/allo/backend/hls.py
@@ -178,8 +178,13 @@ class HLSModule:
                 else:
                     mappings = None
 
+                assert func_args is not None, "Need to specify func_args"
                 generate_input_output_buffers(
-                    self.module, top_func_name, flatten=True, mappings=mappings
+                    self.module,
+                    top_func_name,
+                    func_args,
+                    flatten=True,
+                    mappings=mappings,
                 )
 
                 # TODO: Fix dataflow!

--- a/allo/backend/hls.py
+++ b/allo/backend/hls.py
@@ -1,6 +1,6 @@
 # Copyright Allo authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=consider-using-with, no-name-in-module, unused-argument
+# pylint: disable=consider-using-with, no-name-in-module
 
 import os
 import re

--- a/allo/dataflow.py
+++ b/allo/dataflow.py
@@ -234,7 +234,6 @@ def customize(func):
     s = _customize(func, global_vars=global_vars)
     stream_info = move_stream_to_interface(s)
     s = _build_top(s, stream_info)
-    print(s.module)
     return s
 
 

--- a/allo/dataflow.py
+++ b/allo/dataflow.py
@@ -116,6 +116,7 @@ def remove_unused_func_ops(s, func_names):
             and len(blocks[0].operations) == 1
             and blocks[0].operations[0].name == "func.return"
         ):
+            s.func_args.pop(func_op.attributes["sym_name"].value)
             func_op.erase()
 
 

--- a/allo/dataflow.py
+++ b/allo/dataflow.py
@@ -41,6 +41,7 @@ def array(element, shape):
 def move_stream_to_interface(s):
     stream_info = {}
     funcs = get_all_funcs_except_top(s)
+    new_func_args = s.func_args.copy()
 
     for func in funcs:
         func_name = func.attributes["sym_name"].value
@@ -50,6 +51,7 @@ def move_stream_to_interface(s):
         in_types = func.attributes["function_type"].value.inputs
         out_types = func.attributes["function_type"].value.results
         s_type_str = "_" * len(in_types)
+        new_arg_names = new_func_args[func_name].copy()
         for op in func.entry_block.operations:
             if isinstance(op, allo_d.StreamConstructOp):
                 stream_ops.append(op)
@@ -65,8 +67,10 @@ def move_stream_to_interface(s):
                         raise ValueError("Stream is not used correctly.")
                 stream_info[func_name].append((stream_name, direction))
                 s_type_str += direction[0]
+                new_arg_names.append(stream_name)
         # create new func to update arguments
         in_types += stream_types
+        new_func_args[func_name] = new_arg_names
         with s.module.context, Location.unknown():
             func_type = FunctionType.get(in_types, out_types)
             new_func = func_d.FuncOp(
@@ -95,6 +99,7 @@ def move_stream_to_interface(s):
             for i, arg in enumerate(func.arguments):
                 arg.replace_all_uses_with(new_func.arguments[i])
             func.operation.erase()
+    s.func_args = new_func_args
     return stream_info
 
 
@@ -145,6 +150,7 @@ def _build_top(s, stream_info):
                 if arg_name not in used_args:
                     used_args[arg_name] = len(input_types)
                     input_types.append(arg.type)
+                    s.func_args[s.top_func_name].append(arg_name)
                 arg_mapping[func_name].append(used_args[arg_name])
     # update top function
     top_func = None

--- a/allo/passes.py
+++ b/allo/passes.py
@@ -352,12 +352,14 @@ def analyze_arg_load_store(mod, func_args):
     res = {}
     for func_name, arg_names in func_args.items():
         func = find_func_in_module(mod, func_name)
-        assert func is not None, f"Function {func_name} not found in module"
+        if func is None:
+            # some transformations have been done
+            continue
         func_res = analyze_arg_load_store_in_func(func, arg_names)
         for key, io_type in func_res.items():
             if io_type == "func":
-                continue
-            if key in res and io_type != res[key]:
+                res[key] = "func"
+            elif key in res and io_type != res[key]:
                 res[key] = "both"
             else:
                 res[key] = io_type

--- a/allo/passes.py
+++ b/allo/passes.py
@@ -352,6 +352,7 @@ def analyze_arg_load_store(mod, func_args):
     res = {}
     for func_name, arg_names in func_args.items():
         func = find_func_in_module(mod, func_name)
+        assert func is not None, f"Function {func_name} not found in module"
         func_res = analyze_arg_load_store_in_func(func, arg_names)
         for key, io_type in func_res.items():
             if io_type == "func":

--- a/allo/passes.py
+++ b/allo/passes.py
@@ -108,9 +108,7 @@ def lower_linalg_and_attach_names(module):
                         cnt_loop_nests += 1
 
 
-def generate_input_output_buffers(
-    module, top_func_name, func_args, flatten=False, mappings=None
-):
+def generate_input_output_buffers(module, top_func_name, flatten=False, mappings=None):
     results = {"inputs": [], "outputs": []}
     top_func = find_func_in_module(module, top_func_name)
 
@@ -128,7 +126,7 @@ def generate_input_output_buffers(
                 load_func_names.append("")
                 continue
 
-            if load_store_mapping[func_args[top_func_name][idx]] in {"in", "both"}:
+            if load_store_mapping[top_func_name][idx] in {"in", "both"}:
                 func_name = f"load_buf{idx}"
                 load_func_names.append(func_name)
                 wrap_data_movement(
@@ -175,7 +173,7 @@ def generate_input_output_buffers(
                 if not isinstance(arg.type, MemRefType):
                     # scalar
                     continue
-                if load_store_mapping[func_args[top_func_name][idx]] in {"out", "both"}:
+                if load_store_mapping[top_func_name][idx] in {"out", "both"}:
                     ip = InsertionPoint(top_func)
                     func_name = f"store_res{idx}"
                     store_func_names.append(func_name)
@@ -229,7 +227,7 @@ def generate_input_output_buffers(
                     new_in_types.append(arg.type)
 
                 # Build CallOp for buffer loading
-                if load_store_mapping[func_args[top_func_name][idx]] in {
+                if load_store_mapping[top_func_name][idx] in {
                     "in",
                     "both",
                 }:
@@ -296,7 +294,7 @@ def generate_input_output_buffers(
             for idx, arg in enumerate(top_func.arguments):
                 if not isinstance(arg.type, MemRefType):
                     continue
-                if load_store_mapping[func_args[top_func_name][idx]] in {"out", "both"}:
+                if load_store_mapping[top_func_name][idx] in {"out", "both"}:
                     func_name = f"store_res{idx}"
                     func_d.CallOp(
                         [],

--- a/allo/passes.py
+++ b/allo/passes.py
@@ -172,6 +172,9 @@ def generate_input_output_buffers(
 
         else:
             for idx, arg in enumerate(top_func.arguments):
+                if not isinstance(arg.type, MemRefType):
+                    # scalar
+                    continue
                 if load_store_mapping[func_args[top_func_name][idx]] in {"out", "both"}:
                     ip = InsertionPoint(top_func)
                     func_name = f"store_res{idx}"
@@ -340,7 +343,8 @@ def analyze_arg_load_store_in_func(func, arg_names=[]):
             elif isinstance(use.owner, func_d.CallOp):
                 res[arg_name] = "func"
             else:
-                raise ValueError(f"Unsupported operation: {type(use.owner)}")
+                # return op
+                pass
     return res
 
 

--- a/allo/passes.py
+++ b/allo/passes.py
@@ -108,6 +108,7 @@ def lower_linalg_and_attach_names(module):
                         cnt_loop_nests += 1
 
 
+# pylint: disable=too-many-branches
 def generate_input_output_buffers(module, top_func_name, flatten=False, mappings=None):
     results = {"inputs": [], "outputs": []}
     top_func = find_func_in_module(module, top_func_name)

--- a/allo/passes.py
+++ b/allo/passes.py
@@ -310,6 +310,7 @@ def generate_input_output_buffers(
     return results
 
 
+# pylint: disable=dangerous-default-value
 def analyze_arg_load_store_in_func(func, arg_names=[]):
     res = {}
     for idx, arg in enumerate(func.arguments):
@@ -345,16 +346,16 @@ def analyze_arg_load_store_in_func(func, arg_names=[]):
 
 def analyze_arg_load_store(mod, func_args):
     res = {}
-    for func_name in func_args:
+    for func_name, arg_names in func_args.items():
         func = find_func_in_module(mod, func_name)
-        func_res = analyze_arg_load_store_in_func(func, func_args[func_name])
-        for key in func_res:
-            if func_res[key] == "func":
+        func_res = analyze_arg_load_store_in_func(func, arg_names)
+        for key, io_type in func_res.items():
+            if io_type == "func":
                 continue
-            if key in res and func_res[key] != res[key]:
+            if key in res and io_type != res[key]:
                 res[key] = "both"
             else:
-                res[key] = func_res[key]
+                res[key] = io_type
     return res
 
 

--- a/tests/dataflow/test_mlp.py
+++ b/tests/dataflow/test_mlp.py
@@ -113,8 +113,8 @@ def test_mlp():
         np.dot(np.maximum(np.dot(np.maximum(np.dot(X, np_W0), 0), np_W1), 0), np_W2), 0
     )
     s = df.customize(top)
-    schedule_linear(s, 1, factor=4)
-    schedule_linear(s, 2, factor=4)
+    schedule_linear(s, 1, factor=8)
+    schedule_linear(s, 2, factor=8)
     schedule_linear(s, 3, factor=1)
     print(s.module)
     if hls.is_available("vitis_hls"):
@@ -124,7 +124,7 @@ def test_mlp():
         np.testing.assert_allclose(Y, allo_final_Y, rtol=1e-5)
         print("PASSED CSIM!")
         # hls
-        mod = s.build(target="vitis_hls", mode="hw_emu", project="df-mlp3-relu-unroll-new.prj")
+        mod = s.build(target="vitis_hls", mode="hw", project="df-mlp3-relu-unroll-new.prj")
         mod(X, allo_final_Y)
         np.testing.assert_allclose(Y, allo_final_Y, rtol=1e-5)
         print("PASSED HW!")

--- a/tests/dataflow/test_mlp.py
+++ b/tests/dataflow/test_mlp.py
@@ -124,7 +124,9 @@ def test_mlp():
         np.testing.assert_allclose(Y, allo_final_Y, rtol=1e-5)
         print("PASSED CSIM!")
         # hls
-        mod = s.build(target="vitis_hls", mode="hw", project="df-mlp3-relu-unroll-new.prj")
+        mod = s.build(
+            target="vitis_hls", mode="hw", project="df-mlp3-relu-unroll-new.prj"
+        )
         mod(X, allo_final_Y)
         np.testing.assert_allclose(Y, allo_final_Y, rtol=1e-5)
         print("PASSED HW!")

--- a/tests/dataflow/test_mlp.py
+++ b/tests/dataflow/test_mlp.py
@@ -1,6 +1,7 @@
 # Copyright Allo authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 from allo.ir.types import float32
 from allo.ir.utils import MockBuffer
 import allo.dataflow as df
@@ -12,15 +13,37 @@ BS = 2
 M0, M1, M2 = 256, 128, 64
 NUM_CLASSES = 2
 
-np_W0 = np.random.rand(M0, M1).astype(np.float32)
-np_W1 = np.random.rand(M1, M2).astype(np.float32)
-np_W2 = np.random.rand(M2, NUM_CLASSES).astype(np.float32)
+# class NeuralNetwork(nn.Module):
+#     def __init__(self, input_size, num_classes):
+#         super(NeuralNetwork, self).__init__()
+#         self.layer1 = nn.Linear(input_size, 128)
+#         self.relu = nn.ReLU()
+#         self.layer2 = nn.Linear(128, 64)
+#         self.output_layer = nn.Linear(64, num_classes)
+
+#     def forward(self, x):
+#         out = self.relu(self.layer1(x))
+#         out = self.relu(self.layer2(out))
+#         out = self.output_layer(out)  # No softmax here as it's included in nn.CrossEntropyLoss
+#         return out
+
+if os.path.exists("np_W0.txt"):
+    np_W0 = np.loadtxt("np_W0.txt", dtype=np.float32)
+    np_W1 = np.loadtxt("np_W1.txt", dtype=np.float32)
+    np_W2 = np.loadtxt("np_W2.txt", dtype=np.float32)
+else:
+    np_W0 = np.random.rand(M0, M1).astype(np.float32)
+    np_W1 = np.random.rand(M1, M2).astype(np.float32)
+    np_W2 = np.random.rand(M2, NUM_CLASSES).astype(np.float32)
+    np.savetxt("np_W0.txt", np_W0, fmt="%f")
+    np.savetxt("np_W1.txt", np_W1, fmt="%f")
+    np.savetxt("np_W2.txt", np_W2, fmt="%f")
 
 
 @df.region()
 def top():
-    Z0 = df.pipe(dtype=Ty, shape=(), depth=4)
-    Z1 = df.pipe(dtype=Ty, shape=(), depth=4)
+    Z0 = df.pipe(dtype=Ty, shape=(), depth=BS * M1)
+    Z1 = df.pipe(dtype=Ty, shape=(), depth=BS * M2)
 
     @df.kernel(mapping=[1])
     def linear1(X: Ty[BS, M0]):
@@ -99,11 +122,12 @@ def test_mlp():
         mod = s.build(target="vitis_hls", mode="csim", project="top.prj")
         mod(X, allo_final_Y)
         np.testing.assert_allclose(Y, allo_final_Y, rtol=1e-5)
-        print("PASSED!")
+        print("PASSED CSIM!")
         # hls
-        mod = s.build(target="vitis_hls", mode="hw", project="df-mlp3-relu-unroll.prj")
+        mod = s.build(target="vitis_hls", mode="hw_emu", project="df-mlp3-relu-unroll-new.prj")
         mod(X, allo_final_Y)
         np.testing.assert_allclose(Y, allo_final_Y, rtol=1e-5)
+        print("PASSED HW!")
 
 
 if __name__ == "__main__":

--- a/tests/dataflow/test_wrap_movement.py
+++ b/tests/dataflow/test_wrap_movement.py
@@ -1,7 +1,6 @@
 # Copyright Allo authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import allo
 from allo.ir.types import float32
 import allo.dataflow as df
 import allo.backend.hls as hls
@@ -39,7 +38,7 @@ def test_wrap_void():
         in module
     )
     assert (
-        f"func.func @store_res(%arg0: memref<32x32xf32>, %arg1: memref<1024xf32>)"
+        f"func.func @store_res2(%arg0: memref<32x32xf32>, %arg1: memref<1024xf32>)"
         in module
     )
     # Buffer Allocation
@@ -50,7 +49,7 @@ def test_wrap_void():
         in module
     )
     assert (
-        f"call @store_res(%alloc_1, %arg2) : (memref<32x32xf32>, memref<1024xf32>) -> ()"
+        f"call @store_res2(%alloc_1, %arg2) : (memref<32x32xf32>, memref<1024xf32>) -> ()"
         in module
     )
     print("Data Movement (Flatten) Passed!")
@@ -65,7 +64,7 @@ def test_wrap_void():
         in module
     )
     assert (
-        f"func.func @store_res(%arg0: memref<32x32xf32>, %arg1: memref<32x32xf32>)"
+        f"func.func @store_res2(%arg0: memref<32x32xf32>, %arg1: memref<32x32xf32>)"
         in module
     )
     # Buffer Allocation
@@ -76,7 +75,7 @@ def test_wrap_void():
         in module
     )
     assert (
-        f"call @store_res(%alloc_1, %arg2) : (memref<32x32xf32>, memref<32x32xf32>) -> ()"
+        f"call @store_res2(%alloc_1, %arg2) : (memref<32x32xf32>, memref<32x32xf32>) -> ()"
         in module
     )
     print("Data Movement (Non-flatten) Passed!")

--- a/tests/dataflow/test_wrap_movement.py
+++ b/tests/dataflow/test_wrap_movement.py
@@ -30,7 +30,7 @@ def test_wrap_void():
 
     flatten = True
     s1 = df.customize(top)
-    generate_input_output_buffers(s1.module, "top", flatten=flatten)
+    generate_input_output_buffers(s1.module, "top", s1.func_args, flatten=flatten)
     module = str(s1.module)
     # Movement Function Generation
     assert (
@@ -56,7 +56,7 @@ def test_wrap_void():
 
     flatten = False
     s2 = df.customize(top)
-    generate_input_output_buffers(s2.module, "top", flatten=flatten)
+    generate_input_output_buffers(s2.module, "top", s2.func_args, flatten=flatten)
     module = str(s2.module)
     # Movement Function Generation
     assert (

--- a/tests/dataflow/test_wrap_movement.py
+++ b/tests/dataflow/test_wrap_movement.py
@@ -30,7 +30,7 @@ def test_wrap_void():
 
     flatten = True
     s1 = df.customize(top)
-    generate_input_output_buffers(s1.module, "top", s1.func_args, flatten=flatten)
+    generate_input_output_buffers(s1.module, "top", flatten=flatten)
     module = str(s1.module)
     # Movement Function Generation
     assert (
@@ -56,7 +56,7 @@ def test_wrap_void():
 
     flatten = False
     s2 = df.customize(top)
-    generate_input_output_buffers(s2.module, "top", s2.func_args, flatten=flatten)
+    generate_input_output_buffers(s2.module, "top", flatten=flatten)
     module = str(s2.module)
     # Movement Function Generation
     assert (

--- a/tests/pytorch/test_linear.py
+++ b/tests/pytorch/test_linear.py
@@ -83,4 +83,5 @@ def test_int8_linear():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    # pytest.main([__file__])
+    test_int8_linear()

--- a/tests/test_unify.py
+++ b/tests/test_unify.py
@@ -116,6 +116,8 @@ def test_nested_loop():
                 A[i] -= 1
 
     unified = unify(f1, f2, 1)
+    hls_mod = allo.HLSModule(unified, "f1_f2_unified", "vivado_hls")
+    assert "void f1_f2_unified" in hls_mod.hls_code
     llvm_mod = allo.LLVMModule(unified, "f1_f2_unified")
     allo_A = np.zeros((L), dtype=np.int8)
     allo_B = np.array([5, 6, 7, 8], dtype=np.int8)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -96,5 +96,4 @@ def test_analyze_load_store():
 
 
 if __name__ == "__main__":
-    # pytest.main([__file__])
-    test_analyze_load_store()
+    pytest.main([__file__])

--- a/tests/test_vhls.py
+++ b/tests/test_vhls.py
@@ -20,7 +20,7 @@ def test_io_buffer_gemm(flatten):
     s = allo.customize(gemm)
     print(s.module)
     allo.passes.generate_input_output_buffers(
-        s.module, s.top_func_name, flatten=flatten
+        s.module, s.top_func_name, s.func_args, flatten=flatten
     )
     print(s.module)
     mod = s.build()
@@ -200,7 +200,7 @@ def test_wrap_nonvoid(flatten):
         return B
 
     s = allo.customize(matrix_add)
-    generate_input_output_buffers(s.module, "matrix_add", flatten=flatten)
+    generate_input_output_buffers(s.module, "matrix_add", s.func_args, flatten=flatten)
     module = str(s.module)
 
     if flatten:

--- a/tests/test_vhls.py
+++ b/tests/test_vhls.py
@@ -20,7 +20,7 @@ def test_io_buffer_gemm(flatten):
     s = allo.customize(gemm)
     print(s.module)
     allo.passes.generate_input_output_buffers(
-        s.module, s.top_func_name, s.func_args, flatten=flatten
+        s.module, s.top_func_name, flatten=flatten
     )
     print(s.module)
     mod = s.build()
@@ -200,7 +200,7 @@ def test_wrap_nonvoid(flatten):
         return B
 
     s = allo.customize(matrix_add)
-    generate_input_output_buffers(s.module, "matrix_add", s.func_args, flatten=flatten)
+    generate_input_output_buffers(s.module, "matrix_add", flatten=flatten)
     module = str(s.module)
 
     if flatten:


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR fixes the issue of incorrect dataflow construction introduced by #263. Specifically, we need to analyze the arguments in the top-level function and check whether they have read/write operations. This is done by a sequential traversal of the IR through the `FuncOp`.

### Examples ###
```python
def kernel(A: int32[32], B: int32[32], C: int32[32]):
    for i in range(32):
        C[i] = A[i] + B[i]

def rw_kernel(D: int32[32]):
    for i in range(32):
        D[i] = D[i] + 1

def top2(A: int32[32], B: int32[32], C: int32[32], D: int32[32]):
    kernel(A, B, C)
    write_kernel(A)
    rw_kernel(D)

s = allo.customize(top2)
res = analyze_arg_load_store(s.module)
```
```
{'kernel': ['in', 'in', 'out'], 'write_kernel': ['out'], 'rw_kernel': ['both'], 'top2': ['both', 'in', 'out', 'both']}
```

## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [x] Code is well-documented
