### PR TITLE
[IR] Fix dangling meta_if matching

### DIFF
--- a/allo/ir/builder.py
+++ b/allo/ir/builder.py
@@ -2338,25 +2338,38 @@ class ASTTransformer(ASTBuilder):
             cond = ASTResolver.resolve_constant(node.items[0].context_expr.args[0], ctx)
             if node.items[0].context_expr.func.attr == "meta_if":
                 final_cond = cond
-                ctx.meta_if_stack.append(final_cond)
+                if len(ctx.meta_if_stack) > ctx.with_scope_level:
+                    ctx.meta_if_stack[ctx.with_scope_level].append(final_cond)
+                else:
+                    ctx.meta_if_stack.append([final_cond])
             else:  # meta_elif
-                assert len(ctx.meta_if_stack) > 0, "Unmatched allo.meta_elif()"
-                if ctx.meta_if_stack[-1]:  # previous `if` has already satisfied
-                    ctx.meta_if_stack.pop()
-                    ctx.meta_if_stack.append(True)
+                assert (
+                    len(ctx.meta_if_stack[ctx.with_scope_level]) > 0
+                ), "Unmatched allo.meta_elif()"
+                if ctx.meta_if_stack[ctx.with_scope_level][
+                    -1
+                ]:  # previous `if` has already satisfied
+                    ctx.meta_if_stack[ctx.with_scope_level].pop()
+                    ctx.meta_if_stack[ctx.with_scope_level].append(True)
                     final_cond = False
                 else:
-                    ctx.meta_if_stack.pop()
-                    ctx.meta_if_stack.append(cond)
+                    ctx.meta_if_stack[ctx.with_scope_level].pop()
+                    ctx.meta_if_stack[ctx.with_scope_level].append(cond)
                     final_cond = cond
         elif node.items[0].context_expr.func.attr == "meta_else":
-            assert len(ctx.meta_if_stack) > 0, "Unmatched allo.meta_else()"
-            final_cond = not ctx.meta_if_stack[-1]
-            ctx.meta_if_stack.pop()
+            assert (
+                len(ctx.meta_if_stack[ctx.with_scope_level]) > 0
+            ), "Unmatched allo.meta_else()"
+            final_cond = not ctx.meta_if_stack[ctx.with_scope_level][-1]
+            ctx.meta_if_stack[ctx.with_scope_level].pop()
         else:
             raise RuntimeError("Unsupported meta function")
         if final_cond:
+            ctx.with_scope_level += 1
             stmts = build_stmts(ctx, node.body)
+            # clear inner context
+            ctx.meta_if_stack = ctx.meta_if_stack[: ctx.with_scope_level]
+            ctx.with_scope_level -= 1
             return stmts[-1]
         return "WithStatementSkipped"
 
@@ -2380,5 +2393,13 @@ build_stmt = ASTTransformer()
 def build_stmts(ctx, stmts):
     results = []
     for stmt in stmts:
-        results.append(build_stmt(ctx, stmt))
+        # results.append(build_stmt(ctx, stmt))
+        try:
+            results.append(build_stmt(ctx, stmt))
+        except Exception as e:
+            raise e
+            # raise RuntimeError(
+            #     f"\033[91m[Error]\033[0m Line {stmt.lineno}: {ast.unparse(stmt)}"
+            #     + f" {e}"
+            # )
     return results

--- a/allo/ir/use_def.py
+++ b/allo/ir/use_def.py
@@ -364,9 +364,17 @@ class UseDefChain(ast.NodeVisitor):
         ), "Only support one argument for `allo.meta_if/elif/else()`"
         # Compile-time comparison
         if node.items[0].context_expr.func.attr in {"meta_if", "meta_elif"}:
-            cond = ASTResolver.resolve_constant(
-                node.items[0].context_expr.args[0], self.global_vars
-            )
+            try:
+                # pylint: disable=eval-used
+                cond = eval(
+                    compile(
+                        ast.Expression(node.items[0].context_expr.args[0]), "", "eval"
+                    ),
+                    self.global_vars,
+                )
+            # pylint: disable=broad-exception-caught
+            except Exception:
+                return None
             if node.items[0].context_expr.func.attr == "meta_if":
                 final_cond = cond
                 if len(self.meta_if_stack) > self.with_scope_level:

--- a/allo/ir/use_def.py
+++ b/allo/ir/use_def.py
@@ -53,6 +53,7 @@ class UseDefChain(ast.NodeVisitor):
         self.func_name2id = {}
         self.func_id = None
         # Used for metaprogramming
+        self.with_scope_level = 0
         self.meta_if_stack = []
 
     def __getitem__(self, key):
@@ -363,40 +364,45 @@ class UseDefChain(ast.NodeVisitor):
         ), "Only support one argument for `allo.meta_if/elif/else()`"
         # Compile-time comparison
         if node.items[0].context_expr.func.attr in {"meta_if", "meta_elif"}:
-            try:
-                # pylint: disable=eval-used
-                cond = eval(
-                    compile(
-                        ast.Expression(node.items[0].context_expr.args[0]), "", "eval"
-                    ),
-                    self.global_vars,
-                )
-            # pylint: disable=broad-exception-caught
-            except Exception:
-                return None
+            cond = ASTResolver.resolve_constant(
+                node.items[0].context_expr.args[0], self.global_vars
+            )
             if node.items[0].context_expr.func.attr == "meta_if":
                 final_cond = cond
-                self.meta_if_stack.append(final_cond)
+                if len(self.meta_if_stack) > self.with_scope_level:
+                    self.meta_if_stack[self.with_scope_level].append(final_cond)
+                else:
+                    self.meta_if_stack.append([final_cond])
             else:  # meta_elif
-                assert len(self.meta_if_stack) > 0, "Unmatched allo.meta_elif()"
-                if self.meta_if_stack[-1]:  # previous `if` has already satisfied
-                    self.meta_if_stack.pop()
-                    self.meta_if_stack.append(True)
+                assert (
+                    len(self.meta_if_stack[self.with_scope_level]) > 0
+                ), "Unmatched allo.meta_elif()"
+                if self.meta_if_stack[self.with_scope_level][
+                    -1
+                ]:  # previous `if` has already satisfied
+                    self.meta_if_stack[self.with_scope_level].pop()
+                    self.meta_if_stack[self.with_scope_level].append(True)
                     final_cond = False
                 else:
-                    self.meta_if_stack.pop()
-                    self.meta_if_stack.append(cond)
+                    self.meta_if_stack[self.with_scope_level].pop()
+                    self.meta_if_stack[self.with_scope_level].append(cond)
                     final_cond = cond
         elif node.items[0].context_expr.func.attr == "meta_else":
-            assert len(self.meta_if_stack) > 0, "Unmatched allo.meta_else()"
-            final_cond = not self.meta_if_stack[-1]
-            self.meta_if_stack.pop()
+            assert (
+                len(self.meta_if_stack[self.with_scope_level]) > 0
+            ), "Unmatched allo.meta_else()"
+            final_cond = not self.meta_if_stack[self.with_scope_level][-1]
+            self.meta_if_stack[self.with_scope_level].pop()
         else:
             raise RuntimeError("Unsupported meta function")
         if final_cond:
+            self.with_scope_level += 1
             res = []
             for stmt in node.body:
                 res.append(self.visit(stmt))
+            # clear inner context
+            self.meta_if_stack = self.meta_if_stack[: self.with_scope_level]
+            self.with_scope_level -= 1
             return res[-1]
         return None
 

--- a/allo/ir/visitor.py
+++ b/allo/ir/visitor.py
@@ -63,6 +63,7 @@ class ASTContext:
         # libraries for external IPs
         self.ext_libs = []
         # metaprogramming
+        self.with_scope_level = 0
         self.meta_if_stack = []
         self.has_return = False
 

--- a/tests/dataflow/test_daisy_chain_gemm.py
+++ b/tests/dataflow/test_daisy_chain_gemm.py
@@ -42,9 +42,6 @@ def top():
                 fifo_A[i - 1, 0].put(a[8 * (i - 1) : 8 * i])
                 with allo.meta_if(i < M):
                     L2_A[i + 1].put(a)
-                # TODO: Fix meta matching
-                with allo.meta_else():
-                    pass
         with allo.meta_elif(i == 0):
             # j > 0, the first row
             for k in range(K):
@@ -52,8 +49,6 @@ def top():
                 fifo_B[0, j - 1].put(b[8 * (j - 1) : 8 * j])
                 with allo.meta_if(j < N):
                     L2_B[j + 1].put(b)
-                with allo.meta_else():
-                    pass
         # main body
         with allo.meta_else():
             c: int16 = 0
@@ -63,12 +58,8 @@ def top():
                 c += a * b
                 with allo.meta_if(j < N):
                     fifo_A[i - 1, j].put(a)
-                with allo.meta_else():
-                    pass
                 with allo.meta_if(i < M):
                     fifo_B[i, j - 1].put(b)
-                with allo.meta_else():
-                    pass
             C[i - 1, j - 1] = c
 
 

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -105,9 +105,12 @@ def test_meta_if():
 
     def top[Ty, M, N]() -> "Ty[M, N]":
         with allo.meta_if(Ty == int8):
-            return kernel_int8[M, N]()
+            with allo.meta_if(M == N):
+                return kernel_int8[M, N]()
         with allo.meta_elif(Ty == float32):
-            return kernel_float32[M, N]()
+            with allo.meta_if(M == N):
+                return kernel_float32[M, N]()
+        # test whether the following meta_else will be incorrectly matched
         with allo.meta_else():
             with allo.meta_if(M + 2 == N + 2):
                 A = kernel_int32[M * 2, N * 2]()


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR fixes the dangling `meta_if` matching issue. Previously, each `meta_if` needs to be accompanied with a `meta_else`. Otherwise, different levels of `meta_if/else` will mix together causing problems.

### Examples ###
For example, in the following case, according to the Python convention, the second `meta_else` should match the first `meta_if` based on indention.
```python
with allo.meta_if(...):
    with allo.meta_if(...):
        ...
with allo.meta_else():
    ...
```


## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [x] Code is well-documented
