### PR TITLE
[debug] Support source code error traceback

### DIFF
--- a/allo/ir/builder.py
+++ b/allo/ir/builder.py
@@ -2398,6 +2398,7 @@ def build_stmts(ctx, stmts):
     for stmt in stmts:
         try:
             results.append(build_stmt(ctx, stmt))
+        # pylint: disable=broad-exception-caught
         except Exception as e:
             print(f"{traceback.format_exc()}")
             print_error_message(str(e), stmt, ctx.top_func_tree)

--- a/allo/ir/builder.py
+++ b/allo/ir/builder.py
@@ -5,6 +5,8 @@
 
 import gc
 import ast
+import sys
+import traceback
 import numpy as np
 from .._mlir.ir import (
     Module,
@@ -59,6 +61,7 @@ from .visitor import ASTVisitor
 from .symbol_resolver import ASTResolver
 from ..backend.ip import IPModule
 from ..utils import get_mlir_dtype_from_str
+from ..logging import print_error_message
 
 
 class ASTBuilder(ASTVisitor):
@@ -2393,13 +2396,10 @@ build_stmt = ASTTransformer()
 def build_stmts(ctx, stmts):
     results = []
     for stmt in stmts:
-        # results.append(build_stmt(ctx, stmt))
         try:
             results.append(build_stmt(ctx, stmt))
         except Exception as e:
-            raise e
-            # raise RuntimeError(
-            #     f"\033[91m[Error]\033[0m Line {stmt.lineno}: {ast.unparse(stmt)}"
-            #     + f" {e}"
-            # )
+            print(f"{traceback.format_exc()}")
+            print_error_message(str(e), stmt, ctx.tree)
+            sys.exit(1)
     return results

--- a/allo/ir/builder.py
+++ b/allo/ir/builder.py
@@ -227,7 +227,7 @@ class ASTTransformer(ASTBuilder):
             # The step is a value of same type but required to be positive.
             if step is not None and step <= 0:
                 raise RuntimeError(
-                    "Step in for loop range should be positive, got: ", step
+                    f"Step in for loop range should be positive, got: {step}"
                 )
             step = build_stmt(ctx, args[2] if len(args) >= 3 else ast.Constant(1))
             lb_expr = ASTTransformer.build_cast_op(

--- a/allo/ir/builder.py
+++ b/allo/ir/builder.py
@@ -2400,6 +2400,6 @@ def build_stmts(ctx, stmts):
             results.append(build_stmt(ctx, stmt))
         except Exception as e:
             print(f"{traceback.format_exc()}")
-            print_error_message(str(e), stmt, ctx.tree)
+            print_error_message(str(e), stmt, ctx.top_func_tree)
             sys.exit(1)
     return results

--- a/allo/ir/infer.py
+++ b/allo/ir/infer.py
@@ -78,14 +78,14 @@ class TypeInferer(ASTVisitor):
                 stream_dtype = Stream(base_type, base_shape)
                 shape = tuple()
                 return stream_dtype, shape
-            assert dtype is not None, f"Unsupported type {node.value.id}"
+            assert dtype is not None, f"Unsupported type `{node.value.id}`"
             size = node.slice.value if isinstance(node.slice, ast.Index) else node.slice
             elts = size.elts if isinstance(size, ast.Tuple) else [size]
             shape = tuple(ASTResolver.resolve_constant(x, ctx) for x in elts)
             return dtype, shape
         if isinstance(node, ast.Name):
             dtype = ASTResolver.resolve(node, ctx.global_vars)
-            assert dtype is not None, f"Unsupported type {node.id}"
+            assert dtype is not None, f"Unsupported type `{node.id}`"
             return dtype, tuple()
         if isinstance(node, ast.Call):
             dtype = TypeInferer.visit_call_type(ctx, node)
@@ -115,9 +115,9 @@ class TypeInferer(ASTVisitor):
                 node.dtype = Index()
                 node.shape = tuple()
             else:
-                raise RuntimeError(f"Unsupported global variable {node.id}")
+                raise RuntimeError(f"Unsupported global variable `{node.id}`")
             return node
-        raise RuntimeError(f"Unsupported Name {node.id}")
+        raise RuntimeError(f"Unsupported Name `{node.id}`")
 
     @staticmethod
     def visit_Constant(ctx, node):
@@ -1093,6 +1093,6 @@ def visit_stmts(ctx, stmts):
             results.append(visit_stmt(ctx, stmt))
         except Exception as e:
             print(f"{traceback.format_exc()}")
-            print_error_message(str(e), stmt, ctx.tree)
+            print_error_message(str(e), stmt, ctx.top_func_tree)
             sys.exit(1)
     return results

--- a/allo/ir/infer.py
+++ b/allo/ir/infer.py
@@ -1091,6 +1091,7 @@ def visit_stmts(ctx, stmts):
     for stmt in stmts:
         try:
             results.append(visit_stmt(ctx, stmt))
+        # pylint: disable=broad-exception-caught
         except Exception as e:
             print(f"{traceback.format_exc()}")
             print_error_message(str(e), stmt, ctx.top_func_tree)

--- a/allo/ir/utils.py
+++ b/allo/ir/utils.py
@@ -77,8 +77,17 @@ def get_kwarg(kwargs, name):
     raise RuntimeError(f"Keyword argument {name} not found")
 
 
-def parse_ast(src, verbose=False):
+def _adjust_line_numbers(node, offset):
+    for child in ast.walk(node):
+        if hasattr(child, "lineno"):
+            child.lineno += offset
+        if hasattr(child, "end_lineno"):
+            child.end_lineno += offset
+
+
+def parse_ast(src, starting_line_no=1, verbose=False):
     tree = ast.parse(src)
+    _adjust_line_numbers(tree, starting_line_no - 1)
     if verbose:
         print(src)
         try:

--- a/allo/ir/visitor.py
+++ b/allo/ir/visitor.py
@@ -81,12 +81,12 @@ class ASTContext:
             self.tree,
             self.global_vars.copy(),
             self.mlir_ctx,
+            self.inst,
             self.func_args,
             self.enable_tensor,
             self.verbose,
         )
         ctx.func_id = self.func_id
-        ctx.inst = self.inst
         ctx.func_name2id = self.func_name2id
         ctx.enable_tensor = self.enable_tensor
         ctx.verbose = self.verbose

--- a/allo/ir/visitor.py
+++ b/allo/ir/visitor.py
@@ -33,10 +33,19 @@ class AffineScopeGuard:
 
 class ASTContext:
     def __init__(
-        self, global_vars, mlir_ctx, func_args=None, enable_tensor=False, verbose=False
+        self,
+        tree,
+        global_vars,
+        mlir_ctx,
+        inst=None,
+        func_args=None,
+        enable_tensor=False,
+        verbose=False,
     ):
         self.ip_stack = []
         self.buffers = {}
+        # ast tree
+        self.tree = tree
         self.top_func = None
         self.top_func_tree = None
         self.global_vars = global_vars
@@ -46,7 +55,7 @@ class ASTContext:
         self.func_args = {} if func_args is None else func_args
         self.func_id = None
         # instantiation of a template function
-        self.inst = None
+        self.inst = inst
         self.func_name2id = {}
         # used for subfunction call
         self.call_args = []
@@ -69,6 +78,7 @@ class ASTContext:
 
     def copy(self):
         ctx = ASTContext(
+            self.tree,
             self.global_vars.copy(),
             self.mlir_ctx,
             self.func_args,

--- a/allo/logging.py
+++ b/allo/logging.py
@@ -20,7 +20,7 @@ def print_error_message(error, stmt, tree):
     code_lines = source_code.splitlines()[target_idx - 5 : target_idx + 5]
     highlighted_code = []
     for idx, line in enumerate(code_lines, start=line_number - start_offset):
-        line = line.replace("[", "\[")
+        line = line.replace("[", r"\[")
         if idx == line_number:
             highlighted_code.append(f"[bold red]{idx:4}: {line}[/bold red]")
         else:

--- a/allo/logging.py
+++ b/allo/logging.py
@@ -1,0 +1,39 @@
+# Copyright Allo authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import ast
+from rich.console import Console
+from rich.text import Text
+from rich.panel import Panel
+
+
+def print_error_message(error, stmt, tree):
+    console = Console()
+
+    # Display only 10 lines of the source code, and highlight the error line
+    source_code = ast.unparse(tree)
+    source_stmt = ast.unparse(stmt)
+    strip_lines = [line.strip() for line in source_code.splitlines()]
+    target_idx = strip_lines.index(source_stmt)
+    line_number = stmt.lineno
+    code_lines = source_code.splitlines()[target_idx - 5 : target_idx + 5]
+    highlighted_code = []
+    for idx, line in enumerate(code_lines, start=line_number - 5):
+        if idx == line_number:
+            highlighted_code.append(f"[bold red]{idx:4}: {line}[/bold red]")
+        else:
+            highlighted_code.append(f"{idx:4}: {line}")
+
+    # Format the error message with the traceback
+    error_message = Text.from_markup(f"[bold red]Error:[/bold red] {error}")
+    line_info = Text(f"Line: {line_number}", style="bold yellow")
+    full_error = Panel(
+        "\n".join(highlighted_code),
+        title=f"[bold red]Traceback (most recent call last):[/]\n[bold yellow]{line_info}",
+        subtitle="Source Code",
+        border_style="red",
+    )
+
+    # Print the error message and highlighted code
+    console.print(error_message)
+    console.print(full_error)

--- a/allo/logging.py
+++ b/allo/logging.py
@@ -16,9 +16,11 @@ def print_error_message(error, stmt, tree):
     strip_lines = [line.strip() for line in source_code.splitlines()]
     target_idx = strip_lines.index(source_stmt)
     line_number = stmt.lineno
+    start_offset = min(target_idx, 5)
     code_lines = source_code.splitlines()[target_idx - 5 : target_idx + 5]
     highlighted_code = []
-    for idx, line in enumerate(code_lines, start=line_number - 5):
+    for idx, line in enumerate(code_lines, start=line_number - start_offset):
+        line = line.replace("[", "\[")
         if idx == line_number:
             highlighted_code.append(f"[bold red]{idx:4}: {line}[/bold red]")
         else:

--- a/allo/logging.py
+++ b/allo/logging.py
@@ -14,7 +14,7 @@ def print_error_message(error, stmt, tree):
     source_code = ast.unparse(tree)
     source_stmt = ast.unparse(stmt)
     strip_lines = [line.strip() for line in source_code.splitlines()]
-    target_idx = strip_lines.index(source_stmt)
+    target_idx = strip_lines.index(source_stmt.splitlines()[0].strip())
     line_number = stmt.lineno
     start_offset = min(target_idx, 5)
     code_lines = source_code.splitlines()[target_idx - 5 : target_idx + 5]

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ packaging
 psutil
 ninja
 sympy
+rich

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -173,7 +173,7 @@ def test_negative_step_for():
         for i in range(N - 1, -1, -1):
             y[i] = x[i]
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(SystemExit):
         s = allo.customize(kernel)
 
 
@@ -631,13 +631,13 @@ def test_build_none_return():
     def kernel6(A: int32[32]) -> int32:
         return
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(SystemExit):
         s6 = allo.customize(kernel6)
 
     def kernel7(A: int32[32]) -> int32:
         pass
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(SystemExit):
         s7 = allo.customize(kernel7)
 
 

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -637,7 +637,7 @@ def test_build_none_return():
     def kernel7(A: int32[32]) -> int32:
         pass
 
-    with pytest.raises(SystemExit):
+    with pytest.raises(RuntimeError):
         s7 = allo.customize(kernel7)
 
 

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -64,7 +64,7 @@ def test_linalg_matmul():
     def kernel3(A: int32[M, K], B: int32[K, N]) -> int32[M, N]:
         return allo.matmul_error(A, B)
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(SystemExit):
         s = allo.customize(kernel3)
 
     def kernel4(A: int32[M, K], B: int32[K, N]) -> int32[M, N]:
@@ -161,7 +161,7 @@ def test_linalg_batch_matmul_only3D():
         D = allo.bmm(A, B)
         return D
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(SystemExit):
         allo.customize(kernel)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -87,7 +87,7 @@ def test_analyze_load_store():
     assert res["top2"] == ["both", "in", "out", "both"]
 
 
-def _test_traceback():
+def test_traceback():
     def kernel(A: int32[32]):
         B: undefined_type = 1
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -87,5 +87,29 @@ def test_analyze_load_store():
     assert res["top2"] == ["both", "in", "out", "both"]
 
 
+def _test_traceback():
+    def kernel(A: int32[32]):
+        B: undefined_type = 1
+
+    def kernel2(A: int32[32]):
+        kernel(A)
+
+    with pytest.raises(SystemExit):
+        s = allo.customize(kernel2)
+
+    def long_kernel(A: int32[32]):
+        for i in range(32):
+            A[i] = i
+        for i in range(32):
+            A[i] = A[i] + 1
+            for j in range(32):
+                A[j] = A[j] * 2
+                for k in range(32):
+                    A[k] = A[z] + 1
+
+    with pytest.raises(SystemExit):
+        s = allo.customize(long_kernel)
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
The current Allo implementation does not trace back to the source kernel when encountering an error, which only shows the Python traceback inside the IR builder, making debugging extremely hard. This PR adds traceback to the Allo kernel source code, enabling better error identification and debugging.

### Examples ###
```python
def kernel(A: int32[32]):
    B: undefined_type = 1

def kernel2(A: int32[32]):
    kernel(A)

s = allo.customize(kernel2)
```

The following traceback does not only give the error inside the builder/visitor, but also gives the error from the source code.
```
Traceback (most recent call last):
  File "/scratch/users/hc676/allo/allo/ir/infer.py", line 1093, in visit_stmts
    results.append(visit_stmt(ctx, stmt))
                   ^^^^^^^^^^^^^^^^^^^^^
  File "/scratch/users/hc676/allo/allo/ir/visitor.py", line 122, in __call__
    res = method(ctx, node)
          ^^^^^^^^^^^^^^^^^
  File "/scratch/users/hc676/allo/allo/ir/infer.py", line 521, in visit_AnnAssign
    target_dtype, target_shape = TypeInferer.visit_type_hint(ctx, node.annotation)
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/scratch/users/hc676/allo/allo/ir/infer.py", line 88, in visit_type_hint
    assert dtype is not None, f"Unsupported type `{node.id}`"
AssertionError: Unsupported type `undefined_type`

Error: Unsupported type `undefined_type`
╭──────────────────────────────────────────────────────────────────────── Traceback (most recent call last): Line: 92 ─────────────────────────────────────────────────────────────────────────╮
│   91: def kernel(A: int32[32]):                                                                                                                                                              │
│   92:     B: undefined_type = 1                                                                                                                                                              │
╰──────────────────────────────────────────────────────────────────────────────────────── Source Code ─────────────────────────────────────────────────────────────────────────────────────────╯
```


## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [x] Code is well-documented
