### PR TITLE
[Pass] Fix load/store data from/to a partitioned buffer in top-level

### DIFF
--- a/allo/ir/transform.py
+++ b/allo/ir/transform.py
@@ -401,7 +401,7 @@ def wrap_data_movement(arg, ip, func_name, from_memory, flatten, mapping):
             (np.prod(shape),), MemRefType(arg.type).element_type
         )
 
-    type_buf = MemRefType.get(shape, MemRefType(arg.type).element_type)
+    type_buf = MemRefType(arg.type)
     input_types = [type_flatten, type_buf] if from_memory else [type_buf, type_flatten]
 
     # Build Function

--- a/allo/passes.py
+++ b/allo/passes.py
@@ -205,7 +205,10 @@ def generate_input_output_buffers(module, top_func_name, flatten=False, mappings
                 # Build AllocOP for buffer
                 alloc_op = memref_d.AllocOp(
                     MemRefType.get(
-                        MemRefType(arg.type).shape, MemRefType(arg.type).element_type
+                        MemRefType(arg.type).shape,
+                        MemRefType(arg.type).element_type,
+                        MemRefType(arg.type).layout,
+                        MemRefType(arg.type).memory_space,
                     ),
                     [],
                     [],
@@ -255,7 +258,10 @@ def generate_input_output_buffers(module, top_func_name, flatten=False, mappings
                 # Build AllocOP for buffer
                 if not flatten:
                     store_memref = MemRefType.get(
-                        MemRefType(arg.type).shape, MemRefType(arg.type).element_type
+                        MemRefType(arg.type).shape,
+                        MemRefType(arg.type).element_type,
+                        MemRefType(arg.type).layout,
+                        MemRefType(arg.type).memory_space,
                     )
                 else:
                     store_memref = MemRefType.get(

--- a/allo/passes.py
+++ b/allo/passes.py
@@ -204,12 +204,7 @@ def generate_input_output_buffers(module, top_func_name, flatten=False, mappings
 
                 # Build AllocOP for buffer
                 alloc_op = memref_d.AllocOp(
-                    MemRefType.get(
-                        MemRefType(arg.type).shape,
-                        MemRefType(arg.type).element_type,
-                        MemRefType(arg.type).layout,
-                        MemRefType(arg.type).memory_space,
-                    ),
+                    MemRefType(arg.type),
                     [],
                     [],
                 )
@@ -257,12 +252,7 @@ def generate_input_output_buffers(module, top_func_name, flatten=False, mappings
 
                 # Build AllocOP for buffer
                 if not flatten:
-                    store_memref = MemRefType.get(
-                        MemRefType(arg.type).shape,
-                        MemRefType(arg.type).element_type,
-                        MemRefType(arg.type).layout,
-                        MemRefType(arg.type).memory_space,
-                    )
+                    store_memref = MemRefType(arg.type)
                 else:
                     store_memref = MemRefType.get(
                         (np.prod(MemRefType(arg.type).shape),),


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
When #263 wraps the data loading/storing logic as a function, it does not attach the layout (whether a buffer is partitioned or not) to its function argument and definition, causing the buffer mismatch issue. This PR explicitly attaches the layout to the memref to resolve this issue.


### Examples ###
```python
import allo
from allo.ir.types import float32

concrete_type, L, D, O = float32, 1024, 1024, 1024

def kernel_linear_layer[Ty, L, D, O](X: "Ty[L, D]", W: "Ty[D, O]", B: "Ty[O]", Z: "Ty[L, O]"):
    for i, j in allo.grid(L, O, name="linear_compute"):
        Z[i, j] = B[j]
        for k in allo.reduction(D, name="inner_prod"):
            Z[i, j] += X[i, k] * W[k, j]

s_linear = allo.customize(kernel_linear_layer, instantiate=[concrete_type, L, D, O] )
s_linear.partition(s_linear.X, partition_type=2, dim=2, factor=32)
s_linear.partition(s_linear.W, partition_type=2, dim=1, factor=32)
s_linear.unroll("k", factor=32)
s_linear.pipeline("k")

def top[Ty, L, D, O](X: "Ty[L, D]", W: "Ty[D, O]", B: "Ty[O]", Z: "Ty[L, O]"):
    kernel_linear_layer[float32, 1024, 1024, 1024](X, W, B, Z)

s = allo.customize(top, instantiate=[concrete_type, L, D, O])
s.compose(s_linear)
print(s.module)
mod = s.build("vitis_hls", mode="csyn", project="test.prj")
mod()

```


## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [x] Code is well-documented
