### PR TITLE
[Backend] Support specifying target device and frequency

### DIFF
--- a/allo/backend/config.py
+++ b/allo/backend/config.py
@@ -1,0 +1,29 @@
+# Copyright Allo authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+DEFAULT_CONFIG = {
+    "device": "u280",
+    "frequency": 300,
+    "mode": "csim|csynth|cosim|impl",
+}
+
+PART_NUMBER = {
+    # Reference: https://github.com/Xilinx/XilinxBoardStore/tree/2022.2
+    # Embedded
+    "ultra96v2": "xczu3eg-sbva484-1-i",
+    "pynqz2": "xc7z020clg400-1",
+    "zedboard": "xc7z020clg484-1",
+    # Zynq
+    "zcu102": "xczu9eg-ffvb1156-2-e",
+    "zcu104": "xczu7ev-ffvc1156-2-e",
+    "zcu106": "xczu7ev-ffvc1156-2-e",
+    "zcu111": "xczu28dr-ffvg1517-2-e",
+    # Versal
+    "vck190": "xcvc1902-vsva2197-2MP-e-S",
+    "vhk158": "xcvh1582-vsva3697-2MP-e-S-es1",
+    # Alveo
+    # https://github.com/Xilinx/XilinxBoardStore/pull/434
+    "u200": "xcu200-fsgd2104-2-e",
+    "u250": "xcu250-figd2104-2L-e",
+    "u280": "xcu280-fsvh2892-2L-e",
+}

--- a/allo/backend/hls.py
+++ b/allo/backend/hls.py
@@ -265,6 +265,7 @@ class HLSModule:
                     self.top_func_name,
                     path + "makefile_gen/description.json",
                     dst_path,
+                    frequency=configs["frequency"],
                 )
                 generate_makefile(dst_path, project, self.platform)
                 for postfix in ("us_alveo", "versal_alveo", "versal_ps", "zynqmp"):
@@ -317,6 +318,7 @@ class HLSModule:
                     self.top_func_name,
                     path + "makefile_gen/description.json",
                     dst_path,
+                    frequency=configs["frequency"],
                 )
                 self.args = []
                 generate_makefile(dst_path, project, self.platform)

--- a/allo/backend/hls.py
+++ b/allo/backend/hls.py
@@ -174,18 +174,17 @@ class HLSModule:
         self.project = project
         self.platform = platform
         self.ext_libs = [] if ext_libs is None else ext_libs
+        if configs is not None:
+            new_configs = DEFAULT_CONFIG
+            new_configs.update(configs)
+            configs = new_configs
+        else:
+            configs = DEFAULT_CONFIG
         with Context() as ctx, Location.unknown():
             allo_d.register_dialect(ctx)
             self.module = Module.parse(str(mod), ctx)
             self.func = find_func_in_module(self.module, top_func_name)
             if platform == "vitis_hls":
-                if configs is not None:
-                    new_configs = DEFAULT_CONFIG
-                    new_configs.update(configs)
-                    configs = new_configs
-                else:
-                    configs = DEFAULT_CONFIG
-
                 assert func_args is not None, "Need to specify func_args"
                 generate_input_output_buffers(
                     self.module,

--- a/allo/backend/hls.py
+++ b/allo/backend/hls.py
@@ -231,10 +231,13 @@ class HLSModule:
             )
             pm.run(self.module.operation)
         buf = io.StringIO()
-        if platform == "tapa":
-            allo_d.emit_thls(self.module, buf)
-        else:
-            allo_d.emit_vhls(self.module, buf)
+        match platform:
+            case "tapa":
+                allo_d.emit_thls(self.module, buf)
+            case "intel_hls":
+                allo_d.emit_ihls(self.module, buf)
+            case _:
+                allo_d.emit_vhls(self.module, buf)
         buf.seek(0)
         self.hls_code = buf.read()
         if project is not None:

--- a/allo/backend/hls.py
+++ b/allo/backend/hls.py
@@ -15,6 +15,7 @@ from .._mlir.ir import (
 )
 from .._mlir.passmanager import PassManager
 
+from .config import DEFAULT_CONFIG, PART_NUMBER
 from .vitis import (
     codegen_host,
     postprocess_hls_code,
@@ -58,54 +59,52 @@ def run_process(cmd, pattern=None):
     return out.decode("utf-8")
 
 
-def copy_build_files(top, project, mode, platform="vivado_hls", script=None):
-    # make the project folder and copy files
-    os.makedirs(project, exist_ok=True)
-    path = os.path.dirname(__file__)
-    path = os.path.join(path, "../harness/")
-    if platform in {"vivado_hls", "vitis_hls", "tapa"}:
-        os.system("cp " + path + f"{platform.split('_')[0]}/* " + project)
-        if platform == "tapa":
-            return "success"
-        if mode == "debug":
-            mode = "csyn"
-        elif mode == "sw_emu":
-            mode = "csim"
-        elif mode == "hw_emu":
-            mode = "cosim"
-        else:
-            mode = "csyn"
-        if mode != "custom":
-            removed_mode = ["csyn", "csim", "cosim", "impl"]
-            selected_mode = mode.split("|")
-            for s_mode in selected_mode:
-                removed_mode.remove(s_mode)
+def codegen_tcl(top, configs):
+    out_str = """# Copyright Allo authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
 
-            new_tcl = ""
-            with open(
-                os.path.join(project, "run.tcl"), "r", encoding="utf-8"
-            ) as tcl_file:
-                for line in tcl_file:
-                    if "set_top" in line:
-                        line = "set_top " + top + "\n"
-                    # pylint: disable=too-many-boolean-expressions
-                    if (
-                        ("csim_design" in line and "csim" in removed_mode)
-                        or ("csynth_design" in line and "csyn" in removed_mode)
-                        or ("cosim_design" in line and "cosim" in removed_mode)
-                        or ("export_design" in line and "impl" in removed_mode)
-                    ):
-                        new_tcl += "#" + line
-                    else:
-                        new_tcl += line
-        else:  # custom tcl
-            print("Warning: custom Tcl file is used, and target mode becomes invalid.")
-            new_tcl = script
+#=============================================================================
+# run.tcl 
+#=============================================================================
+# Project name
+set hls_prj out.prj
 
-        with open(os.path.join(project, "run.tcl"), "w", encoding="utf-8") as tcl_file:
-            tcl_file.write(new_tcl)
-        return "success"
-    raise RuntimeError("Not implemented")
+# Open/reset the project
+open_project ${hls_prj} -reset
+
+open_solution -reset solution1 -flow_target vivado
+
+"""
+    out_str += f'# Top function of the design is "{top}"\n'
+    out_str += f"set_top {top}\n"
+    out_str += """
+# Add design and testbench files
+add_files kernel.cpp
+add_files -tb host.cpp -cflags "-std=gnu++0x"
+open_solution "solution1"
+"""
+    device = configs["device"]
+    frequency = configs["frequency"]
+    mode = configs["mode"]
+    if device not in PART_NUMBER:
+        raise RuntimeError(
+            f"Device {device} not supported. Available devices: {list(PART_NUMBER.keys())}"
+        )
+    out_str += f"\n# Target device is {device}\n"
+    out_str += f"set_part {{{PART_NUMBER[device]}}}\n\n"
+    out_str += "# Target frequency\n"
+    out_str += f"create_clock -period {1000 / frequency:.2f}\n\n"
+    out_str += "# Run HLS\n"
+    if "csim" in mode or "sw_emu" in mode:
+        out_str += "csim_design -O\n"
+    if "csyn" in mode or "debug" in mode:
+        out_str += "csynth_design\n"
+    if "cosim" in mode or "hw_emu" in mode:
+        out_str += "cosim_design\n"
+    if "impl" in mode or "hw" in mode:
+        out_str += "export_design -flow impl\n"
+    out_str += "\nexit\n"
+    return out_str
 
 
 def copy_ext_libs(ext_libs, project):
@@ -181,16 +180,18 @@ class HLSModule:
             self.func = find_func_in_module(self.module, top_func_name)
             if platform == "vitis_hls":
                 if configs is not None:
-                    mappings = configs.get("mappings", None)
+                    new_configs = DEFAULT_CONFIG
+                    new_configs.update(configs)
+                    configs = new_configs
                 else:
-                    mappings = None
+                    configs = DEFAULT_CONFIG
 
                 assert func_args is not None, "Need to specify func_args"
                 generate_input_output_buffers(
                     self.module,
                     top_func_name,
                     flatten=True,
-                    mappings=mappings,
+                    mappings=configs.get("mappings", None),
                 )
 
                 # TODO: Fix dataflow!
@@ -238,7 +239,13 @@ class HLSModule:
         self.hls_code = buf.read()
         if project is not None:
             assert mode is not None, "mode must be specified when project is specified"
-            copy_build_files(self.top_func_name, project, mode, platform=platform)
+            os.makedirs(project, exist_ok=True)
+            path = os.path.dirname(__file__)
+            path = os.path.join(path, "../harness/")
+            if platform in {"vivado_hls", "vitis_hls", "tapa"}:
+                os.system("cp " + path + f"{platform.split('_')[0]}/* " + project)
+                with open(f"{project}/run.tcl", "w", encoding="utf-8") as outfile:
+                    outfile.write(codegen_tcl(top_func_name, configs))
             copy_ext_libs(ext_libs, project)
             if self.platform == "vitis_hls":
                 assert self.mode in {

--- a/allo/backend/vitis.py
+++ b/allo/backend/vitis.py
@@ -384,12 +384,12 @@ def postprocess_hls_code(hls_code, top=None):
     return out_str
 
 
-def generate_description_file(top, src_path, dst_path):
+def generate_description_file(top, src_path, dst_path, frequency):
     with open(src_path, "r", encoding="utf-8") as f:
         desc = f.read()
     desc = desc.replace("top", top)
     desc = json.loads(desc)
-    desc["containers"][0]["ldclflags"] += "  --kernel_frequency 300"
+    desc["containers"][0]["ldclflags"] += f"  --kernel_frequency {frequency}"
     with open(dst_path, "w", encoding="utf-8") as outfile:
         json.dump(desc, outfile, indent=4)
 

--- a/allo/customize.py
+++ b/allo/customize.py
@@ -877,22 +877,18 @@ class Schedule:
                 top_func_name=self.top_func_name,
                 ext_libs=self.ext_libs,
             )
-        if target in {"vhls", "vivado_hls", "vitis_hls"}:
+        if target in {"vhls", "vivado_hls", "vitis_hls", "tapa"}:
+            match target:
+                case "vitis_hls":
+                    platform = "vitis_hls"
+                case "tapa":
+                    platform = "tapa"
+                case _:
+                    platform = "vivado_hls"
             return HLSModule(
                 self.module,
                 top_func_name=self.top_func_name,
-                platform="vivado_hls" if target != "vitis_hls" else "vitis_hls",
-                mode=mode,
-                project=project,
-                ext_libs=self.ext_libs,
-                configs=configs,
-                func_args=self.func_args,
-            )
-        if target == "tapa":
-            return HLSModule(
-                self.module,
-                top_func_name=self.top_func_name,
-                platform="tapa",
+                platform=platform,
                 mode=mode,
                 project=project,
                 ext_libs=self.ext_libs,

--- a/allo/customize.py
+++ b/allo/customize.py
@@ -877,12 +877,14 @@ class Schedule:
                 top_func_name=self.top_func_name,
                 ext_libs=self.ext_libs,
             )
-        if target in {"vhls", "vivado_hls", "vitis_hls", "tapa"}:
+        if target in {"vhls", "vivado_hls", "vitis_hls", "tapa", "ihls"}:
             match target:
                 case "vitis_hls":
                     platform = "vitis_hls"
                 case "tapa":
                     platform = "tapa"
+                case "ihls":
+                    platform = "intel_hls"
                 case _:
                     platform = "vivado_hls"
             return HLSModule(

--- a/allo/dataflow.py
+++ b/allo/dataflow.py
@@ -238,7 +238,7 @@ def customize(func):
     return s
 
 
-def build(func, target="vitis_hls", mode="csim", project="top.prj"):
+def build(func, target="vitis_hls", mode="csim", project="top.prj", configs=None):
     if target == "aie":
         global_vars = get_global_vars(func)
         s = _customize(func, global_vars=global_vars)
@@ -252,5 +252,6 @@ def build(func, target="vitis_hls", mode="csim", project="top.prj"):
         target=target,
         mode=mode,
         project=project,
+        configs=configs,
     )
     return hls_mod

--- a/tests/test_vhls.py
+++ b/tests/test_vhls.py
@@ -268,5 +268,15 @@ def test_wrap_nonvoid(flatten):
     print("Passed!")
 
 
+def test_ihls():
+    def top(A: int32[1]) -> int32[1]:
+        A[0] = A[0] + 1
+        return A
+
+    s = allo.customize(top)
+    mod = s.build(target="ihls")
+    assert "h.single_task<Top>([=]() [[intel::kernel_args_restrict]]" in mod.hls_code
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR fixes #274. Users can now specify the target device and frequency by passing in additional configuration in the build function:

```python
s.build(target="vitis_hls", configs={"device": "u250", "frequency": 300})
```

This PR also includes the Intel HLS backend (#206) with the updated LLVM.

## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [x] Code is well-documented
