### PR TITLE
[IR] Attach uint attributes

### DIFF
--- a/mlir/lib/Translation/EmitVivadoHLS.cpp
+++ b/mlir/lib/Translation/EmitVivadoHLS.cpp
@@ -1768,7 +1768,9 @@ void ModuleEmitter::emitBitcast(arith::BitcastOp op) {
 
 template <typename CastOpType> void ModuleEmitter::emitCast(CastOpType op) {
   indent();
-  emitValue(op.getResult());
+  Value result = op.getResult();
+  fixUnsignedType(result, op->hasAttr("unsigned"));
+  emitValue(result);
   os << " = ";
   emitValue(op.getOperand());
   os << ";";

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -43,6 +43,21 @@ def test_int32_float32_casting():
     assert mod(1) == kernel(1)
 
 
+def test_uint():
+    def casting():
+        buf1: UInt(17)[16, 16] = 0
+        buf2: float32[16, 16]
+
+        for i, j in allo.grid(16, 16):
+            buf2[i, j] = float(buf1[i, j] + buf1[j, i])
+
+    s = allo.customize(casting)
+    mod = s.build(target="vhls")
+    code = mod.hls_code
+    assert "ap_uint<17>" in code and "ap_uint<18>" in code
+    assert "ap_int<" not in code
+
+
 def test_index_fixed_casting():
     def test_one_cast(fixed):
         def kernel(a: index) -> float32:


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR attaches the missing unsigned attributes to the MLIR operations in order to preserve the signedness when generating the backend HLS code.

### Examples ###
```python
def casting():
    buf1: UInt(15)[16, 16] = 0
    buf2: float32[16, 16]

    for i, j in allo.grid(16, 16):
        buf2[i, j] = float(buf1[i, j] + buf1[j, i])

s = allo.customize(casting)
print(s.module)
code = s.build(target="vhls")
print(code)
```
```cpp
void casting(

) {     // L2
  ap_uint<15> buf1[16][16];     // L5
  for (int v1 = 0; v1 < 16; v1++) {     // L6
    for (int v2 = 0; v2 < 16; v2++) {   // L6
      buf1[v1][v2] = 0; // L6
    }
  }
  float buf2[16][16];   // L7
  l_S_i_j_0_i: for (int i = 0; i < 16; i++) {   // L8
    l_j: for (int j = 0; j < 16; j++) { // L9
      ap_uint<15> v6 = buf1[i][j];      // L10
      ap_uint<15> v7 = buf1[j][i];      // L11
      uint16_t v8 = v6; // L12
      uint16_t v9 = v7; // L13
      uint16_t v10 = v8 + v9;   // L14
      float v11 = v10;  // L15
      buf2[i][j] = v11; // L16
    }
  }
}
```

## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [x] Code is well-documented
