### PR TITLE
[IR] Add bitcast operation

### DIFF
--- a/allo/ir/builder.py
+++ b/allo/ir/builder.py
@@ -1775,6 +1775,16 @@ class ASTTransformer(ASTBuilder):
                         [],
                         ip=ctx.get_ip(),
                     )
+                if node.func.attr == "bitcast":
+                    val = build_stmt(ctx, node.func.value)
+                    op = arith_d.BitcastOp(
+                        node.dtype.build(),
+                        val.result,
+                        ip=ctx.get_ip(),
+                    )
+                    if isinstance(node.func.value.dtype, UInt) or (node.dtype, UInt):
+                        op.attributes["unsigned"] = UnitAttr.get()
+                    return op
 
             if node.func.id in {"float", "int"}:
                 # Python-Builtin functions

--- a/allo/ir/infer.py
+++ b/allo/ir/infer.py
@@ -780,22 +780,15 @@ class TypeInferer(ASTVisitor):
                     node.func.value.dtype = ctx.buffers[vid].dtype
                 elif node.func.attr == "bitcast":
                     visit_stmt(ctx, node.func.value)
-                    vid = (
-                        node.func.value.id
-                        if isinstance(node.func.value, ast.Name)
-                        else node.func.value.value.id
-                    )
                     # single-element operation
                     node.shape = tuple()
-                    node.func.value.shape = ctx.buffers[vid].shape
-                    node.func.value.dtype = ctx.buffers[vid].dtype
-                    if isinstance(ctx.buffers[vid].dtype, (UInt, Int)):
-                        node.dtype = Float(ctx.buffers[vid].dtype.bits)
+                    if isinstance(node.func.value.dtype, (UInt, Int)):
+                        node.dtype = Float(node.func.value.dtype.bits)
                     else:
-                        # casting between signed and unsigned types in C/C++ 
+                        # casting between signed and unsigned types in C/C++
                         # does not modify the underlying bit representation,
                         # but only the interpretation.
-                        node.dtype = UInt(ctx.buffers[vid].dtype.bits)
+                        node.dtype = UInt(node.func.value.dtype.bits)
                 else:
                     raise RuntimeError(
                         f"Unsupported function call or attribute method `.{node.func.attr}`"
@@ -845,6 +838,7 @@ class TypeInferer(ASTVisitor):
                 # No argument
                 if fn_name == "get_pid":
                     node.shape = (tuple(), tuple())
+                    # pylint: disable=redefined-variable-type
                     node.dtype = (Index(), Index())
                 else:
                     node.shape = None

--- a/allo/ir/infer.py
+++ b/allo/ir/infer.py
@@ -792,6 +792,9 @@ class TypeInferer(ASTVisitor):
                     if isinstance(ctx.buffers[vid].dtype, (UInt, Int)):
                         node.dtype = Float(ctx.buffers[vid].dtype.bits)
                     else:
+                        # casting between signed and unsigned types in C/C++ 
+                        # does not modify the underlying bit representation,
+                        # but only the interpretation.
                         node.dtype = UInt(ctx.buffers[vid].dtype.bits)
                 else:
                     raise RuntimeError(

--- a/mlir/lib/Translation/EmitTapaHLS.cpp
+++ b/mlir/lib/Translation/EmitTapaHLS.cpp
@@ -1793,6 +1793,10 @@ void ModuleEmitter::emitConstant(arith::ConstantOp op) {
 
 void ModuleEmitter::emitBitcast(arith::BitcastOp op) {
   indent();
+  Value result = op.getResult();
+  fixUnsignedType(result, op->hasAttr("unsigned"));
+  Value operand = op.getOperand();
+  fixUnsignedType(operand, op->hasAttr("unsigned"));
   emitValue(op.getResult());
   os << ";\n";
   indent();

--- a/mlir/lib/Translation/EmitVivadoHLS.cpp
+++ b/mlir/lib/Translation/EmitVivadoHLS.cpp
@@ -1743,6 +1743,10 @@ void ModuleEmitter::emitConstant(arith::ConstantOp op) {
 
 void ModuleEmitter::emitBitcast(arith::BitcastOp op) {
   indent();
+  Value result = op.getResult();
+  fixUnsignedType(result, op->hasAttr("unsigned"));
+  Value operand = op.getOperand();
+  fixUnsignedType(operand, op->hasAttr("unsigned"));
   emitValue(op.getResult());
   os << ";\n";
   indent();

--- a/tests/test_bitop.py
+++ b/tests/test_bitop.py
@@ -4,7 +4,7 @@
 import pytest
 import numpy as np
 import allo
-from allo.ir.types import uint1, uint2, int32, uint8, UInt
+from allo.ir.types import uint1, uint2, int32, uint8, uint32, UInt, float32
 
 
 def test_scalar():
@@ -123,6 +123,28 @@ def test_dynamic_slice():
     mod = s.build()
     mod(1234, np_B)
     assert bin(1234) == "0b" + "".join([str(np_B[i]) for i in range(10, -1, -1)])
+
+
+def test_bitcast_uint2float():
+
+    def kernel(A: uint32[10, 10]) -> float32[10, 10]:
+        B: float32[10, 10]
+        for i, j in allo.grid(10, 10):
+            B[i, j] = A[i, j].bitcast()
+        return B
+
+    s = allo.customize(kernel)
+    print(s.module)
+    mod = s.build()
+
+    A_np = np.random.randint(100, size=(10, 10)).astype(np.uint32)
+    B_np = mod(A_np)
+    answer = np.frombuffer(A_np.tobytes(), np.float32).reshape((10, 10))
+    assert np.array_equal(B_np, answer)
+
+    code = str(s.build(target="vhls"))
+    assert "union" in code and "uint32" in code
+    print("Passed!")
 
 
 def test_packed_bconv2D_nchw():

--- a/tests/test_bitop.py
+++ b/tests/test_bitop.py
@@ -126,7 +126,6 @@ def test_dynamic_slice():
 
 
 def test_bitcast_uint2float():
-
     def kernel(A: uint32[10, 10]) -> float32[10, 10]:
         B: float32[10, 10]
         for i, j in allo.grid(10, 10):
@@ -140,6 +139,27 @@ def test_bitcast_uint2float():
     A_np = np.random.randint(100, size=(10, 10)).astype(np.uint32)
     B_np = mod(A_np)
     answer = np.frombuffer(A_np.tobytes(), np.float32).reshape((10, 10))
+    assert np.array_equal(B_np, answer)
+
+    code = str(s.build(target="vhls"))
+    assert "union" in code and "uint32" in code
+    print("Passed!")
+
+
+def test_bitcast_float2uint():
+    def kernel(A: float32[10, 10]) -> uint32[10, 10]:
+        B: uint32[10, 10]
+        for i, j in allo.grid(10, 10):
+            B[i, j] = A[i, j].bitcast()
+        return B
+
+    s = allo.customize(kernel)
+    print(s.module)
+    mod = s.build()
+
+    A_np = np.random.rand(10, 10).astype(np.float32)
+    B_np = mod(A_np)
+    answer = np.frombuffer(A_np.tobytes(), np.uint32).reshape((10, 10))
     assert np.array_equal(B_np, answer)
 
     code = str(s.build(target="vhls"))

--- a/tests/test_bitop.py
+++ b/tests/test_bitop.py
@@ -167,6 +167,28 @@ def test_bitcast_float2uint():
     print("Passed!")
 
 
+def test_bitcast_float2int():
+    def kernel(A: float32[10, 10]) -> int32[10, 10]:
+        B: int32[10, 10]
+        for i, j in allo.grid(10, 10):
+            B[i, j] = A[i, j].bitcast()
+        return B
+
+    s = allo.customize(kernel)
+    print(s.module)
+    mod = s.build()
+
+    A_np = np.random.rand(10, 10).astype(np.float32)
+    B_np = mod(A_np)
+    answer = np.frombuffer(A_np.tobytes(), np.int32).reshape((10, 10))
+    assert np.array_equal(B_np, answer)
+
+    code = str(s.build(target="vhls"))
+    assert "union" in code and "int32" in code
+    print(code)
+    print("Passed!")
+
+
 def test_packed_bconv2D_nchw():
     bs = 4
     ic, oc = 16, 32


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR exposes the bitcast operation to the frontend (which has already been added in MLIR previously). The API is just `.bitcast()`. By default, if `.bitcast()` is operated on an integer, it will be cast to a floating point; while `.bitcast()` is operated on a floating point, it will be cast to an integer with the same bitwidth. Notice this is different from a normal cast, where a normal cast preserves the actual value of the variable, while bitcast preserves the bits.

### Examples ###
```python
def test_bitcast_uint2float():
    def kernel(A: uint32[10, 10]) -> float32[10, 10]:
        B: float32[10, 10]
        for i, j in allo.grid(10, 10):
            B[i, j] = A[i, j].bitcast()
        return B

    s = allo.customize(kernel)
    print(s.module)
    mod = s.build()

    A_np = np.random.randint(100, size=(10, 10)).astype(np.uint32)
    B_np = mod(A_np)
    answer = np.frombuffer(A_np.tobytes(), np.float32).reshape((10, 10))
    assert np.array_equal(B_np, answer)

    code = str(s.build(target="vhls"))
    assert "union" in code and "uint32" in code
    print("Passed!")


def test_bitcast_float2uint():
    def kernel(A: float32[10, 10]) -> uint32[10, 10]:
        B: uint32[10, 10]
        for i, j in allo.grid(10, 10):
            B[i, j] = A[i, j].bitcast()
        return B

    s = allo.customize(kernel)
    print(s.module)
    mod = s.build()

    A_np = np.random.rand(10, 10).astype(np.float32)
    B_np = mod(A_np)
    answer = np.frombuffer(A_np.tobytes(), np.uint32).reshape((10, 10))
    assert np.array_equal(B_np, answer)

    code = str(s.build(target="vhls"))
    assert "union" in code and "uint32" in code
    print("Passed!")
```
```mlir
module {
  func.func @kernel(%arg0: memref<10x10xf32>) -> memref<10x10xi32> attributes {itypes = "_", otypes = "u"} {
    %alloc = memref.alloc() {name = "B", unsigned} : memref<10x10xi32>
    affine.for %arg1 = 0 to 10 {
      affine.for %arg2 = 0 to 10 {
        %0 = affine.load %arg0[%arg1, %arg2] {from = "A"} : memref<10x10xf32>
        %1 = arith.bitcast %0 {unsigned} : f32 to i32
        affine.store %1, %alloc[%arg1, %arg2] {to = "B"} : memref<10x10xi32>
      } {loop_name = "j"}
    } {loop_name = "i", op_name = "S_i_j_0"}
    return %alloc : memref<10x10xi32>
  }
}
```
```cpp
void kernel(
  float v0[10][10],
  uint32_t v1[10][10]
) {     // L2
  l_S_i_j_0_i: for (int i = 0; i < 10; i++) {   // L4
    l_j: for (int j = 0; j < 10; j++) { // L5
      float v4 = v0[i][j];      // L6
      uint32_t v5;
      union { float from; uint32_t to;} _converter_v4_to_v5;
      _converter_v4_to_v5.from = v4;
      v5 = _converter_v4_to_v5.to;      // L7
      v1[i][j] = v5;    // L8
    }
  }
}
```


## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [x] Code is well-documented
