### PR TITLE
[Type][Backend] Support fp16

### DIFF
--- a/allo/backend/llvm.py
+++ b/allo/backend/llvm.py
@@ -1,6 +1,6 @@
 # Copyright Allo authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=no-name-in-module, inconsistent-return-statements
+# pylint: disable=no-name-in-module, inconsistent-return-statements, too-many-function-args
 
 import os
 import ctypes

--- a/allo/backend/llvm.py
+++ b/allo/backend/llvm.py
@@ -356,7 +356,7 @@ class LLVMModule:
                     ret_i = struct_array_to_int_array(
                         np_arr, bitwidth, res_type[0] == "i"
                     )
-                elif result_type == "f16":
+                elif res_type == "f16":
                     ret_i = np.array(np_arr, dtype=np.int16).view(np.float16)
                 elif res_type.startswith("fixed") or res_type.startswith("ufixed"):
                     bitwidth, frac = get_bitwidth_and_frac_from_fixed(res_type)

--- a/allo/backend/llvm.py
+++ b/allo/backend/llvm.py
@@ -155,7 +155,10 @@ class LLVMModule:
                             f"Input type mismatch: {target_in_type} vs f32. Please use NumPy array"
                             " to wrap the data to avoid possible result mismatch"
                         ).warn()
-                    if target_in_type == "f32":
+                    if target_in_type == "f16":
+                        c_float_p = ctypes.c_int16 * 1
+                        arg = np.float16(arg).view(np.int16)
+                    elif target_in_type == "f32":
                         c_float_p = ctypes.c_float * 1
                     else:  # f64
                         c_float_p = ctypes.c_double * 1
@@ -317,6 +320,8 @@ class LLVMModule:
                     ret = struct_array_to_int_array(
                         ret, bitwidth, result_type[0] == "i"
                     )
+                elif result_type == "f16":
+                    ret = np.array(ret, dtype=np.int16).view(np.float16)
                 elif result_type.startswith("fixed") or result_type.startswith(
                     "ufixed"
                 ):
@@ -333,6 +338,8 @@ class LLVMModule:
                 # INVOKE
                 self.execution_engine.invoke(self.top_func_name, *arg_ptrs, return_ptr)
                 ret = return_ptr[0]
+                if result_type == "f16":
+                    ret = np.int16(ret).view(np.float16)
         else:  # multiple returns, assume all memref
             # INVOKE
             self.execution_engine.invoke(self.top_func_name, return_ptr, *arg_ptrs)
@@ -349,6 +356,8 @@ class LLVMModule:
                     ret_i = struct_array_to_int_array(
                         np_arr, bitwidth, res_type[0] == "i"
                     )
+                elif result_type == "f16":
+                    ret_i = np.array(np_arr, dtype=np.int16).view(np.float16)
                 elif res_type.startswith("fixed") or res_type.startswith("ufixed"):
                     bitwidth, frac = get_bitwidth_and_frac_from_fixed(res_type)
                     ret_i = struct_array_to_int_array(

--- a/allo/utils.py
+++ b/allo/utils.py
@@ -9,6 +9,7 @@ from ._mlir.ir import (
     RankedTensorType,
     IntegerType,
     IndexType,
+    F16Type,
     F32Type,
     F64Type,
 )
@@ -18,6 +19,7 @@ from ._mlir.dialects import allo as allo_d
 
 
 np_supported_types = {
+    "f16": np.float16,
     "f32": np.float32,
     "f64": np.float64,
     "i8": np.int8,
@@ -33,6 +35,9 @@ np_supported_types = {
 
 
 ctype_map = {
+    # ctypes.c_float16 does not exist
+    # similar implementation in _mlir/runtime/np_to_memref.py/F16
+    "f16": ctypes.c_int16,
     "f32": ctypes.c_float,
     "f64": ctypes.c_double,
     "i8": ctypes.c_int8,
@@ -152,6 +157,8 @@ def get_dtype_and_shape_from_type(dtype):
         return "index", tuple()
     if IntegerType.isinstance(dtype):
         return str(IntegerType(dtype)), tuple()
+    if F16Type.isinstance(dtype):
+        return str(F16Type(dtype)), tuple()
     if F32Type.isinstance(dtype):
         return str(F32Type(dtype)), tuple()
     if F64Type.isinstance(dtype):

--- a/mlir/lib/Translation/EmitTapaHLS.cpp
+++ b/mlir/lib/Translation/EmitTapaHLS.cpp
@@ -36,7 +36,9 @@ static SmallString<16> getTypeName(Type valType) {
     valType = arrayType.getElementType();
 
   // Handle float types.
-  if (valType.isa<Float32Type>())
+  if (valType.isa<Float16Type>())
+    return SmallString<16>("half");
+  else if (valType.isa<Float32Type>())
     return SmallString<16>("float");
   else if (valType.isa<Float64Type>())
     return SmallString<16>("double");

--- a/mlir/lib/Translation/EmitVivadoHLS.cpp
+++ b/mlir/lib/Translation/EmitVivadoHLS.cpp
@@ -35,7 +35,11 @@ static SmallString<16> getTypeName(Type valType) {
     valType = arrayType.getElementType();
 
   // Handle float types.
-  if (valType.isa<Float32Type>())
+  if (valType.isa<Float16Type>())
+    // Page 222:
+    // https://www.amd.com/content/dam/xilinx/support/documents/sw_manuals/xilinx2020_2/ug902-vivado-high-level-synthesis.pdf
+    return SmallString<16>("half");
+  else if (valType.isa<Float32Type>())
     return SmallString<16>("float");
   else if (valType.isa<Float64Type>())
     return SmallString<16>("double");


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR adds fp16 support for both LLVM and HLS backend. The LLVM backend needs to first represent the float16 value in int16, and the HLS backend uses `half` to represent fp16.

### Examples ###
```python
def test_fp16_array():
    def kernel(A: float16[10]) -> float16[10]:
        B: float16[10]
        for i in range(10):
            B[i] = A[i] + 1
        return B

    s = allo.customize(kernel)
    assert "f16" in str(s.module)
    mod = s.build()
    A = np.random.rand(10).astype(np.float16)
    B = mod(A)
    np.testing.assert_allclose(B, A + 1, rtol=1e-5)
```


## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [x] Code is well-documented
