### PR TITLE
[Backend][AIE] Support global indexing, tensor access and kernel reindex for AIE kernel mapping

### DIFF
--- a/allo/backend/aie.py
+++ b/allo/backend/aie.py
@@ -349,9 +349,7 @@ def codegen_aie_mlir(mod, orig_input_args, func_lower_bounds, func_sizes, buf_di
         code += format_str(
             f"aie.objectfifo @out_p0({{{out_tile_str}}}, {{%tile_mem0}}, 2 : i32) : !aie.objectfifo<{out_type}>"
         )
-        code += format_str(
-            f"aie.objectfifo.link [@out_p0] -> [@out_sh]([] [])"
-        )
+        code += format_str(f"aie.objectfifo.link [@out_p0] -> [@out_sh]([] [])")
     # create core computation
     for pid, func_str in enumerate(func_strs):
         code += format_str(f"%core_0_{pid + 2} = aie.core(%tile_comp{pid}) {{")

--- a/allo/backend/aie.py
+++ b/allo/backend/aie.py
@@ -584,9 +584,7 @@ class AIEModule:
                 update_func_op_arg_types(func_op, input_args, shapes, ctx)
         lower_tensor_to_memref(self.module)
         buf_dicts = record_local_buffer(self.module)
-        code = codegen_aie_mlir(
-            self.module, input_args, func_sizes, buf_dicts
-        )
+        code = codegen_aie_mlir(self.module, input_args, func_sizes, buf_dicts)
         os.makedirs(os.path.join(self.project, "build"), exist_ok=True)
         with open(os.path.join(self.project, "top.mlir"), "w", encoding="utf-8") as f:
             f.write(code)

--- a/allo/backend/aie.py
+++ b/allo/backend/aie.py
@@ -1,7 +1,7 @@
 # Copyright Allo authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 # mlir-aie commit: 8329b6
-# pylint: disable=consider-using-with, bad-builtin, no-name-in-module
+# pylint: disable=consider-using-with, bad-builtin, no-name-in-module, too-many-branches
 
 import os
 import subprocess

--- a/allo/backend/llvm.py
+++ b/allo/backend/llvm.py
@@ -1,6 +1,6 @@
 # Copyright Allo authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=no-name-in-module, inconsistent-return-statements
+# pylint: disable=no-name-in-module, inconsistent-return-statements, too-many-function-args
 
 import os
 import ctypes

--- a/allo/dataflow.py
+++ b/allo/dataflow.py
@@ -121,21 +121,22 @@ def remove_unused_func_ops(s, func_names):
             func_op.erase()
 
 
-def _build_top(s, stream_info):
+def _build_top(s, stream_info, enable_tensor):
     """
     s: top-level schedule
     stream_info: {func_name: [(stream_names, direction)]}
     """
     # remove unused kernel
-    passes = ["canonicalize"]
-    pipeline = f'builtin.module(func.func({",".join(passes)}))'
-    try:
-        with s.module.context:
-            mlir_pass_manager.parse(pipeline).run(s.module.operation)
-    except Exception as e:
-        print("Error: failed to run MLIR lower pipeline, printing module...")
-        print(s.module)
-        raise e
+    if not enable_tensor:
+        passes = ["canonicalize"]
+        pipeline = f'builtin.module(func.func({",".join(passes)}))'
+        try:
+            with s.module.context:
+                mlir_pass_manager.parse(pipeline).run(s.module.operation)
+        except Exception as e:
+            print("Error: failed to run MLIR lower pipeline, printing module...")
+            print(s.module)
+            raise e
     remove_unused_func_ops(s, stream_info.keys())
 
     # create argument mapping
@@ -237,11 +238,11 @@ def df_primitive_default(s):
     df_pipeline(s.module, rewind=True)
 
 
-def customize(func, opt_default=True):
+def customize(func, opt_default=True, enable_tensor=False):
     global_vars = get_global_vars(func)
-    s = _customize(func, global_vars=global_vars)
+    s = _customize(func, global_vars=global_vars, enable_tensor=enable_tensor)
     stream_info = move_stream_to_interface(s)
-    s = _build_top(s, stream_info)
+    s = _build_top(s, stream_info, enable_tensor)
 
     if opt_default:
         df_primitive_default(s)
@@ -257,16 +258,18 @@ def build(
     configs=None,
     wrap_io=True,
     opt_default=True,
+    enable_tensor=False,
 ):
     if target == "aie":
         global_vars = get_global_vars(func)
-        s = _customize(func, global_vars=global_vars)
-        mapping = func.mapping
-        mod = AIEModule(s.module, s.top_func_name, project, mapping)
+        s = _customize(func, global_vars=global_vars, enable_tensor=enable_tensor)
+        stream_info = move_stream_to_interface(s)
+        s = _build_top(s, stream_info, enable_tensor)
+        mod = AIEModule(s.module, s.top_func_name, project)
         mod.build()
         return mod
     # FPGA backend
-    s = customize(func, opt_default)
+    s = customize(func, opt_default, enable_tensor=enable_tensor)
     hls_mod = s.build(
         target=target,
         mode=mode,

--- a/allo/dataflow.py
+++ b/allo/dataflow.py
@@ -263,8 +263,8 @@ def build(
     if target == "aie":
         global_vars = get_global_vars(func)
         s = _customize(func, global_vars=global_vars, enable_tensor=enable_tensor)
-        stream_info = move_stream_to_interface(s)
-        s = _build_top(s, stream_info, enable_tensor)
+        # stream_info = move_stream_to_interface(s)
+        # s = _build_top(s, stream_info, enable_tensor)
         mod = AIEModule(s.module, s.top_func_name, project)
         mod.build()
         return mod

--- a/allo/dataflow.py
+++ b/allo/dataflow.py
@@ -262,7 +262,7 @@ def build(
 ):
     if target == "aie":
         global_vars = get_global_vars(func)
-        s = _customize(func, global_vars=global_vars, enable_tensor=enable_tensor)
+        s = _customize(func, global_vars=global_vars, enable_tensor=True)
         # stream_info = move_stream_to_interface(s)
         # s = _build_top(s, stream_info, enable_tensor)
         mod = AIEModule(s.module, s.top_func_name, project)

--- a/allo/dsl.py
+++ b/allo/dsl.py
@@ -29,6 +29,10 @@ def sub(lhs, rhs, name=None):
     return lhs - rhs
 
 
+def mul(lhs, rhs, name=None):
+    return lhs * rhs
+
+
 def div(lhs, rhs, name=None):
     return lhs / rhs
 

--- a/allo/ir/builder.py
+++ b/allo/ir/builder.py
@@ -990,10 +990,14 @@ class ASTTransformer(ASTBuilder):
         for index, size in zip(slices, in_shape):
             if isinstance(index, ast.Slice):
                 lower = (
-                    0 if index.lower is None else ASTResolver.resolve_constant(index.lower, ctx)
+                    0
+                    if index.lower is None
+                    else ASTResolver.resolve_constant(index.lower, ctx)
                 )
                 upper = (
-                    size if index.upper is None else ASTResolver.resolve_constant(index.upper, ctx)
+                    size
+                    if index.upper is None
+                    else ASTResolver.resolve_constant(index.upper, ctx)
                 )
                 if index.step is None:
                     step = 1
@@ -1004,22 +1008,34 @@ class ASTTransformer(ASTBuilder):
                 if lower is None:
                     static_offsets.append(ShapedType.get_dynamic_size())
                     offset_expr = build_stmt(ctx, index.lower)
-                    offset = ASTTransformer.build_cast_op(ctx, offset_expr, index.dtype, Index()).result
+                    offset = ASTTransformer.build_cast_op(
+                        ctx, offset_expr, index.dtype, Index()
+                    ).result
                     offsets.append(offset)
                     static_sizes.append(ShapedType.get_dynamic_size())
                     if upper is None:
                         upper_expr = build_stmt(ctx, index.upper)
-                        size_expr = tensor_d.FloorDivSOp(tensor_d.SubOp(upper_expr, offset_expr).result, step)
+                        size_expr = tensor_d.FloorDivSOp(
+                            tensor_d.SubOp(upper_expr, offset_expr).result, step
+                        )
                     else:
-                        size_expr = tensor_d.FloorDivSOp(tensor_d.SubOp(upper, offset_expr).result, step)
-                    size = ASTTransformer.build_cast_op(ctx, size_expr, index.dtype, Index()).result
+                        size_expr = tensor_d.FloorDivSOp(
+                            tensor_d.SubOp(upper, offset_expr).result, step
+                        )
+                    size = ASTTransformer.build_cast_op(
+                        ctx, size_expr, index.dtype, Index()
+                    ).result
                     sizes.append(size)
                     continue
                 elif upper is None:
                     static_sizes.append(ShapedType.get_dynamic_size())
                     upper_expr = build_stmt(ctx, index.upper)
-                    size_expr = tensor_d.FloorDivSOp(tensor_d.SubOp(upper_expr, lower).result, step)
-                    size = ASTTransformer.build_cast_op(ctx, size_expr, index.dtype, Index()).result
+                    size_expr = tensor_d.FloorDivSOp(
+                        tensor_d.SubOp(upper_expr, lower).result, step
+                    )
+                    size = ASTTransformer.build_cast_op(
+                        ctx, size_expr, index.dtype, Index()
+                    ).result
                     sizes.append(size)
                     continue
             elif isinstance(index, (ast.Index, ast.Constant)):
@@ -1973,10 +1989,20 @@ class ASTTransformer(ASTBuilder):
             }:
                 if fn_name in {"add", "sub", "mul", "div"}:
                     new_args[0] = ASTTransformer.build_broadcast_op(
-                        ctx, new_args[0], node.dtype, node.args[0].shape, node.shape, node.dims[0]
+                        ctx,
+                        new_args[0],
+                        node.dtype,
+                        node.args[0].shape,
+                        node.shape,
+                        node.dims[0],
                     )
                     new_args[1] = ASTTransformer.build_broadcast_op(
-                        ctx, new_args[1], node.dtype, node.args[1].shape, node.shape, node.dims[1]
+                        ctx,
+                        new_args[1],
+                        node.dtype,
+                        node.args[1].shape,
+                        node.shape,
+                        node.dims[1],
                     )
                 return ASTTransformer.build_library_op(
                     ctx, node=node, attr=fn_name, new_args=new_args

--- a/allo/ir/builder.py
+++ b/allo/ir/builder.py
@@ -1959,6 +1959,7 @@ class ASTTransformer(ASTBuilder):
                 "log",
                 "add",
                 "sub",
+                "mul",
                 "div",
                 "relu",
                 "conv2d",
@@ -1970,6 +1971,13 @@ class ASTTransformer(ASTBuilder):
                 "view",
                 "concat",
             }:
+                if fn_name in {"add", "sub", "mul", "div"}:
+                    new_args[0] = ASTTransformer.build_broadcast_op(
+                        ctx, new_args[0], node.dtype, node.args[0].shape, node.shape, node.dims[0]
+                    )
+                    new_args[1] = ASTTransformer.build_broadcast_op(
+                        ctx, new_args[1], node.dtype, node.args[1].shape, node.shape, node.dims[1]
+                    )
                 return ASTTransformer.build_library_op(
                     ctx, node=node, attr=fn_name, new_args=new_args
                 )

--- a/allo/ir/builder.py
+++ b/allo/ir/builder.py
@@ -1027,7 +1027,7 @@ class ASTTransformer(ASTBuilder):
                     ).result
                     sizes.append(size)
                     continue
-                elif upper is None:
+                if upper is None:
                     static_sizes.append(ShapedType.get_dynamic_size())
                     upper_expr = build_stmt(ctx, index.upper)
                     size_expr = tensor_d.FloorDivSOp(

--- a/allo/ir/infer.py
+++ b/allo/ir/infer.py
@@ -899,7 +899,9 @@ class TypeInferer(ASTVisitor):
         }:
             # Element-wise operation
             if op_name in {"add", "sub", "mul", "div"}:
-                final_shape, lhs_dims, rhs_dims = TypeInferer.visit_broadcast(ctx, new_args[0], new_args[1])
+                final_shape, lhs_dims, rhs_dims = TypeInferer.visit_broadcast(
+                    ctx, new_args[0], new_args[1]
+                )
             node.shape = final_shape
             node.dtype = new_args[0].dtype
             node.dims = (lhs_dims, rhs_dims)

--- a/allo/ir/infer.py
+++ b/allo/ir/infer.py
@@ -902,9 +902,11 @@ class TypeInferer(ASTVisitor):
                 final_shape, lhs_dims, rhs_dims = TypeInferer.visit_broadcast(
                     ctx, new_args[0], new_args[1]
                 )
-            node.shape = final_shape
+                node.dims = (lhs_dims, rhs_dims)
+                node.shape = final_shape
+            else:
+                node.shape = new_args[0].shape
             node.dtype = new_args[0].dtype
-            node.dims = (lhs_dims, rhs_dims)
             return node
         if op_name in {"matmul", "bmm", "linear", "conv2d", "sumpool", "maxpool"}:
             argAshape = new_args[0].shape

--- a/allo/ir/infer.py
+++ b/allo/ir/infer.py
@@ -892,17 +892,17 @@ class TypeInferer(ASTVisitor):
             "log",
             "add",
             "sub",
+            "mul",
             "div",
             "relu",
             "copy",
         }:
             # Element-wise operation
-            if op_name in {"add", "sub", "div"}:
-                assert (
-                    new_args[0].shape == new_args[1].shape
-                ), f"Only support element-wise {op_name} of two inputs with the same shape, got {new_args[0].shape} and {new_args[1].shape}"
-            node.shape = new_args[0].shape
+            if op_name in {"add", "sub", "mul", "div"}:
+                final_shape, lhs_dims, rhs_dims = TypeInferer.visit_broadcast(ctx, new_args[0], new_args[1])
+            node.shape = final_shape
             node.dtype = new_args[0].dtype
+            node.dims = (lhs_dims, rhs_dims)
             return node
         if op_name in {"matmul", "bmm", "linear", "conv2d", "sumpool", "maxpool"}:
             argAshape = new_args[0].shape

--- a/allo/utils.py
+++ b/allo/utils.py
@@ -421,3 +421,14 @@ def extract_out_np_arrays_from_out_struct(out_struct_ptr_ptr, num_output):
             ranked_memref_to_numpy(getattr(out_struct_ptr_ptr[0][0], f"memref{i}"))
         )
     return out_np_arrays
+
+
+def get_element_type_from_str(element_type_str, context):
+    if element_type_str.startswith('f'):
+        bits = int(element_type_str[1:])
+        return F32Type.get(context) if bits == 32 else F64Type.get(context)
+    elif element_type_str.startswith('i'):
+        bits = int(element_type_str[1:])
+        return IntegerType.get_signless(bits, context)
+    else:
+        raise ValueError(f"unknown element_type_str: {element_type_str}")

--- a/allo/utils.py
+++ b/allo/utils.py
@@ -427,8 +427,7 @@ def get_element_type_from_str(element_type_str, context):
     if element_type_str.startswith("f"):
         bits = int(element_type_str[1:])
         return F32Type.get(context) if bits == 32 else F64Type.get(context)
-    elif element_type_str.startswith("i"):
+    if element_type_str.startswith("i"):
         bits = int(element_type_str[1:])
         return IntegerType.get_signless(bits, context)
-    else:
-        raise ValueError(f"unknown element_type_str: {element_type_str}")
+    raise ValueError(f"unknown element_type_str: {element_type_str}")

--- a/allo/utils.py
+++ b/allo/utils.py
@@ -424,10 +424,10 @@ def extract_out_np_arrays_from_out_struct(out_struct_ptr_ptr, num_output):
 
 
 def get_element_type_from_str(element_type_str, context):
-    if element_type_str.startswith('f'):
+    if element_type_str.startswith("f"):
         bits = int(element_type_str[1:])
         return F32Type.get(context) if bits == 32 else F64Type.get(context)
-    elif element_type_str.startswith('i'):
+    elif element_type_str.startswith("i"):
         bits = int(element_type_str[1:])
         return IntegerType.get_signless(bits, context)
     else:

--- a/tests/dataflow/aie/test_gemm.py
+++ b/tests/dataflow/aie/test_gemm.py
@@ -22,7 +22,7 @@ def _test_gemm():
                 A[pi * Mt : (pi + 1) * Mt, :], B
             )
 
-    mod = df.build(top, target="aie", enable_tensor=True)
+    mod = df.build(top, target="aie")
     A = np.random.randint(0, 64, (M, K)).astype(np.int32)
     B = np.random.randint(0, 64, (K, N)).astype(np.int32)
     C = np.zeros((M, N)).astype(np.int32)

--- a/tests/dataflow/aie/test_gemm.py
+++ b/tests/dataflow/aie/test_gemm.py
@@ -1,3 +1,6 @@
+# Copyright Allo authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import allo.dataflow as df
 from allo.ir.types import int32
 import numpy as np
@@ -6,8 +9,8 @@ import allo
 
 def _test_gemm():
     Ty = int32
-    M, N, K = 64, 64, 64
-    P0 = 4
+    M, N, K = 16, 16, 16
+    P0 = 2
     Mt = M // P0
 
     @df.region()

--- a/tests/dataflow/aie/test_gemm.py
+++ b/tests/dataflow/aie/test_gemm.py
@@ -18,9 +18,10 @@ def _test_gemm():
         @df.kernel(mapping=[P0])
         def gemm(A: Ty[M, K], B: Ty[K, N], C: Ty[M, N]):
             pi = df.get_pid()
-            C[pi * Mt: (pi + 1) * Mt, :] = allo.matmul(
-                A[pi * Mt: (pi + 1) * Mt, :], B)
-            
+            C[pi * Mt : (pi + 1) * Mt, :] = allo.matmul(
+                A[pi * Mt : (pi + 1) * Mt, :], B
+            )
+
     mod = df.build(top, target="aie", enable_tensor=True)
     A = np.random.randint(0, 64, (M, K)).astype(np.int32)
     B = np.random.randint(0, 64, (K, N)).astype(np.int32)
@@ -28,7 +29,7 @@ def _test_gemm():
     mod(A, B, C)
     np.testing.assert_allclose(C, A @ B, atol=1e-5)
     print("PASSED!")
-    
-    
+
+
 if __name__ == "__main__":
     _test_gemm()

--- a/tests/dataflow/aie/test_gemm.py
+++ b/tests/dataflow/aie/test_gemm.py
@@ -1,0 +1,31 @@
+import allo.dataflow as df
+from allo.ir.types import int32
+import numpy as np
+import allo
+
+
+def _test_gemm():
+    Ty = int32
+    M, N, K = 16, 16, 16
+    P0 = 1
+    Mt = M // P0
+
+    @df.region()
+    def top():
+        @df.kernel(mapping=[P0])
+        def gemm(A: Ty[M, K], B: Ty[K, N], C: Ty[M, N]):
+            pi = df.get_pid()
+            C[pi * Mt: (pi + 1) * Mt, :] = allo.matmul(
+                A[pi * Mt: (pi + 1) * Mt, :], B)
+            
+    mod = df.build(top, target="aie", enable_tensor=True)
+    A = np.random.randint(0, 16, (M, K)).astype(np.int32)
+    B = np.random.randint(0, 16, (K, N)).astype(np.int32)
+    C = np.zeros((M, N)).astype(np.int32)
+    mod(A, B, C)
+    np.testing.assert_allclose(C, A @ B, atol=1e-5)
+    print("PASSED!")
+    
+    
+if __name__ == "__main__":
+    _test_gemm()

--- a/tests/dataflow/aie/test_gemm.py
+++ b/tests/dataflow/aie/test_gemm.py
@@ -6,8 +6,8 @@ import allo
 
 def _test_gemm():
     Ty = int32
-    M, N, K = 16, 16, 16
-    P0 = 1
+    M, N, K = 64, 64, 64
+    P0 = 4
     Mt = M // P0
 
     @df.region()
@@ -19,8 +19,8 @@ def _test_gemm():
                 A[pi * Mt: (pi + 1) * Mt, :], B)
             
     mod = df.build(top, target="aie", enable_tensor=True)
-    A = np.random.randint(0, 16, (M, K)).astype(np.int32)
-    B = np.random.randint(0, 16, (K, N)).astype(np.int32)
+    A = np.random.randint(0, 64, (M, K)).astype(np.int32)
+    B = np.random.randint(0, 64, (K, N)).astype(np.int32)
     C = np.zeros((M, N)).astype(np.int32)
     mod(A, B, C)
     np.testing.assert_allclose(C, A @ B, atol=1e-5)

--- a/tests/dataflow/aie/test_matrix.py
+++ b/tests/dataflow/aie/test_matrix.py
@@ -20,7 +20,7 @@ def _test_matrix_scalar_add():
             pi = df.get_pid()
             B[pi * Mt : (pi + 1) * Mt, :] = allo.add(A[pi * Mt : (pi + 1) * Mt, :], 1)
 
-    mod = df.build(top, target="aie", enable_tensor=True)
+    mod = df.build(top, target="aie")
     A = np.random.randint(0, 100, (M, N)).astype(np.int32)
     B = np.zeros((M, N)).astype(np.int32)
     mod(A, B)
@@ -43,7 +43,7 @@ def _test_matrix_matrix_add():
                 A[pi * Mt : (pi + 1) * Mt, :], B[pi * Mt : (pi + 1) * Mt, :]
             )
 
-    mod = df.build(top, target="aie", enable_tensor=True)
+    mod = df.build(top, target="aie")
     A = np.random.randint(0, 100, (M, N)).astype(np.int32)
     B = np.random.randint(0, 100, (M, N)).astype(np.int32)
     C = np.zeros((M, N)).astype(np.int32)

--- a/tests/dataflow/aie/test_matrix.py
+++ b/tests/dataflow/aie/test_matrix.py
@@ -18,7 +18,7 @@ def _test_matrix_scalar_add():
         @df.kernel(mapping=[P0])
         def core(A: Ty[M, N], B: Ty[M, N]):
             pi = df.get_pid()
-            B[pi * Mt: (pi + 1) * Mt, :] = allo.add(A[pi * Mt: (pi + 1) * Mt, :], 1)
+            B[pi * Mt : (pi + 1) * Mt, :] = allo.add(A[pi * Mt : (pi + 1) * Mt, :], 1)
 
     mod = df.build(top, target="aie", enable_tensor=True)
     A = np.random.randint(0, 100, (M, N)).astype(np.int32)
@@ -39,7 +39,9 @@ def _test_matrix_matrix_add():
         @df.kernel(mapping=[P0])
         def core(A: Ty[M, N], B: Ty[M, N], C: Ty[M, N]):
             pi = df.get_pid()
-            C[pi * Mt: (pi + 1) * Mt, :] = allo.add(A[pi * Mt: (pi + 1) * Mt, :], B[pi * Mt: (pi + 1) * Mt, :])
+            C[pi * Mt : (pi + 1) * Mt, :] = allo.add(
+                A[pi * Mt : (pi + 1) * Mt, :], B[pi * Mt : (pi + 1) * Mt, :]
+            )
 
     mod = df.build(top, target="aie", enable_tensor=True)
     A = np.random.randint(0, 100, (M, N)).astype(np.int32)

--- a/tests/dataflow/aie/test_matrix.py
+++ b/tests/dataflow/aie/test_matrix.py
@@ -11,16 +11,19 @@ def _test_matrix_scalar_add():
     Ty = int32
     M, N = 64, 64
     P0 = 4
+    Mt = M // P0
 
-    @df.kernel(mapping=[P0])
-    def core(A: Ty[M, N], B: Ty[M, N]):
-        for i, j in allo.grid(M // P0, N):
-            B[i, j] = A[i, j] + 1
+    @df.region()
+    def top():
+        @df.kernel(mapping=[P0])
+        def core(A: Ty[M, N], B: Ty[M, N]):
+            pi = df.get_pid()
+            B[pi * Mt: (pi + 1) * Mt, :] = allo.add(A[pi * Mt: (pi + 1) * Mt, :], 1)
 
-    top = df.build(core, target="aie")
+    mod = df.build(top, target="aie", enable_tensor=True)
     A = np.random.randint(0, 100, (M, N)).astype(np.int32)
     B = np.zeros((M, N)).astype(np.int32)
-    top(A, B)
+    mod(A, B)
     np.testing.assert_allclose(B, A + 1)
     print("PASSED!")
 
@@ -29,17 +32,20 @@ def _test_matrix_matrix_add():
     Ty = int32
     M, N = 64, 64
     P0 = 4
+    Mt = M // P0
 
-    @df.kernel(mapping=[P0])
-    def core(A: Ty[M, N], B: Ty[M, N], C: Ty[M, N]):
-        for i, j in allo.grid(M // P0, N):
-            C[i, j] = A[i, j] + B[i, j]
+    @df.region()
+    def top():
+        @df.kernel(mapping=[P0])
+        def core(A: Ty[M, N], B: Ty[M, N], C: Ty[M, N]):
+            pi = df.get_pid()
+            C[pi * Mt: (pi + 1) * Mt, :] = allo.add(A[pi * Mt: (pi + 1) * Mt, :], B[pi * Mt: (pi + 1) * Mt, :])
 
-    top = df.build(core, target="aie")
+    mod = df.build(top, target="aie", enable_tensor=True)
     A = np.random.randint(0, 100, (M, N)).astype(np.int32)
     B = np.random.randint(0, 100, (M, N)).astype(np.int32)
     C = np.zeros((M, N)).astype(np.int32)
-    top(A, B, C)
+    mod(A, B, C)
     np.testing.assert_allclose(C, A + B)
     print("PASSED!")
 

--- a/tests/dataflow/aie/test_multi_core.py
+++ b/tests/dataflow/aie/test_multi_core.py
@@ -22,7 +22,7 @@ def _test_vector_scalar_add():
         @df.kernel(mapping=[P0])
         def core(A: Ty[M], B: Ty[M]):
             pi = df.get_pid()
-            B[pi * Mt: (pi + 1) * Mt] = allo.add(A[pi * Mt: (pi + 1) * Mt], 1)
+            B[pi * Mt : (pi + 1) * Mt] = allo.add(A[pi * Mt : (pi + 1) * Mt], 1)
             return
 
     mod = df.build(top, target="aie", enable_tensor=True)
@@ -48,7 +48,9 @@ def _test_vector_vector_add():
         @df.kernel(mapping=[P0])
         def core(A: Ty[M], B: Ty[M], C: Ty[M]):
             pi = df.get_pid()
-            C[pi * Mt: (pi + 1) * Mt] = allo.add(A[pi * Mt: (pi + 1) * Mt], B[pi * Mt: (pi + 1) * Mt])
+            C[pi * Mt : (pi + 1) * Mt] = allo.add(
+                A[pi * Mt : (pi + 1) * Mt], B[pi * Mt : (pi + 1) * Mt]
+            )
 
     mod = df.build(top, target="aie", enable_tensor=True)
     A = np.random.randint(0, 100, M).astype(np.int32)

--- a/tests/dataflow/aie/test_multi_core.py
+++ b/tests/dataflow/aie/test_multi_core.py
@@ -23,9 +23,8 @@ def _test_vector_scalar_add():
         def core(A: Ty[M], B: Ty[M]):
             pi = df.get_pid()
             B[pi * Mt : (pi + 1) * Mt] = allo.add(A[pi * Mt : (pi + 1) * Mt], 1)
-            return
 
-    mod = df.build(top, target="aie", enable_tensor=True)
+    mod = df.build(top, target="aie")
     A = np.random.randint(0, 100, M).astype(np.int32)
     B = np.zeros(M).astype(np.int32)
     mod(A, B)
@@ -52,7 +51,7 @@ def _test_vector_vector_add():
                 A[pi * Mt : (pi + 1) * Mt], B[pi * Mt : (pi + 1) * Mt]
             )
 
-    mod = df.build(top, target="aie", enable_tensor=True)
+    mod = df.build(top, target="aie")
     A = np.random.randint(0, 100, M).astype(np.int32)
     B = np.random.randint(0, 100, M).astype(np.int32)
     C = np.zeros(M).astype(np.int32)

--- a/tests/dataflow/aie/test_multi_core.py
+++ b/tests/dataflow/aie/test_multi_core.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import allo
-from allo.ir.types import int32, float32
+from allo.ir.types import int32
 import allo.dataflow as df
 import numpy as np
 
@@ -13,18 +13,22 @@ def _test_vector_scalar_add():
     #                v   v-------------------------v              v
     # shim tile <-> mem tile <-> comp tile0    comp tile1    comp tile2
     Ty = int32
-    M = 48
-    P0 = 3
+    M = 1024
+    P0 = 4
+    Mt = M // P0
 
-    @df.kernel(mapping=[P0])
-    def core(A: Ty[M], B: Ty[M]):
-        for i in range(M // P0):
-            B[i] = A[i] + 1
+    @df.region()
+    def top():
+        @df.kernel(mapping=[P0])
+        def core(A: Ty[M], B: Ty[M]):
+            pi = df.get_pid()
+            B[pi * Mt: (pi + 1) * Mt] = allo.add(A[pi * Mt: (pi + 1) * Mt], 1)
+            return
 
-    top = df.build(core, target="aie")
+    mod = df.build(top, target="aie", enable_tensor=True)
     A = np.random.randint(0, 100, M).astype(np.int32)
     B = np.zeros(M).astype(np.int32)
-    top(A, B)
+    mod(A, B)
     np.testing.assert_allclose(B, A + 1)
     print("PASSED!")
 
@@ -37,17 +41,20 @@ def _test_vector_vector_add():
     Ty = int32
     M = 1024
     P0 = 4
+    Mt = M // P0
 
-    @df.kernel(mapping=[P0])
-    def core(A: Ty[M], B: Ty[M], C: Ty[M]):
-        for i in range(M // P0):
-            C[i] = A[i] + B[i]
+    @df.region()
+    def top():
+        @df.kernel(mapping=[P0])
+        def core(A: Ty[M], B: Ty[M], C: Ty[M]):
+            pi = df.get_pid()
+            C[pi * Mt: (pi + 1) * Mt] = allo.add(A[pi * Mt: (pi + 1) * Mt], B[pi * Mt: (pi + 1) * Mt])
 
-    top = df.build(core, target="aie")
+    mod = df.build(top, target="aie", enable_tensor=True)
     A = np.random.randint(0, 100, M).astype(np.int32)
     B = np.random.randint(0, 100, M).astype(np.int32)
     C = np.zeros(M).astype(np.int32)
-    top(A, B, C)
+    mod(A, B, C)
     np.testing.assert_allclose(C, A + B)
     print("PASSED!")
 

--- a/tests/dataflow/aie/test_vector.py
+++ b/tests/dataflow/aie/test_vector.py
@@ -18,7 +18,7 @@ def _test_vector_scalar_add():
         def core(A: Ty[M], B: Ty[M]):
             B[:] = allo.add(A, 1)
 
-    mod = df.build(top, target="aie", enable_tensor=True)
+    mod = df.build(top, target="aie")
     A = np.random.randint(0, 100, M).astype(np.int32)
     B = np.zeros(M).astype(np.int32)
     mod(A, B)
@@ -37,7 +37,7 @@ def _test_vector_scalar_mul():
         def core(A: Ty[M], B: Ty[M]):
             B[:] = allo.mul(A, 2)
 
-    mod = df.build(top, target="aie", enable_tensor=True)
+    mod = df.build(top, target="aie")
     A = np.random.random(M).astype(np.float32)
     B = np.zeros(M).astype(np.float32)
     mod(A, B)
@@ -56,7 +56,7 @@ def _test_vector_vector_add():
         def core(A: Ty[M], B: Ty[M], C: Ty[M]):
             C[:] = allo.add(A, B)
 
-    mod = df.build(top, target="aie", enable_tensor=True)
+    mod = df.build(top, target="aie")
     A = np.random.randint(0, 100, M).astype(np.int32)
     B = np.random.randint(0, 100, M).astype(np.int32)
     C = np.zeros(M).astype(np.int32)
@@ -76,7 +76,7 @@ def _test_vector_vector_mul():
         def core(A: Ty[M], B: Ty[M], C: Ty[M]):
             C[:] = allo.mul(A, B)
 
-    mod = df.build(top, target="aie", enable_tensor=True)
+    mod = df.build(top, target="aie")
     A = np.random.random(M).astype(np.float32)
     B = np.random.random(M).astype(np.float32)
     C = np.zeros(M).astype(np.float32)

--- a/tests/dataflow/aie/test_vector.py
+++ b/tests/dataflow/aie/test_vector.py
@@ -12,15 +12,16 @@ def _test_vector_scalar_add():
     Ty = int32
     M = 1024
 
-    @df.kernel(mapping=[1])
-    def core(A: Ty[M], B: Ty[M]):
-        for i in range(M):
-            B[i] = A[i] + 1
+    @df.region()
+    def top():
+        @df.kernel(mapping=[1])
+        def core(A: Ty[M], B: Ty[M]):
+            B[:] = allo.add(A, 1)
 
-    top = df.build(core, target="aie")
+    mod = df.build(top, target="aie", enable_tensor=True)
     A = np.random.randint(0, 100, M).astype(np.int32)
     B = np.zeros(M).astype(np.int32)
-    top(A, B)
+    mod(A, B)
     np.testing.assert_allclose(B, A + 1)
     print("PASSED!")
 
@@ -30,15 +31,16 @@ def _test_vector_scalar_mul():
     Ty = float32
     M = 512
 
-    @df.kernel(mapping=[1])
-    def core(A: Ty[M], B: Ty[M]):
-        for i in range(M):
-            B[i] = A[i] * 2
+    @df.region()
+    def top():
+        @df.kernel(mapping=[1])
+        def core(A: Ty[M], B: Ty[M]):
+            B[:] = allo.mul(A, 2)
 
-    top = df.build(core, target="aie")
+    mod = df.build(top, target="aie", enable_tensor=True)
     A = np.random.random(M).astype(np.float32)
     B = np.zeros(M).astype(np.float32)
-    top(A, B)
+    mod(A, B)
     np.testing.assert_allclose(B, A * 2, rtol=1e-5)
     print("PASSED!")
 
@@ -48,16 +50,17 @@ def _test_vector_vector_add():
     Ty = int32
     M = 1024
 
-    @df.kernel(mapping=[1])
-    def core(A: Ty[M], B: Ty[M], C: Ty[M]):
-        for i in range(M):
-            C[i] = A[i] + B[i]
+    @df.region()
+    def top():
+        @df.kernel(mapping=[1])
+        def core(A: Ty[M], B: Ty[M], C: Ty[M]):
+            C[:] = allo.add(A, B)
 
-    top = df.build(core, target="aie")
+    mod = df.build(top, target="aie", enable_tensor=True)
     A = np.random.randint(0, 100, M).astype(np.int32)
     B = np.random.randint(0, 100, M).astype(np.int32)
     C = np.zeros(M).astype(np.int32)
-    top(A, B, C)
+    mod(A, B, C)
     np.testing.assert_allclose(C, A + B)
     print("PASSED!")
 
@@ -67,16 +70,17 @@ def _test_vector_vector_mul():
     Ty = float32
     M = 1024
 
-    @df.kernel(mapping=[1])
-    def core(A: Ty[M], B: Ty[M], C: Ty[M]):
-        for i in range(M):
-            C[i] = A[i] * B[i]
+    @df.region()
+    def top():
+        @df.kernel(mapping=[1])
+        def core(A: Ty[M], B: Ty[M], C: Ty[M]):
+            C[:] = allo.mul(A, B)
 
-    top = df.build(core, target="aie")
+    mod = df.build(top, target="aie", enable_tensor=True)
     A = np.random.random(M).astype(np.float32)
     B = np.random.random(M).astype(np.float32)
     C = np.zeros(M).astype(np.float32)
-    top(A, B, C)
+    mod(A, B, C)
     np.testing.assert_allclose(C, A * B, rtol=1e-5)
     print("PASSED!")
 


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
The original AIE backend with dataflow interface only support simple element-wise application, like vector add. It used local indexing, which is insufficient for more complex tensor access pattern, like matrix multiplication. 

### Problems ###
In the original AIE interface, the compiler lacks sufficient information to determine which dimension (M, K, or N) should be used for tiling in this GEMM implementation.
```
Ty = int32
M, N, K = 16, 16, 16
P0 = 1
Mt = M // P0

@df.region()
def top():
    @df.kernel(mapping=[P0])
    def gemm(A: Ty[M, K], B: Ty[K, N], C: Ty[M, N]):
        for i, j, k in allo.grid(Mt, K, N):
            C[i, j] += A[i, k] * B[k, j]
```

### Proposed Solutions ###
In the new interface, we adopt global indexing similar to the HLS backend for AIE. Additionally, we leverage tensor slicing access, inspired by Triton, to enable the compiler to determine the precise access range for each tensor, facilitating backend reindexing. Furthermore, we use primitives like allo.matmul to encapsulate fundamental operations, streamlining MLIR construction and lowering processes.
```
Ty = int32
M, N, K = 16, 16, 16
P0 = 2
Mt = M // P0

@df.region()
def top():
    @df.kernel(mapping=[P0])
    def gemm(A: Ty[M, K], B: Ty[K, N], C: Ty[M, N]):
        pi = df.get_pid()
        C[pi * Mt: (pi + 1) * Mt, :] = allo.matmul(
            A[pi * Mt: (pi + 1) * Mt, :], B)
```
```
module {
  aie.device(npu1_2col) {
    %tile_shim = aie.tile(0, 0)
    %tile_mem0 = aie.tile(0, 1)
    %tile_mem1 = aie.tile(1, 1)
    %tile_comp0 = aie.tile(0, 2)
    %tile_comp0_buf0 = aie.buffer(%tile_comp0) : memref<8x16xi32>
    %tile_comp1 = aie.tile(0, 3)
    %tile_comp1_buf0 = aie.buffer(%tile_comp1) : memref<8x16xi32>
    aie.objectfifo @in_sh0(%tile_shim, {%tile_mem0}, 2 : i32) : !aie.objectfifo<memref<16x16xi32>>
    aie.objectfifo @in0_p0(%tile_mem0, {%tile_comp0}, 2 : i32) : !aie.objectfifo<memref<8x16xi32>>
    aie.objectfifo @in0_p1(%tile_mem0, {%tile_comp1}, 2 : i32) : !aie.objectfifo<memref<8x16xi32>>
    aie.objectfifo.link [@in_sh0] -> [@in0_p0, @in0_p1]([] [0, 128])
    aie.objectfifo @in_sh1(%tile_shim, {%tile_mem1}, 2 : i32) : !aie.objectfifo<memref<16x16xi32>>
    aie.objectfifo @in1_p0(%tile_mem1, {%tile_comp0, %tile_comp1}, 2 : i32) : !aie.objectfifo<memref<16x16xi32>>
    aie.objectfifo.link [@in_sh1] -> [@in1_p0]([] [])
    aie.objectfifo @out_p0(%tile_comp0, {%tile_mem0}, 2 : i32) : !aie.objectfifo<memref<8x16xi32>>
    aie.objectfifo @out_p1(%tile_comp1, {%tile_mem0}, 2 : i32) : !aie.objectfifo<memref<8x16xi32>>
    aie.objectfifo @out_sh(%tile_mem0, {%tile_shim}, 2 : i32) : !aie.objectfifo<memref<16x16xi32>>
    aie.objectfifo.link [@out_p0, @out_p1] -> [@out_sh]([0, 128] [])
    %core_0_2 = aie.core(%tile_comp0) {
      %c1000 = arith.constant 0 : index
      %c1001 = arith.constant 1 : index
      %c9223372036854775807 = arith.constant 9223372036854775807 : index
      scf.for %arg0 = %c1000 to %c9223372036854775807 step %c1001 {
        %fifo0 = aie.objectfifo.acquire @in0_p0(Consume, 1) : !aie.objectfifosubview<memref<8x16xi32>>
        %local0 = aie.objectfifo.subview.access %fifo0[0] : !aie.objectfifosubview<memref<8x16xi32>> -> memref<8x16xi32>
        %fifo1 = aie.objectfifo.acquire @in1_p0(Consume, 1) : !aie.objectfifosubview<memref<16x16xi32>>
        %local1 = aie.objectfifo.subview.access %fifo1[0] : !aie.objectfifosubview<memref<16x16xi32>> -> memref<16x16xi32>
        %fifo_out = aie.objectfifo.acquire @out_p0(Produce, 1) : !aie.objectfifosubview<memref<8x16xi32>>
        %local_out = aie.objectfifo.subview.access %fifo_out[0] : !aie.objectfifosubview<memref<8x16xi32>> -> memref<8x16xi32>
      %c0_i32 = arith.constant 0 : i32
      %subview = memref.subview %local0[0, 0] [8, 16] [1, 1] : memref<8x16xi32> to memref<8x16xi32, strided<[16, 1]>>
      %c0 = arith.constant 0 : index
      %c8 = arith.constant 8 : index
      %c1 = arith.constant 1 : index
      scf.for %arg3 = %c0 to %c8 step %c1 {
        %c0_4 = arith.constant 0 : index
        %c16 = arith.constant 16 : index
        %c1_5 = arith.constant 1 : index
        scf.for %arg4 = %c0_4 to %c16 step %c1_5 {
          memref.store %c0_i32, %tile_comp0_buf0[%arg3, %arg4] : memref<8x16xi32>
        }
      }
      %c0_0 = arith.constant 0 : index
      %c8_1 = arith.constant 8 : index
      %c1_2 = arith.constant 1 : index
      scf.for %arg3 = %c0_0 to %c8_1 step %c1_2 {
        %c0_4 = arith.constant 0 : index
        %c16 = arith.constant 16 : index
        %c1_5 = arith.constant 1 : index
        scf.for %arg4 = %c0_4 to %c16 step %c1_5 {
          %c0_6 = arith.constant 0 : index
          %c16_7 = arith.constant 16 : index
          %c1_8 = arith.constant 1 : index
          scf.for %arg5 = %c0_6 to %c16_7 step %c1_8 {
            %0 = memref.load %subview[%arg3, %arg5] : memref<8x16xi32, strided<[16, 1]>>
            %1 = memref.load %local1[%arg5, %arg4] : memref<16x16xi32>
            %2 = memref.load %tile_comp0_buf0[%arg3, %arg4] : memref<8x16xi32>
            %3 = arith.muli %0, %1 : i32
            %4 = arith.addi %2, %3 : i32
            memref.store %4, %tile_comp0_buf0[%arg3, %arg4] : memref<8x16xi32>
          }
        }
      }
      %subview_3 = memref.subview %local_out[0, 0] [8, 16] [1, 1] : memref<8x16xi32> to memref<8x16xi32, strided<[16, 1]>>
      memref.copy %tile_comp0_buf0, %subview_3 : memref<8x16xi32> to memref<8x16xi32, strided<[16, 1]>>
        aie.objectfifo.release @in0_p0(Consume, 1)
        aie.objectfifo.release @in1_p0(Consume, 1)
        aie.objectfifo.release @out_p0(Produce, 1)
      }
      aie.end
    }
    %core_0_3 = aie.core(%tile_comp1) {
      %c1000 = arith.constant 0 : index
      %c1001 = arith.constant 1 : index
      %c9223372036854775807 = arith.constant 9223372036854775807 : index
      scf.for %arg0 = %c1000 to %c9223372036854775807 step %c1001 {
        %fifo0 = aie.objectfifo.acquire @in0_p1(Consume, 1) : !aie.objectfifosubview<memref<8x16xi32>>
        %local0 = aie.objectfifo.subview.access %fifo0[0] : !aie.objectfifosubview<memref<8x16xi32>> -> memref<8x16xi32>
        %fifo1 = aie.objectfifo.acquire @in1_p0(Consume, 1) : !aie.objectfifosubview<memref<16x16xi32>>
        %local1 = aie.objectfifo.subview.access %fifo1[0] : !aie.objectfifosubview<memref<16x16xi32>> -> memref<16x16xi32>
        %fifo_out = aie.objectfifo.acquire @out_p1(Produce, 1) : !aie.objectfifosubview<memref<8x16xi32>>
        %local_out = aie.objectfifo.subview.access %fifo_out[0] : !aie.objectfifosubview<memref<8x16xi32>> -> memref<8x16xi32>
      %c0_i32 = arith.constant 0 : i32
      %subview = memref.subview %local0[0, 0] [8, 16] [1, 1] : memref<8x16xi32> to memref<8x16xi32, strided<[16, 1]>>
      %c0 = arith.constant 0 : index
      %c8 = arith.constant 8 : index
      %c1 = arith.constant 1 : index
      scf.for %arg3 = %c0 to %c8 step %c1 {
        %c0_4 = arith.constant 0 : index
        %c16 = arith.constant 16 : index
        %c1_5 = arith.constant 1 : index
        scf.for %arg4 = %c0_4 to %c16 step %c1_5 {
          memref.store %c0_i32, %tile_comp1_buf0[%arg3, %arg4] : memref<8x16xi32>
        }
      }
      %c0_0 = arith.constant 0 : index
      %c8_1 = arith.constant 8 : index
      %c1_2 = arith.constant 1 : index
      scf.for %arg3 = %c0_0 to %c8_1 step %c1_2 {
        %c0_4 = arith.constant 0 : index
        %c16 = arith.constant 16 : index
        %c1_5 = arith.constant 1 : index
        scf.for %arg4 = %c0_4 to %c16 step %c1_5 {
          %c0_6 = arith.constant 0 : index
          %c16_7 = arith.constant 16 : index
          %c1_8 = arith.constant 1 : index
          scf.for %arg5 = %c0_6 to %c16_7 step %c1_8 {
            %0 = memref.load %subview[%arg3, %arg5] : memref<8x16xi32, strided<[16, 1]>>
            %1 = memref.load %local1[%arg5, %arg4] : memref<16x16xi32>
            %2 = memref.load %tile_comp1_buf0[%arg3, %arg4] : memref<8x16xi32>
            %3 = arith.muli %0, %1 : i32
            %4 = arith.addi %2, %3 : i32
            memref.store %4, %tile_comp1_buf0[%arg3, %arg4] : memref<8x16xi32>
          }
        }
      }
      %subview_3 = memref.subview %local_out[0, 0] [8, 16] [1, 1] : memref<8x16xi32> to memref<8x16xi32, strided<[16, 1]>>
      memref.copy %tile_comp1_buf0, %subview_3 : memref<8x16xi32> to memref<8x16xi32, strided<[16, 1]>>
        aie.objectfifo.release @in0_p1(Consume, 1)
        aie.objectfifo.release @in1_p0(Consume, 1)
        aie.objectfifo.release @out_p1(Produce, 1)
      }
      aie.end
    }
    aiex.runtime_sequence(%arg0: memref<16x16xi32>, %arg1: memref<16x16xi32>, %arg2: memref<16x16xi32>) {
      aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][1, 1, 16, 16][0, 0, 16, 1]) {id = 1 : i64, issue_token = true, metadata = @in_sh0} : memref<16x16xi32>
      aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 0][1, 1, 32, 16][0, 0, 16, 1]) {id = 2 : i64, issue_token = true, metadata = @in_sh1} : memref<16x16xi32>
      aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 0, 0][1, 1, 16, 16][0, 0, 16, 1]) {id = 0 : i64, metadata = @out_sh} : memref<16x16xi32>
      aiex.npu.dma_wait {symbol = @in_sh0}
      aiex.npu.dma_wait {symbol = @in_sh1}
      aiex.npu.dma_wait {symbol = @out_sh}
    }
  }
}
```


## Checklist ##

- [ ] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [ ] Code is well-documented
