### PR TITLE
[Frontend] Support auto schedule composition for PyTorch models

### DIFF
--- a/allo/backend/llvm.py
+++ b/allo/backend/llvm.py
@@ -1,6 +1,6 @@
 # Copyright Allo authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=no-name-in-module, inconsistent-return-statements, too-many-function-args
+# pylint: disable=no-name-in-module, inconsistent-return-statements
 
 import os
 import ctypes

--- a/allo/customize.py
+++ b/allo/customize.py
@@ -1010,10 +1010,12 @@ def customize(
     # Get Python AST
     if isinstance(fn, str):
         src, starting_line_no = fn, 1
+        file_name = None
     else:
         src, starting_line_no = inspect.getsourcelines(fn)
         src = [textwrap.fill(line, tabsize=4, width=9999) for line in src]
         src = textwrap.dedent("\n".join(src))
+        file_name = inspect.getfile(fn)
     tree = parse_ast(src, starting_line_no=starting_line_no, verbose=verbose)
     if instantiate is None:
         instantiate = []
@@ -1039,7 +1041,6 @@ def customize(
         enable_tensor=enable_tensor,
         verbose=verbose,
     )
-    file_name = inspect.getfile(fn)
     module = ASTTransformer()(ctx, tree, file_name)
     if lower_linalg:
         lower_linalg_and_attach_names(module)

--- a/allo/ir/builder.py
+++ b/allo/ir/builder.py
@@ -1734,7 +1734,8 @@ class ASTTransformer(ASTBuilder):
         elif isinstance(node.func, ast.Subscript):
             obj = ASTResolver.resolve(node.func.value, ctx.global_vars)
             assert obj is not None, "Unsupported function call"
-            obj_name = node.func.value.id
+            obj_name = obj.__name__
+            ctx.global_vars[obj_name] = obj
             ctx.inst = ASTResolver.resolve_param_types(node.func.slice, ctx.global_vars)
             if ctx.func_id is None:
                 func_id = get_func_id_from_param_types(ctx.inst)

--- a/allo/ir/builder.py
+++ b/allo/ir/builder.py
@@ -1734,7 +1734,9 @@ class ASTTransformer(ASTBuilder):
         elif isinstance(node.func, ast.Subscript):
             obj = ASTResolver.resolve(node.func.value, ctx.global_vars)
             assert obj is not None, "Unsupported function call"
-            obj_name = obj.__name__
+            obj_name = (
+                node.func.value.id if isinstance(obj, func_d.FuncOp) else obj.__name__
+            )
             ctx.global_vars[obj_name] = obj
             ctx.inst = ASTResolver.resolve_param_types(node.func.slice, ctx.global_vars)
             if ctx.func_id is None:

--- a/allo/ir/infer.py
+++ b/allo/ir/infer.py
@@ -724,7 +724,8 @@ class TypeInferer(ASTVisitor):
         elif isinstance(node.func, ast.Subscript):
             obj = ASTResolver.resolve(node.func.value, ctx.global_vars)
             assert obj is not None, "Unsupported function call"
-            obj_name = node.func.value.id
+            obj_name = obj.__name__
+            ctx.global_vars[obj_name] = obj
             ctx.inst = ASTResolver.resolve_param_types(node.func.slice, ctx.global_vars)
             if ctx.func_id is None:
                 func_id = get_func_id_from_param_types(ctx.inst)
@@ -861,7 +862,6 @@ class TypeInferer(ASTVisitor):
         else:
             # Visit arguments in the top-level
             visit_stmts(ctx, node.args)
-            func = ctx.global_vars[obj_name]
             src, starting_line_no = inspect.getsourcelines(func)
             src = [textwrap.fill(line, tabsize=4, width=9999) for line in src]
             src = textwrap.dedent("\n".join(src))

--- a/allo/library/__init__.py
+++ b/allo/library/__init__.py
@@ -16,6 +16,8 @@ from .gemv import (
 )
 
 from .nn import (
+    linear,
+    schedule_linear,
     softmax,
     schedule_softmax,
     layer_norm,
@@ -38,6 +40,7 @@ KERNEL2SCHEDULE[int8xint8_mat_vec] = schedule_int8xint8_mat_vec
 
 KERNEL2SCHEDULE.update(
     {
+        linear: schedule_linear,
         softmax: schedule_softmax,
         layer_norm: schedule_layernorm,
         GeLU: schedule_gelu,

--- a/allo/library/__init__.py
+++ b/allo/library/__init__.py
@@ -18,6 +18,8 @@ from .gemv import (
 from .nn import (
     linear,
     schedule_linear,
+    relu,
+    schedule_relu,
     softmax,
     schedule_softmax,
     layer_norm,
@@ -41,6 +43,7 @@ KERNEL2SCHEDULE[int8xint8_mat_vec] = schedule_int8xint8_mat_vec
 KERNEL2SCHEDULE.update(
     {
         linear: schedule_linear,
+        relu: schedule_relu,
         softmax: schedule_softmax,
         layer_norm: schedule_layernorm,
         GeLU: schedule_gelu,

--- a/allo/library/nn.py
+++ b/allo/library/nn.py
@@ -27,9 +27,6 @@ def schedule_linear(s):
     s.pipeline(f"linear:j")
     s.pipeline(f"linear:j_init")
     s.pipeline(f"linear:j_back")
-    # s.partition(
-    #     MockBuffer(f"linear{lid}", "buf"), dim=0, partition_type=2, factor=factor
-    # )
     return s
 
 

--- a/allo/library/nn.py
+++ b/allo/library/nn.py
@@ -24,9 +24,9 @@ def linear[Ty, M, N, K](X: "Ty[M, K]", W: "Ty[N, K]", b: "Ty[N]") -> "Ty[M, N]":
 
 
 def schedule_linear(s):
-    s.pipeline(f"linear:j")
-    s.pipeline(f"linear:j_init")
-    s.pipeline(f"linear:j_back")
+    s.pipeline("linear:j")
+    s.pipeline("linear:j_init")
+    s.pipeline("linear:j_back")
     return s
 
 
@@ -38,7 +38,7 @@ def relu[Ty, L, D](X: "Ty[L, D]") -> "Ty[L, D]":
 
 
 def schedule_relu(s):
-    s.pipeline(f"relu:j")
+    s.pipeline("relu:j")
     return s
 
 

--- a/allo/library/nn.py
+++ b/allo/library/nn.py
@@ -30,6 +30,18 @@ def schedule_linear(s):
     return s
 
 
+def relu[Ty, L, D](X: "Ty[L, D]") -> "Ty[L, D]":
+    Z: Ty[L, D]
+    for i, j in dsl.grid(L, D):
+        Z[i, j] = max(0.0, X[i, j])
+    return Z
+
+
+def schedule_relu(s):
+    s.pipeline(f"relu:j")
+    return s
+
+
 def softmax[Ty, L](X: "Ty[L, L]") -> "Ty[L, L]":
     Z: Ty[L, L]
     E: Ty[L, L]

--- a/examples/torch/mlp.py
+++ b/examples/torch/mlp.py
@@ -10,7 +10,7 @@ import allo
 class MLP(nn.Module):
     def __init__(self):
         super().__init__()
-        self.linear1 = torch.nn.Linear(16, 32) # 8*16 * 32*16
+        self.linear1 = torch.nn.Linear(16, 32)  # 8*16 * 32*16
         self.linear2 = torch.nn.Linear(32, 10)
 
     def forward(self, data):

--- a/examples/torch/mlp.py
+++ b/examples/torch/mlp.py
@@ -10,8 +10,8 @@ import allo
 class MLP(nn.Module):
     def __init__(self):
         super().__init__()
-        self.linear1 = torch.nn.Linear(30, 30)
-        self.linear2 = torch.nn.Linear(30, 30)
+        self.linear1 = torch.nn.Linear(16, 32) # 8*16 * 32*16
+        self.linear2 = torch.nn.Linear(32, 10)
 
     def forward(self, data):
         out = self.linear1(data)
@@ -22,11 +22,12 @@ class MLP(nn.Module):
 
 model = MLP()
 model.eval()
-example_inputs = [torch.rand(30, 30)]
+example_inputs = [torch.rand(8, 16)]
 llvm_mod = allo.frontend.from_pytorch(
-    model, example_inputs=example_inputs, verbose=False
+    model, example_inputs=example_inputs, verbose=True
 )
 golden = model(*example_inputs)
 np_inputs = [x.detach().numpy() for x in example_inputs]
 res = llvm_mod(*np_inputs)
 torch.testing.assert_close(res, golden.detach().numpy())
+print("Passed!")


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR automatically dispatches PyTorch operations to Allo kernels and applies pre-defined schedules.


### Examples ###
```python
import torch
import torch.nn.functional as F
import torch.nn as nn
import allo


class MLP(nn.Module):
    def __init__(self):
        super().__init__()
        self.linear1 = torch.nn.Linear(16, 32)  # 8*16 * 32*16
        self.linear2 = torch.nn.Linear(32, 10)

    def forward(self, data):
        out = self.linear1(data)
        out = self.linear2(out)
        out = F.relu(out)
        return out


model = MLP()
model.eval()
example_inputs = [torch.rand(8, 16)]
llvm_mod = allo.frontend.from_pytorch(
    model, example_inputs=example_inputs, verbose=True
)
golden = model(*example_inputs)
np_inputs = [x.detach().numpy() for x in example_inputs]
res = llvm_mod(*np_inputs)
torch.testing.assert_close(res, golden.detach().numpy())
print("Passed!")

```
```mlir
graph():
    %data : [num_users=1] = placeholder[target=data]
    %linear1 : [num_users=1] = call_module[target=linear1](args = (%data,), kwargs = {})
    %linear2 : [num_users=1] = call_module[target=linear2](args = (%linear1,), kwargs = {})
    %relu : [num_users=1] = call_function[target=torch.nn.functional.relu](args = (%linear2,), kwargs = {inplace: False})
    return relu

def forward(data: float32[8, 16]) -> (float32[8, 10]):
    linear1_weight: float32[32, 16] = g_linear1_weight
    linear1_bias: float32[32] = g_linear1_bias
    linear2_weight: float32[10, 32] = g_linear2_weight
    linear2_bias: float32[10] = g_linear2_bias
    linear1 = nn.linear[float32, 8, 32, 16, "1"](data, linear1_weight, linear1_bias)
    linear2 = nn.linear[float32, 8, 10, 32, "2"](linear1, linear2_weight, linear2_bias)
    relu = nn.relu[float32, 8, 10](linear2)
    return (relu)

module {
  memref.global "private" @linear1_weight ...
  func.func @linear_1(%arg0: memref<8x16xf32>, %arg1: memref<32x16xf32>, %arg2: memref<32xf32>) -> memref<8x32xf32> attributes {itypes = "___", otypes = "_"} {
    %alloc = memref.alloc() {name = "Z"} : memref<8x32xf32>
    %alloc_0 = memref.alloc() {name = "buf"} : memref<32xf32>
    affine.for %arg3 = 0 to 8 {
      affine.for %arg4 = 0 to 32 {
        %c0_i32 = arith.constant 0 : i32
        %0 = arith.sitofp %c0_i32 : i32 to f32
        affine.store %0, %alloc_0[%arg4] {to = "buf"} : memref<32xf32>
      } {loop_name = "j_init", op_name = "S_j_init_0", pipeline_ii = 1 : ui32}
      affine.for %arg4 = 0 to 16 {
        %0 = affine.load %arg0[%arg3, %arg4] {from = "X"} : memref<8x16xf32>
        %alloc_1 = memref.alloc() {name = "x"} : memref<f32>
        affine.store %0, %alloc_1[] {to = "x"} : memref<f32>
        affine.for %arg5 = 0 to 32 {
          %1 = affine.load %arg1[%arg5, %arg4] {from = "W"} : memref<32x16xf32>
          %2 = affine.load %alloc_1[] {from = "x"} : memref<f32>
          %3 = arith.mulf %2, %1 : f32
          %4 = affine.load %alloc_0[%arg5] {from = "buf"} : memref<32xf32>
          %5 = arith.addf %4, %3 : f32
          affine.store %5, %alloc_0[%arg5] {to = "buf"} : memref<32xf32>
        } {loop_name = "j", op_name = "S_j_1", pipeline_ii = 1 : ui32}
      } {loop_name = "k", op_name = "S_k_1"}
      affine.for %arg4 = 0 to 32 {
        %0 = affine.load %alloc_0[%arg4] {from = "buf"} : memref<32xf32>
        %1 = affine.load %arg2[%arg4] {from = "b"} : memref<32xf32>
        %2 = arith.addf %0, %1 : f32
        affine.store %2, %alloc[%arg3, %arg4] {to = "Z"} : memref<8x32xf32>
      } {loop_name = "j_back", op_name = "S_j_back_3", pipeline_ii = 1 : ui32}
    } {loop_name = "i", op_name = "S_i_0"}
    return %alloc : memref<8x32xf32>
  }
  func.func @linear_2(%arg0: memref<8x32xf32>, %arg1: memref<10x32xf32>, %arg2: memref<10xf32>) -> memref<8x10xf32> attributes {itypes = "___", otypes = "_"} {
    %alloc = memref.alloc() {name = "Z"} : memref<8x10xf32>
    %alloc_0 = memref.alloc() {name = "buf"} : memref<10xf32>
    affine.for %arg3 = 0 to 8 {
      affine.for %arg4 = 0 to 10 {
        %c0_i32 = arith.constant 0 : i32
        %0 = arith.sitofp %c0_i32 : i32 to f32
        affine.store %0, %alloc_0[%arg4] {to = "buf"} : memref<10xf32>
      } {loop_name = "j_init", op_name = "S_j_init_0", pipeline_ii = 1 : ui32}
      affine.for %arg4 = 0 to 32 {
        %0 = affine.load %arg0[%arg3, %arg4] {from = "X"} : memref<8x32xf32>
        %alloc_1 = memref.alloc() {name = "x"} : memref<f32>
        affine.store %0, %alloc_1[] {to = "x"} : memref<f32>
        affine.for %arg5 = 0 to 10 {
          %1 = affine.load %arg1[%arg5, %arg4] {from = "W"} : memref<10x32xf32>
          %2 = affine.load %alloc_1[] {from = "x"} : memref<f32>
          %3 = arith.mulf %2, %1 : f32
          %4 = affine.load %alloc_0[%arg5] {from = "buf"} : memref<10xf32>
          %5 = arith.addf %4, %3 : f32
          affine.store %5, %alloc_0[%arg5] {to = "buf"} : memref<10xf32>
        } {loop_name = "j", op_name = "S_j_1", pipeline_ii = 1 : ui32}
      } {loop_name = "k", op_name = "S_k_1"}
      affine.for %arg4 = 0 to 10 {
        %0 = affine.load %alloc_0[%arg4] {from = "buf"} : memref<10xf32>
        %1 = affine.load %arg2[%arg4] {from = "b"} : memref<10xf32>
        %2 = arith.addf %0, %1 : f32
        affine.store %2, %alloc[%arg3, %arg4] {to = "Z"} : memref<8x10xf32>
      } {loop_name = "j_back", op_name = "S_j_back_3", pipeline_ii = 1 : ui32}
    } {loop_name = "i", op_name = "S_i_0"}
    return %alloc : memref<8x10xf32>
  }
  func.func @relu(%arg0: memref<8x10xf32>) -> memref<8x10xf32> attributes {itypes = "_", otypes = "_"} {
    %alloc = memref.alloc() {name = "Z"} : memref<8x10xf32>
    affine.for %arg1 = 0 to 8 {
      affine.for %arg2 = 0 to 10 {
        %0 = affine.load %arg0[%arg1, %arg2] {from = "X"} : memref<8x10xf32>
        %cst = arith.constant 0.000000e+00 : f32
        %1 = arith.maximumf %cst, %0 : f32
        affine.store %1, %alloc[%arg1, %arg2] {to = "Z"} : memref<8x10xf32>
      } {loop_name = "j", pipeline_ii = 1 : ui32}
    } {loop_name = "i", op_name = "S_i_j_0"}
    return %alloc : memref<8x10xf32>
  }
  func.func @forward(%arg0: memref<8x16xf32>) -> memref<8x10xf32> attributes {itypes = "_", otypes = "_"} {
    %0 = memref.get_global @linear1_weight : memref<32x16xf32>
    %1 = memref.get_global @linear1_bias : memref<32xf32>
    %2 = memref.get_global @linear2_weight : memref<10x32xf32>
    %3 = memref.get_global @linear2_bias : memref<10xf32>
    %4 = call @linear_1(%arg0, %0, %1) {name = "linear1"} : (memref<8x16xf32>, memref<32x16xf32>, memref<32xf32>) -> memref<8x32xf32>
    %5 = call @linear_2(%4, %2, %3) {name = "linear2"} : (memref<8x32xf32>, memref<10x32xf32>, memref<10xf32>) -> memref<8x10xf32>
    %6 = call @relu(%5) {name = "relu"} : (memref<8x10xf32>) -> memref<8x10xf32>
    return %6 : memref<8x10xf32>
  }
}
```


## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [x] Code is well-documented
