### PR TITLE
[Backend][AIE] Support pure memref builder for AIE backend

### DIFF
--- a/allo/backend/llvm.py
+++ b/allo/backend/llvm.py
@@ -1,6 +1,6 @@
 # Copyright Allo authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=no-name-in-module, inconsistent-return-statements
+# pylint: disable=no-name-in-module, inconsistent-return-statements, too-many-function-args
 
 import os
 import ctypes

--- a/allo/dataflow.py
+++ b/allo/dataflow.py
@@ -295,10 +295,10 @@ def build(
 ):
     if target == "aie":
         global_vars = get_global_vars(func)
-        s = _customize(func, global_vars=global_vars, enable_tensor=True)
+        s = _customize(func, global_vars=global_vars, enable_tensor=enable_tensor)
         # stream_info = move_stream_to_interface(s)
         # s = _build_top(s, stream_info, enable_tensor=True)
-        mod = AIEModule(s.module, s.top_func_name, project, func.mappings)
+        mod = AIEModule(s.module, s.top_func_name, project, func.mappings, enable_tensor)
         mod.build()
         return mod
     if target == "simulator":

--- a/allo/dataflow.py
+++ b/allo/dataflow.py
@@ -298,7 +298,9 @@ def build(
         s = _customize(func, global_vars=global_vars, enable_tensor=enable_tensor)
         # stream_info = move_stream_to_interface(s)
         # s = _build_top(s, stream_info, enable_tensor=True)
-        mod = AIEModule(s.module, s.top_func_name, project, func.mappings, enable_tensor)
+        mod = AIEModule(
+            s.module, s.top_func_name, project, func.mappings, enable_tensor
+        )
         mod.build()
         return mod
     if target == "simulator":

--- a/allo/ir/builder.py
+++ b/allo/ir/builder.py
@@ -1117,7 +1117,7 @@ class ASTTransformer(ASTBuilder):
     @staticmethod
     def build_memory_access(ctx, node, val=None, idx=0):
         value = build_stmt(ctx, node.value)
-        if len(node.shape) >= 1:
+        if isinstance(node.slice, ast.Slice) and len(node.shape) >= 1:
             dtype = MemRefType(value.result.type).element_type
             in_shape = MemRefType(value.result.type).shape
             (

--- a/allo/ir/builder.py
+++ b/allo/ir/builder.py
@@ -1131,7 +1131,7 @@ class ASTTransformer(ASTBuilder):
                 orig_offset = orig_layout.offset
                 orig_strides = orig_layout.strides
             elif isinstance(orig_layout, AffineMapAttr):
-                # TODO: need to non-identity affine map
+                # TODO: need to support non-identity affine map
                 orig_offset = 0
                 orig_strides = []
                 times = 1

--- a/allo/ir/builder.py
+++ b/allo/ir/builder.py
@@ -1138,7 +1138,10 @@ class ASTTransformer(ASTBuilder):
                 strides=[],
                 ip=ctx.get_ip(),
             )
-            op = subview
+            if isinstance(node.ctx, ast.Load):
+                op = subview
+            else:
+                op = memref_d.CopyOp(val.result, subview.result, ip=ctx.get_ip())
         else:
             new_indices, is_affine = ASTTransformer.build_indices(ctx, node.slice)
             if len(node.value.shape) > len(new_indices):  # partial access


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR introduces support for building the AIE backend without relying on the tensor dialect. This enables top function construction and optimization for operation fusion. Users can select between tensor dialect-based and memref dialect-based building using the `enable_tensor` option.


### Examples ###
```python
import allo.dataflow as df
from allo.ir.types import int32
import numpy as np
import allo

Ty = int32
M, N, K = 16, 16, 16
P0, P1 = 2, 2
Mt, Nt = M // P0, N // P1

@df.region()
def top():
    @df.kernel(mapping=[P0, P1])
    def gemm(A: Ty[M, K], B: Ty[K, N], C: Ty[M, N]):
        p0, p1 = df.get_pid()
        C[p0 * Mt : (p0 + 1) * Mt, p1 * Nt : (p1 + 1) * Nt] = allo.matmul(
            A[p0 * Mt : (p0 + 1) * Mt, :], B[:, p1 * Nt : (p1 + 1) * Nt]
        )

mod = df.build(top, target="aie", enable_tensor=False)
A = np.random.randint(0, 64, (M, K)).astype(np.int32)
B = np.random.randint(0, 64, (K, N)).astype(np.int32)
C = np.zeros((M, N)).astype(np.int32)
mod(A, B, C)
np.testing.assert_allclose(C, A @ B, atol=1e-5)
print("PASSED!")
```


## Checklist ##

- [ ] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [ ] Code is well-documented
