### PR TITLE
[Pass] Preprocess Reduction Loops

### DIFF
--- a/allo/passes.py
+++ b/allo/passes.py
@@ -316,6 +316,8 @@ def generate_input_output_buffers(module, top_func_name, flatten=False, mappings
 # pylint: disable=dangerous-default-value
 def analyze_arg_load_store_in_func(func, mapping={}):
     res = []
+    if func.is_external:
+        return ["in"] * len(func.type.inputs)
     for _, arg in enumerate(func.arguments):
         if not isinstance(arg.type, MemRefType):
             res.append("scalar")

--- a/allo/passes.py
+++ b/allo/passes.py
@@ -20,7 +20,9 @@ from ._mlir.ir import (
     Module,
     IntegerAttr,
     IntegerType,
+    IntegerSetAttr,
     Operation,
+    Block,
 )
 from ._mlir.dialects import (
     allo as allo_d,
@@ -314,8 +316,6 @@ def generate_input_output_buffers(module, top_func_name, flatten=False, mappings
 # pylint: disable=dangerous-default-value
 def analyze_arg_load_store_in_func(func, mapping={}):
     res = []
-    if func.is_external:
-        return ["in"] * len(func.type.inputs)
     for _, arg in enumerate(func.arguments):
         if not isinstance(arg.type, MemRefType):
             res.append("scalar")
@@ -742,7 +742,7 @@ def dataflow_canonicalization_pass(module):
     """
     Implements the dataflow canonicalization pass as described in the Stream-HLS paper (https://arxiv.org/pdf/2501.09118)
 
-    This pass ensures that the program is compatible with dataflow architectures by transforming shared buffers to adhere to single-producer-single-consumer patterns. This pass does not handle complex patterns involving multiple producers writing to the same buffer.
+    This pass ensures that the program is compatible with dataflow architectures by transforming shared buffers to adhere to single-producer-single-consumer patterns. This pass does not handle complex patterns involving multiple producers writing to the same buffer, except in the case of reduction loops.
     """
     with module.context, Location.unknown():
         for op in module.body.operations:
@@ -763,14 +763,16 @@ def canonicalize_fn(op: func_d.FuncOp):
 
 def canonicalize_call(op: func_d.CallOp):
     for result in op.results:
-        loads = []
-        stores = []
+        loads = []  # (op, idx)
+        stores = []  # ops
         for use in result.uses:
             user = use.owner
             if isinstance(
                 user, (memref_d.LoadOp, affine_d.AffineLoadOp, func_d.CallOp)
             ):
-                loads.append(user)
+                for idx, operand in enumerate(user.operands):
+                    if operand == op.result:
+                        loads.append((user, idx))
             elif isinstance(user, (memref_d.StoreOp, affine_d.AffineStoreOp)):
                 stores.append(user)
 
@@ -822,19 +824,27 @@ def canonicalize_call(op: func_d.CallOp):
             with InsertionPoint(loop.body):
                 affine_d.AffineYieldOp([])
 
-        for idx, user in enumerate(loads):
-            user.operation.replace_uses_of_with(result, new_allocs[idx].result)
+        for idx, (user, op_idx) in enumerate(loads):
+            user.operation.operands[op_idx] = new_allocs[idx].result
 
 
 def canonicalize_alloc(alloc_op):
-    loads = []
-    stores = []
+    """
+    Updated canonicalize_alloc function that incorporates the StoreLoadStoreLoad pattern.
+    """
+    loads = []  # (op, idx)
+    stores = []  # ops
+    returns = []  # ops
     for use in alloc_op.result.uses:
         user = use.owner
         if isinstance(user, (memref_d.LoadOp, affine_d.AffineLoadOp, func_d.CallOp)):
-            loads.append(user)
+            for idx, operand in enumerate(user.operands):
+                if operand == alloc_op.result:
+                    loads.append((user, idx))
         elif isinstance(user, (memref_d.StoreOp, affine_d.AffineStoreOp)):
             stores.append(user)
+        elif isinstance(user, func_d.ReturnOp):
+            returns.append(user)
 
     memref_type = alloc_op.result.type
     shape = memref_type.shape
@@ -848,17 +858,136 @@ def canonicalize_alloc(alloc_op):
     # single store with multiple loads.
     if len(stores) == 1 and len(loads) > 1:
         store = stores[0]
-        for i, load in enumerate(loads[1:]):
+        for i, (load, idx) in enumerate(loads[1:]):
             new_alloc = alloc_op.operation.clone(ip=InsertionPoint(alloc_op))
             new_alloc.attributes["name"] = StringAttr.get(f"{orig_name}_split_{i}")
             store_dup = store.clone(ip=InsertionPoint(store))
             store_dup.operation.replace_uses_of_with(alloc_op.result, new_alloc.result)
-            print(store_dup.memref, new_alloc.result)
-            load.operation.replace_uses_of_with(store.memref, new_alloc.result)
+            # load.operation.replace_uses_of_with(store.memref, new_alloc.result)
+            load.operation.operands[idx] = new_alloc.result
         return
+
+    # store-load-store-load loop redunction pattern
+    if len(stores) == 2 and len(loads) + len(returns) == 2:
+        l_ops = [l[0] for l in loads]
+        l_ops.extend(returns)
+        if store_load_store_load_pattern(alloc_op, l_ops, stores):
+            return
 
     # multiple loads and multiple stores
     if len(stores) >= 2 or len(loads) >= 2:
         raise NotImplementedError(
             "Complex pattern detected in alloc op; additional canonicalization not implemented yet."
         )
+
+
+def store_load_store_load_pattern(alloc_op, loads, stores):
+    """
+    Transforms reduction loops to satisfy the condition that the number of writes to a shared buffer equals the number of reads.
+    """
+    assert len(loads) == 2 and len(stores) == 2
+
+    loop_load, loop_store = None, None
+
+    # find loop_load and loop_store
+    for load in loads:
+        for store in stores:
+            if load.parent == store.parent:
+                loop_load = load
+                loop_store = store
+                break
+        if loop_load:
+            break
+
+    if not loop_load or not loop_store:
+        return False
+
+    store_op = [s for s in stores if s != loop_store][0]
+    load_op = [l for l in loads if l != loop_load][0]
+
+    # check for unsupported store_op in an if block
+    parent = store_op.parent
+    while parent:
+        if isinstance(parent, affine_d.AffineIfOp):
+            return False
+        parent = parent.parent
+
+    loop_nest = []
+    current_op = loop_load.parent
+    while current_op:
+        if isinstance(current_op.opview, affine_d.AffineForOp):
+            loop_nest.append(current_op.opview)
+        current_op = current_op.parent
+    if not loop_nest:
+        return False
+
+    ip = InsertionPoint(alloc_op)
+    memref_type = alloc_op.result.type
+    new_alloc1 = memref_d.AllocOp(memref_type, [], [], ip=ip)
+    new_alloc2 = memref_d.AllocOp(memref_type, [], [], ip=ip)
+
+    loop_ivs = [loop.induction_variable for loop in loop_nest]  # innermost IV first
+
+    with InsertionPoint.at_block_begin(loop_nest[0].body):
+        first_iter_set = affine_d.IntegerSet.get(
+            1, 0, [affine_d.AffineExpr.get_dim(0)], [True]
+        )
+
+        first_iter_if = affine_d.AffineIfOp(
+            results_=[], _gen_arg_0=[loop_ivs[0]], loc=Location.unknown()
+        )
+
+        first_iter_if.attributes["condition"] = IntegerSetAttr.get(first_iter_set)
+
+    # In the if block, load from original buffer and store to new_alloc1
+    then_block = Block.create_at_start(parent=first_iter_if.thenRegion)
+    with InsertionPoint(then_block):
+        new_load = affine_d.AffineLoadOp(
+            memref_type.element_type, alloc_op.result, loop_load.indices, loop_load.map
+        )
+        affine_d.AffineStoreOp(
+            new_load.result, new_alloc1.result, loop_load.indices, loop_load.map
+        )
+        affine_d.AffineYieldOp([])
+
+    loop_load.operation.replace_uses_of_with(alloc_op.result, new_alloc1.result)
+    loop_store.operation.replace_uses_of_with(alloc_op.result, new_alloc1.result)
+
+    inner_loop_upper_map = loop_nest[-1].upperBoundMap.value
+
+    # check upper bound is a constant
+    if not (
+        inner_loop_upper_map.n_dims == 0 and len(inner_loop_upper_map.results) == 1
+    ):
+        return False
+
+    loop_upper_bound = inner_loop_upper_map.results[0]
+
+    last_iter_set = affine_d.IntegerSet.get(
+        1, 0, [affine_d.AffineExpr.get_dim(0) - loop_upper_bound + 1], [True]
+    )
+
+    last_iter_if = affine_d.AffineIfOp(
+        results_=[], _gen_arg_0=[loop_ivs[0]], loc=Location.unknown(), ip=ip
+    )
+
+    last_iter_if.move_after(loop_store)
+
+    last_iter_if.attributes["condition"] = IntegerSetAttr.get(last_iter_set)
+
+    final_then_block = Block.create_at_start(parent=last_iter_if.thenRegion)
+    with InsertionPoint(final_then_block):
+        final_loop_load = affine_d.AffineLoadOp(
+            memref_type.element_type,
+            new_alloc1.result,
+            loop_load.indices,
+            loop_load.map,
+        )
+        affine_d.AffineStoreOp(
+            final_loop_load.result, new_alloc2.result, loop_load.indices, loop_load.map
+        )
+        affine_d.AffineYieldOp([])
+
+    load_op.operation.replace_uses_of_with(alloc_op.result, new_alloc2.result)
+
+    return True

--- a/tests/test_canonicalization.py
+++ b/tests/test_canonicalization.py
@@ -8,10 +8,11 @@ from allo.ir.types import int32, float32, MemRefType
 from allo._mlir.dialects import func as func_d
 from allo._mlir.dialects import memref as memref_d
 from allo._mlir.dialects import affine as affine_d
-from allo.passes import dataflow_canonicalization_pass as dcp
+from allo.passes import dataflow_canonicalization_pass as dcp, _mlir_lower_pipeline
 from allo._mlir.ir import WalkResult
 from allo.customize import Schedule
 
+from allo.ir.transform import find_func_in_module
 
 def check_single_producer_single_consumer(module):
     spsc = True
@@ -33,8 +34,11 @@ def check_single_producer_single_consumer(module):
                         use.owner,
                         (func_d.CallOp, memref_d.LoadOp, affine_d.AffineLoadOp),
                     )
+                    # ignore if inside if-statement
+                    and not isinstance(use.owner.parent.opview, affine_d.AffineForOp)
                 )
                 if consumers > 1:
+                    print(op)
                     spsc = False
                     return WalkResult(0)
         return WalkResult(0)
@@ -48,9 +52,12 @@ def check_single_producer_single_consumer(module):
 
 
 def canonicalize(schedule: Schedule) -> Schedule:
+    fn_name = schedule.top_func.name.value
+    mod = _mlir_lower_pipeline(schedule.module, lower_linalg=True)
+    f = find_func_in_module(mod, fn_name)
     return Schedule(
-        dcp(schedule.module),
-        schedule.top_func,
+        dcp(mod),
+        f,
         schedule.func_args,
         schedule.ip,
         schedule.ext_libs,
@@ -180,6 +187,96 @@ def test_nd_array():
     mod = s.build()
     res = mod()
     np.testing.assert_array_equal(res, 0)
+    assert check_single_producer_single_consumer(s.module)
+
+
+def test_matmul_addition_condition1():
+    """Checks that the matmul reduction loop is transformed correctly as described in the Stream-HLS paper (https://arxiv.org/pdf/2501.09118)."""
+
+    def matmul_addition() -> float32[8, 8]:
+        A: float32[8, 8] = 1.0
+        B: float32[8, 8] = 2.0
+        C: float32[8, 8] = 0.0
+        D: float32[8, 8] = 3.0
+
+        for i in range(8):
+            for j in range(8):
+                for k in range(8):
+                    C[i, j] = C[i, j] + A[i, k] * B[k, j]
+
+        E: float32[8, 8]
+        for i in range(8):
+            for j in range(8):
+                E[i, j] = C[i, j] + D[i, j]
+
+        return E
+
+    s = allo.customize(matmul_addition)
+    print(s.module)
+
+    s = canonicalize(s)
+    print(s.module)
+
+    mod = s.build()
+    res = mod()
+
+    expected = (
+        np.full((8, 8), 1.0, dtype=np.float32) @ np.full((8, 8), 2.0, dtype=np.float32)
+        + 3.0
+    )
+
+    np.testing.assert_allclose(res, expected, rtol=1e-5)
+    assert check_single_producer_single_consumer(s.module)
+
+
+def test_matmul_addition_nested_condition1():
+    def matrix_multiply(A: float32[8, 8], B: float32[8, 8]) -> float32[8, 8]:
+        C: float32[8, 8] = 0
+        for i in range(8):
+            for j in range(8):
+                for k in range(8):
+                    C[i, j] = C[i, j] + A[i, k] * B[k, j]
+        return C
+
+    def matrix_add(C: float32[8, 8], D: float32[8, 8]) -> float32[8, 8]:
+        E: float32[8, 8]
+        for i in range(8):
+            for j in range(8):
+                E[i, j] = C[i, j] + D[i, j]
+        return E
+
+    def top() -> float32[8, 8]:
+        A: float32[8, 8] = 1.0
+        B: float32[8, 8] = 2.0
+        D: float32[8, 8] = 3.0
+
+        C = matrix_multiply(A, B)
+
+        E1 = matrix_add(C, D)
+        E2 = matrix_add(C, C)  # Use C twice to force split
+
+        return E1
+
+    mm = allo.customize(matrix_multiply)
+    ma = allo.customize(matrix_add)
+    s = allo.customize(top)
+
+    s.compose([mm, ma])
+
+    print("Before preprocessing:")
+    print(s.module)
+
+    s = canonicalize(s)
+
+    print("After preprocessing:")
+    print(s.module)
+
+    mod = s.build()
+    res = mod()
+
+    expected = np.full((8, 8), 19.0, dtype=np.float32)
+    np.testing.assert_allclose(res, expected, rtol=1e-5)
+
     assert check_single_producer_single_consumer(s.module)
 
 

--- a/tests/test_canonicalization.py
+++ b/tests/test_canonicalization.py
@@ -39,7 +39,7 @@ def check_single_producer_single_consumer(module):
                     and not isinstance(use.owner.parent.opview, affine_d.AffineForOp)
                 )
                 if consumers > 1:
-                    print(op)
+                    print("Multiple consumers of buffer allocated by,", op)
                     spsc = False
                     return WalkResult(0)
         return WalkResult(0)

--- a/tests/test_canonicalization.py
+++ b/tests/test_canonicalization.py
@@ -14,6 +14,7 @@ from allo.customize import Schedule
 
 from allo.ir.transform import find_func_in_module
 
+
 def check_single_producer_single_consumer(module):
     spsc = True
 
@@ -213,7 +214,6 @@ def test_matmul_addition_condition1():
 
     s = allo.customize(matmul_addition)
     print(s.module)
-
     s = canonicalize(s)
     print(s.module)
 
@@ -263,12 +263,8 @@ def test_matmul_addition_nested_condition1():
 
     s.compose([mm, ma])
 
-    print("Before preprocessing:")
     print(s.module)
-
     s = canonicalize(s)
-
-    print("After preprocessing:")
     print(s.module)
 
     mod = s.build()


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR is the first of many for an autoscheduling optimization (https://github.com/cornell-zhang/allo/discussions/297) outlined in the stream-hls paper that implements preprocessing of reduction loops. 
### Problems ###
Legal conversion of shared buffers to FIFO requires that the number of writes to the shared buffer equals the number of reads. Below is a violation of this condition, where matrix C is written to $8^3$ times, while only read from $8^2$ times. 

```python
def matmul_addition() -> float32[8, 8]:
        A: float32[8, 8] = 1.0
        B: float32[8, 8] = 2.0
        C: float32[8, 8] = 0.0
        D: float32[8, 8] = 3.0

        for i in range(8):
            for j in range(8):
                for k in range(8):
                    C[i, j] = C[i, j] + A[i, k] * B[k, j]

        E: float32[8, 8]
        for i in range(8):
            for j in range(8):
                E[i, j] = C[i, j] + D[i, j]

        return E
```

### Proposed Solutions ###
The pass works in conjunction with canonicalization (https://github.com/cornell-zhang/allo/pull/304) to find reduction loops. It then transforms the code to satisfy the desired form by inserting two additional buffers that are conditionally read/written to in the first and last loop iteration to break the data reuse pattern. 

Note: linalg should be lowered to affine before performing this pass. 
### Examples ###
Before pass:
```mlir
module {
  func.func @matmul_addition() -> memref<8x8xf32> attributes {itypes = "", otypes = "_"} {
    %alloc = memref.alloc() {name = "A"} : memref<8x8xf32>
    %cst = arith.constant 1.000000e+00 : f32
    linalg.fill ins(%cst : f32) outs(%alloc : memref<8x8xf32>)
    %alloc_0 = memref.alloc() {name = "B"} : memref<8x8xf32>
    %cst_1 = arith.constant 2.000000e+00 : f32
    linalg.fill ins(%cst_1 : f32) outs(%alloc_0 : memref<8x8xf32>)
    %alloc_2 = memref.alloc() {name = "C"} : memref<8x8xf32>
    %cst_3 = arith.constant 0.000000e+00 : f32
    linalg.fill ins(%cst_3 : f32) outs(%alloc_2 : memref<8x8xf32>)
    %alloc_4 = memref.alloc() {name = "D"} : memref<8x8xf32>
    %cst_5 = arith.constant 3.000000e+00 : f32
    linalg.fill ins(%cst_5 : f32) outs(%alloc_4 : memref<8x8xf32>)
    affine.for %arg0 = 0 to 8 {
      affine.for %arg1 = 0 to 8 {
        affine.for %arg2 = 0 to 8 {
          %0 = affine.load %alloc_2[%arg0, %arg1] {from = "C"} : memref<8x8xf32>
          %1 = affine.load %alloc[%arg0, %arg2] {from = "A"} : memref<8x8xf32>
          %2 = affine.load %alloc_0[%arg2, %arg1] {from = "B"} : memref<8x8xf32>
          %3 = arith.mulf %1, %2 : f32
          %4 = arith.addf %0, %3 : f32
          affine.store %4, %alloc_2[%arg0, %arg1] {to = "C"} : memref<8x8xf32>
        } {loop_name = "k", op_name = "S_k_0"}
      } {loop_name = "j", op_name = "S_j_0"}
    } {loop_name = "i", op_name = "S_i_0"}
    %alloc_6 = memref.alloc() {name = "E"} : memref<8x8xf32>
    affine.for %arg0 = 0 to 8 {
      affine.for %arg1 = 0 to 8 {
        %0 = affine.load %alloc_2[%arg0, %arg1] {from = "C"} : memref<8x8xf32>
        %1 = affine.load %alloc_4[%arg0, %arg1] {from = "D"} : memref<8x8xf32>
        %2 = arith.addf %0, %1 : f32
        affine.store %2, %alloc_6[%arg0, %arg1] {to = "E"} : memref<8x8xf32>
      } {loop_name = "j", op_name = "S_j_3"}
    } {loop_name = "i", op_name = "S_i_3"}
    return %alloc_6 : memref<8x8xf32>
  }
}
```
After pass:
```mlir
#set = affine_set<(d0) : (d0 == 0)>
#set1 = affine_set<(d0) : (d0 - 7 == 0)>
module {
  func.func @matmul_addition() -> memref<8x8xf32> attributes {itypes = "", otypes = "_"} {
    %cst = arith.constant 3.000000e+00 : f32
    %cst_0 = arith.constant 0.000000e+00 : f32
    %cst_1 = arith.constant 2.000000e+00 : f32
    %cst_2 = arith.constant 1.000000e+00 : f32
    %alloc = memref.alloc() {name = "A"} : memref<8x8xf32>
    affine.for %arg0 = 0 to 8 {
      affine.for %arg1 = 0 to 8 {
        affine.store %cst_2, %alloc[%arg0, %arg1] : memref<8x8xf32>
      }
    }
    %alloc_3 = memref.alloc() {name = "B"} : memref<8x8xf32>
    affine.for %arg0 = 0 to 8 {
      affine.for %arg1 = 0 to 8 {
        affine.store %cst_1, %alloc_3[%arg0, %arg1] : memref<8x8xf32>
      }
    }
    %alloc_4 = memref.alloc() : memref<8x8xf32>
    %alloc_5 = memref.alloc() : memref<8x8xf32>
    %alloc_6 = memref.alloc() {name = "C"} : memref<8x8xf32>
    affine.for %arg0 = 0 to 8 {
      affine.for %arg1 = 0 to 8 {
        affine.store %cst_0, %alloc_6[%arg0, %arg1] : memref<8x8xf32>
      }
    }
    %alloc_7 = memref.alloc() {name = "D"} : memref<8x8xf32>
    affine.for %arg0 = 0 to 8 {
      affine.for %arg1 = 0 to 8 {
        affine.store %cst, %alloc_7[%arg0, %arg1] : memref<8x8xf32>
      }
    }
    affine.for %arg0 = 0 to 8 {
      affine.for %arg1 = 0 to 8 {
        affine.for %arg2 = 0 to 8 {
          affine.if #set(%arg2) {
            %5 = affine.load %alloc_6[%arg0, %arg1] : memref<8x8xf32>
            affine.store %5, %alloc_4[%arg0, %arg1] : memref<8x8xf32>
          }
          %0 = affine.load %alloc_4[%arg0, %arg1] {from = "C"} : memref<8x8xf32>
          %1 = affine.load %alloc[%arg0, %arg2] {from = "A"} : memref<8x8xf32>
          %2 = affine.load %alloc_3[%arg2, %arg1] {from = "B"} : memref<8x8xf32>
          %3 = arith.mulf %1, %2 : f32
          %4 = arith.addf %0, %3 : f32
          affine.store %4, %alloc_4[%arg0, %arg1] {to = "C"} : memref<8x8xf32>
          affine.if #set1(%arg2) {
            %5 = affine.load %alloc_4[%arg0, %arg1] : memref<8x8xf32>
            affine.store %5, %alloc_5[%arg0, %arg1] : memref<8x8xf32>
          }
        } {loop_name = "k", op_name = "S_k_0"}
      } {loop_name = "j", op_name = "S_j_0"}
    } {loop_name = "i", op_name = "S_i_0"}
    %alloc_8 = memref.alloc() {name = "E"} : memref<8x8xf32>
    affine.for %arg0 = 0 to 8 {
      affine.for %arg1 = 0 to 8 {
        %0 = affine.load %alloc_5[%arg0, %arg1] {from = "C"} : memref<8x8xf32>
        %1 = affine.load %alloc_7[%arg0, %arg1] {from = "D"} : memref<8x8xf32>
        %2 = arith.addf %0, %1 : f32
        affine.store %2, %alloc_8[%arg0, %arg1] {to = "E"} : memref<8x8xf32>
      } {loop_name = "j", op_name = "S_j_3"}
    } {loop_name = "i", op_name = "S_i_3"}
    return %alloc_8 : memref<8x8xf32>
  }
}
```
## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [x] Code is well-documented
