### PR TITLE
[Types] Add bfloat16

### DIFF
--- a/allo/backend/llvm.py
+++ b/allo/backend/llvm.py
@@ -4,6 +4,7 @@
 
 import os
 import ctypes
+import ml_dtypes
 import numpy as np
 from .._mlir.ir import (
     Context,
@@ -156,6 +157,9 @@ class LLVMModule:
                     if target_in_type == "f16":
                         c_float_p = ctypes.c_int16 * 1
                         arg = np.float16(arg).view(np.int16)
+                    elif target_in_type == "bf16":
+                        c_float_p = ctypes.c_int16 * 1
+                        arg = ml_dtypes.bfloat16(arg).view(np.int16)
                     elif target_in_type == "f32":
                         c_float_p = ctypes.c_float * 1
                     else:  # f64
@@ -320,6 +324,8 @@ class LLVMModule:
                     )
                 elif result_type == "f16":
                     ret = np.array(ret, dtype=np.int16).view(np.float16)
+                elif result_type == "bf16":
+                    ret = np.array(ret, dtype=np.int16).view(ml_dtypes.bfloat16)
                 elif result_type.startswith("fixed") or result_type.startswith(
                     "ufixed"
                 ):
@@ -338,6 +344,8 @@ class LLVMModule:
                 ret = return_ptr[0]
                 if result_type == "f16":
                     ret = np.int16(ret).view(np.float16)
+                elif result_type == "bf16":
+                    ret = np.int16(ret).view(ml_dtypes.bfloat16)
         else:  # multiple returns, assume all memref
             # INVOKE
             self.execution_engine.invoke(self.top_func_name, return_ptr, *arg_ptrs)
@@ -356,6 +364,8 @@ class LLVMModule:
                     )
                 elif res_type == "f16":
                     ret_i = np.array(np_arr, dtype=np.int16).view(np.float16)
+                elif res_type == "bf16":
+                    ret_i = np.array(np_arr, dtype=np.int16).view(ml_dtypes.bfloat16)
                 elif res_type.startswith("fixed") or res_type.startswith("ufixed"):
                     bitwidth, frac = get_bitwidth_and_frac_from_fixed(res_type)
                     ret_i = struct_array_to_int_array(

--- a/allo/backend/vitis.py
+++ b/allo/backend/vitis.py
@@ -53,6 +53,7 @@ dtype_size_map = {
 }
 
 ctype_map = {
+    "bf16": "std::bfloat16_t",
     "f32": "float",
     "f64": "double",
     "i8": "int8_t",
@@ -416,5 +417,8 @@ def write_tensor_to_file(tensor, shape, file_path):
 
 
 def read_tensor_from_file(dtype, shape, file_path):
+    if dtype == "bf16":
+        # numpy does not support bf16
+        dtype = "f32"
     arr = np.fromfile(file_path, sep="\n", dtype=np_supported_types[dtype])
     return arr.reshape(shape)

--- a/allo/ir/builder.py
+++ b/allo/ir/builder.py
@@ -57,7 +57,7 @@ from .utils import (
     get_func_id_from_param_types,
     resolve_generic_types,
 )
-from .types import Int, UInt, Index, Float, Fixed, UFixed, Struct
+from .types import Int, UInt, Index, Float, Fixed, UFixed, Struct, float32
 from .visitor import ASTVisitor
 from .symbol_resolver import ASTResolver
 from ..backend.ip import IPModule
@@ -1913,7 +1913,7 @@ class ASTTransformer(ASTBuilder):
                     ctx,
                     stmts[0],
                     node.args[0].dtype,
-                    Int(32) if node.func.id == "int" else Float(32),
+                    Int(32) if node.func.id == "int" else float32,
                 )
 
             if node.func.id in {"min", "max"}:

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ psutil
 ninja
 sympy
 rich
+ml_dtypes

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+import ml_dtypes
 import numpy as np
 import allo
 from allo.ir.types import (
@@ -15,6 +16,8 @@ from allo.ir.types import (
     int32,
     float16,
     float32,
+    float64,
+    bfloat16,
     index,
 )
 import allo.ir.types as T
@@ -138,7 +141,7 @@ def test_large_bitwidth():
 
 
 def test_load_type():
-    def kernel(A: allo.ir.types.Float(32)[32, 32]) -> Int(32)[32, 32]:
+    def kernel(A: allo.ir.types.float32[32, 32]) -> Int(32)[32, 32]:
         B: int32[32, 32] = 0
         v: T.Int(32) = 1
         for i, j in allo.grid(32, 32):
@@ -244,8 +247,8 @@ def test_arbitrary_bitwidth_gemm_alloc_output():
 
 
 def test_load_type_scalar():
-    def kernel(a: allo.ir.types.Float(32)) -> Int(32):
-        b: Float(32) = float(int(1))
+    def kernel(a: allo.ir.types.float32) -> Int(32):
+        b: float32 = float(int(1))
         c: float32 = int(a)
         return int(b + c)
 
@@ -274,7 +277,7 @@ def test_compare_int_float():
     mod = s.build()
     assert mod(2) == kernel(2)
 
-    Ty = Float(32)
+    Ty = float32
     s = allo.customize(kernel)
     mod = s.build()
     assert abs(mod(-1.3) - kernel(-1.3)) < 1e-6
@@ -346,6 +349,24 @@ def test_fp16_array():
     A = np.random.rand(10).astype(np.float16)
     B = mod(A)
     np.testing.assert_allclose(B, A + 1, rtol=1e-5)
+
+
+def test_bf16_array():
+    def kernel(A: bfloat16[10]) -> bfloat16[10]:
+        B: bfloat16[10]
+        for i in range(10):
+            B[i] = A[i] + 1
+        return B
+
+    s = allo.customize(kernel)
+    assert "bf16" in str(s.module)
+    print(s.module)
+    mod = s.build()
+    A = np.random.rand(10).astype(ml_dtypes.bfloat16)
+    B = mod(A)
+    np.testing.assert_allclose(
+        B.astype(np.float32), (A + 1).astype(np.float32), rtol=1e-5
+    )
 
 
 def test_fp16_array_inplace():
@@ -500,7 +521,13 @@ def test_anywidth_int_constant():
 
 def test_polymorphism():
     def gemm[
-        T: (float32, int32), M: int32, N: int32, K: int32
+        T: (
+            float32,
+            int32,
+        ),
+        M: int32,
+        N: int32,
+        K: int32,
     ](A: "T[M, K]", B: "T[K, N]") -> "T[M, N]":
         C: T[M, N] = 0
         for i, j, k in allo.grid(M, N, K):
@@ -526,7 +553,14 @@ def test_polymorphism():
 
 def test_multiple_poly_types():
     def vadd[
-        T0, T1: Int, T2: (Float, Int), M: int32, N: int32
+        T0,
+        T1: Int,
+        T2: (
+            Float,
+            Int,
+        ),
+        M: int32,
+        N: int32,
     ](A: "T0[M, N]", B: "T1[M, N]") -> "T2[M, N]":
         C: T2[M, N] = 0
         for i in range(M):
@@ -601,14 +635,14 @@ def test_struct_simple():
 
 def test_type_comparison():
     # float type attributes
-    assert Float(32).fracs == 23
-    assert Float(32).exponent == 8
-    assert Float(32).bits == 32
-    assert Float(64).fracs == 52
-    assert Float(64).exponent == 11
-    assert Float(64).bits == 64
+    assert float32.fracs == 23
+    assert float32.exponent == 8
+    assert float32.bits == 32
+    assert float64.fracs == 52
+    assert float64.exponent == 11
+    assert float64.bits == 64
     # type comparision
-    list_of_types = [Float(32), Float(64)]
+    list_of_types = [float32, float64]
     list_of_types += [Int(i) for i in range(2, 66, 4)]
     list_of_types += [UInt(i) for i in range(2, 66, 4)]
     list_of_types += [Fixed(i, i - 2) for i in range(2, 66, 4)]

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -365,7 +365,7 @@ def test_bf16_array():
     A = np.random.rand(10).astype(ml_dtypes.bfloat16)
     B = mod(A)
     np.testing.assert_allclose(
-        B.astype(np.float32), (A + 1).astype(np.float32), rtol=1e-5
+        B.astype(np.float32), (A + 1).astype(np.float32), rtol=1e-2
     )
 
 

--- a/tutorials/dive_01_data_types.py
+++ b/tutorials/dive_01_data_types.py
@@ -18,7 +18,7 @@ from allo.ir.types import int16, int32, float32, Int, UInt, Float, Fixed
 # Currently, Allo supports three base data types for mathematical operations:
 #
 # - Integers: ``Int(bitwdith)``, ``UInt(bitwidth)``
-# - Floating points: ``Float(bitwidth)`` (only support 16, 32, and 64 bits)
+# - Floating points: ``Float(bitwidth, fracs)`` (we can use float32, float64, etc. as shorthands)
 # - Fixed points: ``Fixed(bitwidth, frac)``, ``UFixed(bitwidth, frac)``
 #
 # For example, one can declare a 15-bit integer as ``Int(15)`` and an unsigned 8-bit fixed-point number with 3 fractional bits as ``UFixed(8, 3)``.


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR adds bfloat16 support which will be used in the AIE backend. The NumPy support is via [ml_dtypes](https://github.com/jax-ml/ml_dtypes).

Now we need to explicitly specify the fractional bits of the floating point types, specifically `Float(16, 10)` represents `float16` while `Float(16, 7)` represents `bfloat16`.

### Examples ###
```python
def test_bf16_array():
    def kernel(A: bfloat16[10]) -> bfloat16[10]:
        B: bfloat16[10]
        for i in range(10):
            B[i] = A[i] + 1
        return B

    s = allo.customize(kernel)
    assert "bf16" in str(s.module)
    print(s.module)
    mod = s.build()
    A = np.random.rand(10).astype(ml_dtypes.bfloat16)
    B = mod(A)
    np.testing.assert_allclose(
        B.astype(np.float32), (A + 1).astype(np.float32), rtol=1e-5
    )
```

## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [x] Code is well-documented
