### PR TITLE
[Backend][AIE] Support external vectorized kernels

### DIFF
--- a/allo/backend/aie_kernels/add.cc
+++ b/allo/backend/aie_kernels/add.cc
@@ -1,3 +1,7 @@
+/*
+ * Copyright Allo authors. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
 //===- scale.cc -------------------------------------------------*- C++ -*-===//
 //
 // This file is licensed under the Apache License v2.0 with LLVM Exceptions.

--- a/allo/backend/aie_kernels/add.cc
+++ b/allo/backend/aie_kernels/add.cc
@@ -1,0 +1,65 @@
+//===- scale.cc -------------------------------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+#define __AIENGINE__ 2
+#define NOCPP
+#define __AIEARCH__ 20
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <type_traits>
+
+#include <aie_api/aie.hpp>
+
+template <typename T_in, typename T_out, const int N>
+void eltwise_add(T_in *a, T_in *b, T_out *c) {
+  for (int i = 0; i < N; i++) {
+    c[i] = a[i] + b[i];
+  }
+}
+
+template <typename T_in, typename T_out, const int N>
+void eltwise_vadd(T_in *a, T_in *b, T_out *c) {
+
+  constexpr int vec_factor = 16;
+  event0();
+  T_in *__restrict pA1 = a;
+  T_in *__restrict pB1 = b;
+  T_out *__restrict pC1 = c;
+  const int F = N / vec_factor;
+  for (int i = 0; i < F; i++)
+    chess_prepare_for_pipelining chess_loop_range(16, ) {
+      aie::vector<T_in, vec_factor> A0 = aie::load_v<vec_factor>(pA1);
+      pA1 += vec_factor;
+      aie::vector<T_in, vec_factor> B0 = aie::load_v<vec_factor>(pB1);
+      pB1 += vec_factor;
+      aie::vector<T_out, vec_factor> cout = aie::add(A0, B0);
+      aie::store_v(pC1, cout);
+      pC1 += vec_factor;
+    }
+  event1();
+}
+
+extern "C" {
+
+void eltwise_add_i32_vector(int32_t *a, int32_t *b, int32_t *c) {
+  eltwise_vadd<int32_t, int32_t, 1024>(a, b, c);
+}
+
+void eltwise_add_f32_vector(float *a, float *b, float *c) {
+  eltwise_vadd<float, float, 1024>(a, b, c);
+}
+
+void eltwise_add_bf16_vector(bfloat16 *a_in, bfloat16 *b_in, bfloat16 *c_out) {
+  eltwise_vadd<bfloat16, bfloat16, 1024>(a_in, b_in, c_out);
+}
+
+} // extern "C"


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR adds support for incorporating vectorized kernels in the AIE backend.

### Examples ###
```python
def _test_vector_vector_add():
    Ty = int32
    M = 1024

    @df.region()
    def top():
        @df.kernel(mapping=[1])
        def core(A: Ty[M], B: Ty[M], C: Ty[M]):
            C[:] = allo.add(A, B)

    mod = df.build(top, target="aie")
    A = np.random.randint(0, 100, M).astype(np.int32)
    B = np.random.randint(0, 100, M).astype(np.int32)
    C = np.zeros(M).astype(np.int32)
    mod(A, B, C)
    np.testing.assert_allclose(C, A + B)
    print("PASSED!")
```

See the generated private function and the `func.call` function below.
```mlir
module {
  aie.device(npu1_2col) {
    func.func private @eltwise_add_i32_vector(memref<1024xi32>, memref<1024xi32>, memref<1024xi32>)
    %tile_shim = aie.tile(0, 0)
    %tile_mem0 = aie.tile(0, 1)
    %tile_mem1 = aie.tile(1, 1)
    %tile_comp_core_0 = aie.tile(0, 2)
    %tile_comp_core_0_buf0 = aie.buffer(%tile_comp_core_0) : memref<1024xi32>
    aie.objectfifo @in_sh_core_0(%tile_shim, {%tile_mem0}, 2 : i32) : !aie.objectfifo<memref<1024xi32>>
    aie.objectfifo @in_core_0_0(%tile_mem0, {%tile_comp_core_0}, 2 : i32) : !aie.objectfifo<memref<1024xi32>>
    aie.objectfifo.link [@in_sh_core_0] -> [@in_core_0_0]([] [0])
    aie.objectfifo @in_sh_core_1(%tile_shim, {%tile_mem1}, 2 : i32) : !aie.objectfifo<memref<1024xi32>>
    aie.objectfifo @in_core_1_0(%tile_mem1, {%tile_comp_core_0}, 2 : i32) : !aie.objectfifo<memref<1024xi32>>
    aie.objectfifo.link [@in_sh_core_1] -> [@in_core_1_0]([] [0])
    aie.objectfifo @out_core_0(%tile_comp_core_0, {%tile_mem0}, 2 : i32) : !aie.objectfifo<memref<1024xi32>>
    aie.objectfifo @out_sh_core(%tile_mem0, {%tile_shim}, 2 : i32) : !aie.objectfifo<memref<1024xi32>>
    aie.objectfifo.link [@out_core_0] -> [@out_sh_core]([0] [])
    %core_0_2 = aie.core(%tile_comp_core_0) {
      %global_c0 = arith.constant 0 : index
      %global_c1 = arith.constant 1 : index
      %c9223372036854775807 = arith.constant 9223372036854775807 : index
      scf.for %arg0 = %global_c0 to %c9223372036854775807 step %global_c1 {
        %fifo0 = aie.objectfifo.acquire @in_core_0_0(Consume, 1) : !aie.objectfifosubview<memref<1024xi32>>
        %local0 = aie.objectfifo.subview.access %fifo0[0] : !aie.objectfifosubview<memref<1024xi32>> -> memref<1024xi32>
        %fifo1 = aie.objectfifo.acquire @in_core_1_0(Consume, 1) : !aie.objectfifosubview<memref<1024xi32>>
        %local1 = aie.objectfifo.subview.access %fifo1[0] : !aie.objectfifosubview<memref<1024xi32>> -> memref<1024xi32>
        %fifo_out = aie.objectfifo.acquire @out_core_0(Produce, 1) : !aie.objectfifosubview<memref<1024xi32>>
        %local_out = aie.objectfifo.subview.access %fifo_out[0] : !aie.objectfifosubview<memref<1024xi32>> -> memref<1024xi32>
        func.call @eltwise_add_i32_vector(%local0, %local1, %tile_comp_core_0_buf0) : (memref<1024xi32>, memref<1024xi32>, memref<1024xi32>) -> ()
        %subview = memref.subview %local_out[0] [1024] [1] : memref<1024xi32> to memref<1024xi32, strided<[1]>>
        memref.copy %tile_comp_core_0_buf0, %subview {to = "C"} : memref<1024xi32> to memref<1024xi32, strided<[1]>>
        aie.objectfifo.release @in_core_0_0(Consume, 1)
        aie.objectfifo.release @in_core_1_0(Consume, 1)
        aie.objectfifo.release @out_core_0(Produce, 1)
      }
      aie.end
    } {link_with = "add.o"}
    aiex.runtime_sequence(%arg0: memref<1024xi32>,%arg1: memref<1024xi32>, %arg2: memref<1024xi32>) {
      aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][1, 1, 1, 1024][0, 0, 0, 1]) {id = 1 : i64, issue_token = true, metadata = @in_sh_core_0} : memref<1024xi32>
      aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 0][1, 1, 1, 1024][0, 0, 0, 1]) {id = 2 : i64, issue_token = true, metadata = @in_sh_core_1} : memref<1024xi32>
      aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 0, 0][1, 1, 1, 1024][0, 0, 0, 1]) {id = 0 : i64, metadata = @out_sh_core} : memref<1024xi32>
      aiex.npu.dma_wait {symbol = @in_sh_core_0}
      aiex.npu.dma_wait {symbol = @in_sh_core_1}
      aiex.npu.dma_wait {symbol = @out_sh_core}
    }
  }
}
```


## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [x] Code is well-documented
