### PR TITLE
[Backend][AIE] Support fifo and multi-kernel communication for AIE backend

### DIFF
--- a/allo/backend/aie.py
+++ b/allo/backend/aie.py
@@ -678,7 +678,11 @@ def codegen_aie_mlir(
                         )
                     # Main computation
                     with format_code(indent=6):
-                        for line in func_str.splitlines()[1:-2]:
+                        lines = func_str.splitlines()
+                        i = 1
+                        while i < len(lines) - 2:
+                            line = lines[i]
+                            i += 1
                             # Replace stream.get and stream.put
                             if "stream_get" in line:
                                 # Extract argument id
@@ -692,9 +696,15 @@ def codegen_aie_mlir(
                                 # Extract return variable
                                 return_var = line.split("=")[0].strip()
                                 stream_name = streams[arg_id - len(inputs) - len(outputs)][0]
-                                func_str = func_str.replace(
-                                    return_var, f"%local_{stream_name}"
-                                )
+                                if "x" not in ele_type:
+                                    code += format_str(
+                                        f"{return_var} = memref.load %local_{stream_name}[] : {ele_type}"
+                                    )
+                                else:
+                                    func_str = func_str.replace(
+                                        return_var, f"%local_{stream_name}"
+                                    )
+                                    lines = func_str.splitlines()
                             elif "stream_put" in line:
                                 # Extract argument id
                                 keyword = "stream_put(%arg"

--- a/allo/dataflow.py
+++ b/allo/dataflow.py
@@ -19,7 +19,7 @@ from .ir.utils import get_global_vars, get_all_funcs_except_top
 from .backend.aie import AIEModule
 from .backend.simulator import LLVMOMPModule
 from .ir.types import Stream
-from .passes import df_pipeline, analyze_arg_load_store
+from .passes import df_pipeline
 
 
 def get_pid():
@@ -300,7 +300,12 @@ def build(
         stream_info = move_stream_to_interface(s)
         s = _build_top(s, stream_info, enable_tensor=enable_tensor, target=target)
         mod = AIEModule(
-            s.module, s.top_func_name, project, func.mappings, enable_tensor, stream_info
+            s.module,
+            s.top_func_name,
+            project,
+            func.mappings,
+            enable_tensor,
+            stream_info,
         )
         mod.build()
         return mod

--- a/allo/dataflow.py
+++ b/allo/dataflow.py
@@ -299,9 +299,8 @@ def build(
         s = _customize(func, global_vars=global_vars, enable_tensor=enable_tensor)
         stream_info = move_stream_to_interface(s)
         s = _build_top(s, stream_info, enable_tensor=enable_tensor, target=target)
-        load_store_mapping = analyze_arg_load_store(s.module)
         mod = AIEModule(
-            s.module, s.top_func_name, project, func.mappings, enable_tensor
+            s.module, s.top_func_name, project, func.mappings, enable_tensor, stream_info
         )
         mod.build()
         return mod

--- a/allo/utils.py
+++ b/allo/utils.py
@@ -230,6 +230,8 @@ def get_func_inputs_outputs(func):
         else "_" * len(func.type.inputs)
     )
     for in_type, in_hint in zip(func.type.inputs, in_hints):
+        if "!allo.stream" in str(in_type):
+            continue
         dtype, shape = get_dtype_and_shape_from_type(in_type)
         in_type = get_signed_type_by_hint(dtype, in_hint)
         inputs.append((in_type, shape))

--- a/tests/dataflow/aie/test_producer_consumer.py
+++ b/tests/dataflow/aie/test_producer_consumer.py
@@ -1,0 +1,50 @@
+# Copyright Allo authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import allo
+from allo.ir.types import int32
+import allo.dataflow as df
+import numpy as np
+
+Ty = int32
+M, N, K = 16, 16, 16
+
+
+@df.region()
+def top():
+    pipe = df.pipe(dtype=Ty, shape=(), depth=4)
+
+    @df.kernel(mapping=[1])
+    def producer(A: Ty[M, N]):
+        for i, j in allo.grid(M, N):
+            # load data
+            out: Ty = A[i, j]
+            # send data
+            pipe.put(out)
+
+    @df.kernel(mapping=[1])
+    def consumer(B: Ty[M, N]):
+        for i, j in allo.grid(M, N):
+            # receive data
+            data = pipe.get()
+            # computation
+            B[i, j] = data + 1
+
+
+def test_producer_consumer():
+    A = np.random.randint(0, 64, (M, K)).astype(np.int32)
+    B = np.zeros((M, N), dtype=np.int32)
+
+    sim_mod = df.build(top, target="simulator")
+    sim_mod(A, B)
+    np.testing.assert_allclose(B, A + 1)
+    print("Dataflow Simulator Passed!")
+
+    mod = df.build(top, target="aie")
+    mod(A, B)
+    np.testing.assert_allclose(A + 1, B, atol=1e-5)
+    print("Passed!")
+
+
+if __name__ == "__main__":
+    test_producer_consumer()


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR supports fifo created by `df.pipe` in AIE backend. It also support multi-kernel communication patterns like producer-consumer case.


### Examples ###
```python
Ty = int32
M, N, K = 16, 16, 16


@df.region()
def top():
    pipe = df.pipe(dtype=Ty, shape=(), depth=4)

    @df.kernel(mapping=[1])
    def producer(A: Ty[M, N]):
        for i, j in allo.grid(M, N):
            # load data
            out: Ty = A[i, j]
            # send data
            pipe.put(out)

    @df.kernel(mapping=[1])
    def consumer(B: Ty[M, N]):
        for i, j in allo.grid(M, N):
            # receive data
            data = pipe.get()
            # computation
            B[i, j] = data + 1
```

```mlir
module {
  aie.device(npu1_1col) {
    %tile_shim = aie.tile(0, 0)
    %tile_mem0 = aie.tile(0, 1)
    %tile_comp_producer_0 = aie.tile(0, 2)
    %tile_comp_producer_0_buf0 = aie.buffer(%tile_comp_producer_0) : memref<i32>
    %tile_comp_consumer_0 = aie.tile(0, 3)
    aie.objectfifo @in_sh_producer_a0(%tile_shim, {%tile_mem0}, 2 : i32) : !aie.objectfifo<memref<16x16xi32>>
    aie.objectfifo @in_producer_0_a0(%tile_mem0, {%tile_comp_producer_0}, 2 : i32) : !aie.objectfifo<memref<16x16xi32>>
    aie.objectfifo.link [@in_sh_producer_a0] -> [@in_producer_0_a0]([] [0])
    aie.objectfifo @out_consumer_0(%tile_comp_consumer_0, {%tile_mem0}, 2 : i32) : !aie.objectfifo<memref<16x16xi32>>
    aie.objectfifo @out_sh_consumer(%tile_mem0, {%tile_shim}, 2 : i32) : !aie.objectfifo<memref<16x16xi32>>
    aie.objectfifo.link [@out_consumer_0] -> [@out_sh_consumer]([0] [])
    aie.objectfifo @pipe(%tile_comp_producer_0, {%tile_comp_consumer_0}, 4 : i32) : !aie.objectfifo<memref<i32>>
    %core_0_2 = aie.core(%tile_comp_producer_0) {
      %global_c0 = arith.constant 0 : index
      %global_c1 = arith.constant 1 : index
      %c9223372036854775807 = arith.constant 9223372036854775807 : index
      scf.for %arg0 = %global_c0 to %c9223372036854775807 step %global_c1 {
        %fifo0 = aie.objectfifo.acquire @in_producer_0_a0(Consume, 1) : !aie.objectfifosubview<memref<16x16xi32>>
        %local0 = aie.objectfifo.subview.access %fifo0[0] : !aie.objectfifosubview<memref<16x16xi32>> -> memref<16x16xi32>
        %c0 = arith.constant 0 : index
        %c16 = arith.constant 16 : index
        %c1 = arith.constant 1 : index
        scf.for %arg2 = %c0 to %c16 step %c1 {
          %c0_0 = arith.constant 0 : index
          %c16_1 = arith.constant 16 : index
          %c1_2 = arith.constant 1 : index
          scf.for %arg3 = %c0_0 to %c16_1 step %c1_2 {
            %0 = memref.load %local0[%arg2, %arg3] : memref<16x16xi32>
            memref.store %0, %tile_comp_producer_0_buf0[] : memref<i32>
            %1 = memref.load %tile_comp_producer_0_buf0[] : memref<i32>
            %pipe = aie.objectfifo.acquire @pipe(Produce, 1) : !aie.objectfifosubview<memref<i32>>
            %local_pipe = aie.objectfifo.subview.access %pipe[0] : !aie.objectfifosubview<memref<i32>> -> memref<i32>
            memref.store %1, %local_pipe[] : memref<i32>
            aie.objectfifo.release @pipe(Produce, 1)
          }
        }
        aie.objectfifo.release @in_producer_0_a0(Consume, 1)
      }
      aie.end
    }
    %core_0_3 = aie.core(%tile_comp_consumer_0) {
      %global_c0 = arith.constant 0 : index
      %global_c1 = arith.constant 1 : index
      %c9223372036854775807 = arith.constant 9223372036854775807 : index
      scf.for %arg0 = %global_c0 to %c9223372036854775807 step %global_c1 {
        %fifo_out = aie.objectfifo.acquire @out_consumer_0(Produce, 1) : !aie.objectfifosubview<memref<16x16xi32>>
        %local_out = aie.objectfifo.subview.access %fifo_out[0] : !aie.objectfifosubview<memref<16x16xi32>> -> memref<16x16xi32>
        %c1_i33 = arith.constant 1 : i33
        %c0 = arith.constant 0 : index
        %c16 = arith.constant 16 : index
        %c1 = arith.constant 1 : index
        scf.for %arg2 = %c0 to %c16 step %c1 {
          %c0_0 = arith.constant 0 : index
          %c16_1 = arith.constant 16 : index
          %c1_2 = arith.constant 1 : index
          scf.for %arg3 = %c0_0 to %c16_1 step %c1_2 {
            %pipe = aie.objectfifo.acquire @pipe(Consume, 1) : !aie.objectfifosubview<memref<i32>>
            %local_pipe = aie.objectfifo.subview.access %pipe[0] : !aie.objectfifosubview<memref<i32>> -> memref<i32>
            %0 = memref.load %local_pipe[] : memref<i32>
            aie.objectfifo.release @pipe(Consume, 1)
            %1 = arith.extsi %0 : i32 to i33
            %2 = arith.addi %1, %c1_i33 : i33
            %3 = arith.trunci %2 : i33 to i32
            memref.store %3, %local_out[%arg2, %arg3] : memref<16x16xi32>
          }
        }
        aie.objectfifo.release @out_consumer_0(Produce, 1)
      }
      aie.end
    }
    aiex.runtime_sequence(%arg0: memref<16x16xi32>, %arg1: memref<16x16xi32>) {
      aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][1, 1, 16, 16][0, 0, 16, 1]) {id = 1 : i64, issue_token = true, metadata = @in_sh_producer_a0} : memref<16x16xi32>
      aiex.npu.dma_wait {symbol = @in_sh_producer_a0}
      aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 0][1, 1, 16, 16][0, 0, 16, 1]) {id = 0 : i64, metadata = @out_sh_consumer} : memref<16x16xi32>
      aiex.npu.dma_wait {symbol = @out_sh_consumer}
    }
  }
}
```


## Checklist ##

- [ ] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [ ] Code is well-documented
