### PR TITLE
[Dataflow] DFG Implementation

### DIFF
--- a/allo/autoscheduler/dfg.py
+++ b/allo/autoscheduler/dfg.py
@@ -1,0 +1,496 @@
+# Copyright Allo authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+from collections import defaultdict
+import enum
+import sys
+import itertools
+from allo._mlir.dialects import (
+    func as func_d,
+    affine as affine_d,
+    memref as memref_d,
+)
+from allo._mlir.ir import WalkResult, Operation, AffineMap
+from allo.ir.types import MemRefType
+from .util import (
+    LoopInfo,
+    is_reduction_loop,
+    is_terminator,
+    get_minimal_access_pattern,
+    compute_loop_II
+)
+
+class DFGNodeType(enum.Enum):
+    AFFINE = 0
+    RET = 1
+    ALLOC = 2
+    CONST = 3
+
+class Edge:
+    """Represents a data dependency between nodes in the dataflow graph."""
+    def __init__(self, dst_id: int, value=None, src_op=None, dst_op=None):
+        self.id = dst_id        # Destination node ID
+        self.value = value      # The value/memref being communicated
+        self.src_op = src_op    # Source operation (e.g., store)
+        self.dst_op = dst_op    # Destination operation (e.g., load)
+    
+    def __repr__(self):
+        return f"Edge(id={self.id}, value={self.value.get_name()})"    
+
+class EdgeInfo:
+    def __init__(self, accessMap: AffineMap): 
+        self.accessMap = accessMap
+        self.first_element_time = 0
+        self.last_element_time = 0
+
+    def __repr__(self): 
+        return f"EdgeInfo(accessMap={self.accessMap}"
+
+class NodeInfo:
+    def __init__(self, permutation):
+        # Map permutation to edge info associated with that permutation
+        self.stores_map = {} 
+        self.loads_map = {}
+        self.II = 0
+        self.trip_count = 0
+        self.permutation = permutation
+    def __repr__(self):
+        return f"NodeInfo(permutation={self.permutation})"
+
+class Node:
+    """Represents a computation node (typically a loop nest) in the dataflow graph."""
+    def __init__(self, node_id: int, op=None, op_type=None):
+        self.id = node_id                 # Unique identifier
+        self.op = op                 # The operation (typically a loop)
+        self.loads = []              # Load operations within this node
+        self.stores = []             # Store operations within this node
+        self.allocations = []        # Allocation operations
+        self.loop_info = []          # Loop information (in the original permutation)
+        self.node_info = []          # Node information precomputed per permutation
+        self.type = op_type          # Node type (AFFINE, RET, ALLOC, CONST)
+        self.DSP_factor = 0          # DSP factor for this node
+        self.is_reduction = None     # Whether this node is a reduction loop
+    
+    def __repr__(self):
+        return f"Node(id={self.id}, op={str(self.op.operation.name) if self.op else 'None'})"
+    
+    def get_load_op_count(self, memref) -> int:
+        """Count load operations for a specific memref."""
+        return sum(1 for load_op in self.loads 
+                  if self._get_memref(load_op) == memref)
+    
+    def get_store_op_count(self, memref) -> int:
+        """Count store operations for a specific memref."""
+        return sum(1 for store_op in self.stores 
+                  if self._get_memref(store_op) == memref)
+    
+    def _get_memref(self, op):
+        """Get the memref from an operation."""
+        if hasattr(op, "memref"):
+            return op.memref
+        # Fall back to checking operands
+        for operand in op.operands:
+            if hasattr(operand, "type") and "memref" in str(operand.type):
+                return operand
+        return None
+    
+class DFG:
+    """Dataflow Graph representing an MLIR module."""
+    def __init__(self, block=None, dsp_factors=None, mem_r_ports=None, mem_w_ports=None):
+        self.block: Block = block
+        self.nodes: dict[int, Node] = {}    # Map from node ID to Node
+        self.in_edges = defaultdict(list)   # Map from node ID to incoming edges
+        self.out_edges = defaultdict(list)  # Map from node ID to outgoing edges
+        self.edges = []         # list of all edges
+        self.memref_edge_count = defaultdict(int)  # Count edges per memref
+        self.next_node_id = 0
+        self.dsp_factors = {
+            'arith.mulf': 3, 
+            'arith.addf': 0,      
+            'arith.subf': 0,      
+            'arith.divf': 14,     
+            'arith.remf': 14,
+            'arith.muli': 1,    
+            'arith.addi': 0,      
+            'arith.subi': 0,    
+            'arith.divi': 8,   
+            'arith.divu': 8, 
+            'arith.remi': 8,   
+            'arith.remu': 8, 
+        } if not dsp_factors else dsp_factors
+        self.mem_r_ports = mem_r_ports
+        self.mem_w_ports = mem_w_ports
+    
+    def add_node(self, op, op_type) -> int:
+        """Add a node to the graph and return its ID."""
+        node = Node(self.next_node_id, op, op_type)
+        self.nodes[node.id] = node
+        self.next_node_id += 1
+        return node.id
+    
+    def get_node(self, node_id: int) -> Node:
+        """Get a node by its ID."""
+        if node_id not in self.nodes:
+            raise KeyError(f"Node ID {node_id} not found in graph")
+        return self.nodes[node_id]
+    
+    def has_edge(self, src_id: int, dst_id: int, value=None) -> bool:
+        """Check if there's an edge from src_id to dst_id."""
+        if src_id not in self.out_edges or dst_id not in self.in_edges:
+            return False
+            
+        has_out_edge = any(edge.id == dst_id and (not value or edge.value == value)
+                          for edge in self.out_edges[src_id])
+        has_in_edge = any(edge.id == src_id and (not value or edge.value == value)
+                          for edge in self.in_edges[dst_id])
+        
+        return has_out_edge and has_in_edge
+    
+    def add_edge(self, src_id: int, dst_id: int, value=None, src_op=None, dst_op=None):
+        """Add an edge from src_id to dst_id."""
+        if not self.has_edge(src_id, dst_id, value):
+            self.out_edges[src_id].append(Edge(dst_id, value, src_op, dst_op))
+            self.in_edges[dst_id].append(Edge(src_id, value, src_op, dst_op))
+            self.edges.append((src_id, dst_id, value))
+            
+            if value and hasattr(value, "type") and "memref" in str(value.type):
+                self.memref_edge_count[value] += 1
+
+    def _compute_loop_info(self, loop_op) -> list[LoopInfo]:
+        """Calculate loop info, outermost loop first."""
+        lower_bound = int(str(loop_op.lowerBoundMap.value.results[0]))
+        upper_bound = int(str(loop_op.upperBoundMap.value.results[0]))
+
+        step = 1
+        if loop_op.step is not None: 
+            step = int(loop_op.step)
+        
+        if step == 0:
+            return 0 
+        
+        if upper_bound < lower_bound:
+            return 0 
+        
+        inner_for_ops = [op for op in loop_op.body.operations if self._is_loop_op(op)]
+        current_trip_count = (upper_bound - lower_bound + step - 1) // step 
+
+        if len(inner_for_ops) == 0:
+            return [LoopInfo(loop_op, lower_bound, upper_bound, step, current_trip_count)]
+
+        if len(inner_for_ops) == 1:
+            inner_loop_infos = self._compute_loop_info(inner_for_ops[0])
+            return [LoopInfo(loop_op, lower_bound, upper_bound, step, current_trip_count)] + inner_loop_infos
+       
+        raise NotImplementedError("Nested loops with more than 1 inner loop are not supported")
+        
+    def _compute_first_and_last_element_time(self, op: Operation, loop_band: list[LoopInfo]) -> tuple[int, int]:
+        """Compute the first and last element time for an operation."""
+        op = op.opview
+        if isinstance(op, (affine_d.AffineLoadOp, affine_d.AffineStoreOp)):
+            mapOperands = op.indices
+        else:
+            assert False, "op is not an affine load or store operation"
+        
+        # Compute the first and last element time
+        first_element_time = 0
+        last_element_time = 0
+        curr_factor = 1
+        innermost_first = list(reversed(loop_band))
+        for idx, loop in enumerate(innermost_first):
+            prev_trip_count = 1 if idx == 0 else innermost_first[idx - 1].trip_count
+            curr_factor *= prev_trip_count
+            iv = loop.op.opview.induction_variable
+            if iv in mapOperands:
+                first_element_time += 0 
+                last_element_time += (loop.trip_count - 1) * curr_factor 
+
+            # not in loop bound, compute conservative estimate. for loads it is 0, for stores it is trip_count - 1
+            elif isinstance(op, affine_d.AffineLoadOp):
+                    first_element_time += 0
+                    last_element_time += 0
+            else: 
+                first_element_time += (loop.trip_count - 1) * curr_factor
+                last_element_time += (loop.trip_count - 1) * curr_factor
+        return first_element_time, last_element_time
+                    
+    def _populate_node_info(self, node_id: int) -> bool:
+        """Populate node information for a specific node."""
+        node: Node = self.get_node(node_id)
+        if node.type != DFGNodeType.AFFINE:
+            return False
+
+        top_level_for = node.loop_info[0].op
+        def update_dsp_count(op):
+            if hasattr(op, 'opview') and hasattr(op.opview, 'operation') and hasattr(op.opview.operation, 'name'):
+                op_name = op.opview.operation.name
+                if op_name.startswith('arith.'):
+                    node.DSP_factor += self.dsp_factors.get(op_name, 0)
+            return WalkResult(0)
+        
+        top_level_for.walk(update_dsp_count)
+        node.is_reduction = is_reduction_loop(top_level_for)
+
+        num_loops = len(node.loop_info)
+        
+        all_permutations = itertools.permutations(range(num_loops))
+
+        for perm in all_permutations:
+            node_info = NodeInfo(perm)
+            node.node_info.append(node_info)
+            permuted_loops = [node.loop_info[i] for i in perm]
+            for load in node.loads:
+                access_map = get_minimal_access_pattern(load, permuted_loops)
+                node_info.loads_map[load] = EdgeInfo(access_map)
+                first_element_time, last_element_time = self._compute_first_and_last_element_time(load, permuted_loops)
+                node_info.loads_map[load].first_element_time = first_element_time
+                node_info.loads_map[load].last_element_time = last_element_time
+
+            for store in node.stores:
+                access_map = get_minimal_access_pattern(store, permuted_loops)
+                node_info.stores_map[store] = EdgeInfo(access_map)
+                first_element_time, last_element_time = self._compute_first_and_last_element_time(store, permuted_loops)
+                node_info.stores_map[store].first_element_time = first_element_time
+                node_info.stores_map[store].last_element_time = last_element_time
+            
+            # Compute II
+            node_info.II = compute_loop_II(top_level_for, permuted_loops)
+        return True
+
+    def init(self) -> bool:
+        """Initialize the dataflow graph from the MLIR module."""
+        if not self.block:
+            return False
+            
+        # Map from loops to node IDs
+        loop_to_node_id = {}
+        
+        # Map from memrefs to set of nodes that access them
+        memref_stores = defaultdict(set)
+        memref_loads = defaultdict(set)
+        memref_allocs = defaultdict(set)
+        
+        # Create nodes
+        for op in self.block.operations:
+            if self._is_loop_op(op):
+                node_id = self.add_node(op, DFGNodeType.AFFINE)
+                loop_to_node_id[op] = node_id
+                
+                self._collect_memory_ops(op, self.nodes[node_id])
+                self.nodes[node_id].loop_info = self._compute_loop_info(op)
+                                
+                for load_op in self.nodes[node_id].loads:
+                    memref = self._get_memref(load_op)
+                    if memref:
+                        memref_loads[memref].add((node_id, load_op))
+                
+                for store_op in self.nodes[node_id].stores:
+                    memref = self._get_memref(store_op)
+                    if memref:
+                        memref_stores[memref].add((node_id, store_op))
+
+                for alloc_op in self.nodes[node_id].allocations:
+                    memref = self._get_memref(alloc_op)
+                    if memref:
+                        memref_allocs[memref].add((node_id, alloc_op))
+
+            elif is_terminator(op):
+                node_id = self.add_node(op, DFGNodeType.RET)
+                memrefs = self._get_memrefs_for_return(op)
+                for memref in memrefs:
+                    memref_loads[memref].add((node_id, op))
+
+            elif self._is_alloc_op(op):
+                node_id = self.add_node(op, DFGNodeType.ALLOC)
+                if self._get_memref(op):
+                    memref_allocs[self._get_memref(op)].add((node_id, op))
+                    node = self.get_node(node_id)
+                    node.allocations.append(op)
+
+            elif self._is_constant_op(op):
+                node_id = self.add_node(op, DFGNodeType.CONST)
+
+            else: 
+                raise NotImplementedError(f"Unsupported operation found in kernel: {op}")
+        
+        # add edges
+        for memref, node_ids in memref_loads.items():
+            loads_node_list = sorted(list(node_ids), key=lambda x: x[0])
+            stores_node_list = sorted(list(memref_stores[memref]), key=lambda x: x[0])
+            for load_node_id, load_op in loads_node_list:
+                for store_node_id, store_op in stores_node_list:
+                    if load_node_id != store_node_id:
+                        self.add_edge(store_node_id, load_node_id, value=memref, src_op=store_op, dst_op=load_op)
+            
+            for alloc_node_id, alloc_op in memref_allocs[memref]:
+                for store_node_id, store_op in stores_node_list:
+                    self.add_edge(alloc_node_id, store_node_id, value=memref, src_op=store_op, dst_op=alloc_op)
+            
+        
+        # Third pass: populate node information for each loop permutation
+        for node in self.nodes.values():
+            self._populate_node_info(node.id)
+        
+        return True
+    
+    def _is_loop_op(self, op) -> bool:
+        """Check if an operation is a loop."""
+        return isinstance(op.opview, affine_d.AffineForOp)
+    
+    def _is_load_op(self, op) -> bool:
+        """Check if an operation is a load."""
+        return isinstance(op.opview, (affine_d.AffineLoadOp, memref_d.LoadOp))
+    
+    def _is_store_op(self, op) -> bool:
+        """Check if an operation is a store."""
+        return isinstance(op.opview, (affine_d.AffineStoreOp, memref_d.StoreOp))
+        
+    def _is_alloc_op(self, op) -> bool:
+        """Check if an operation is an allocation."""
+        return isinstance(op.opview, memref_d.AllocOp)
+    
+    def _is_constant_op(self, op) -> bool:
+        """Check if an operation is a constant."""
+        return op.OPERATION_NAME.endswith(".constant")
+        
+    def _get_memref(self, op):
+        """Get the memrefs from operation."""
+        assert not isinstance(op.opview, func_d.ReturnOp)
+        if hasattr(op, "memref"):
+            return op.memref
+        
+        for operand in op.operands:
+            if hasattr(operand, "type") and isinstance(operand.type, MemRefType):
+                return operand
+        return None
+    
+    def _get_memrefs_for_return(self, op) -> list:
+        return [operand for operand in op.operands if isinstance(operand.type, MemRefType)]
+    
+    def _collect_memory_ops(self, op: Operation, node: Node):
+        def collector_callback(current_op):
+            if self._is_load_op(current_op):
+                node.loads.append(current_op)
+            elif self._is_store_op(current_op):
+                node.stores.append(current_op)
+            elif self._is_alloc_op(current_op):
+                node.allocations.append(current_op)
+
+            return WalkResult(0)
+        
+        assert self._is_loop_op(op)
+        op.walk(collector_callback)
+    
+    def _find_store_op(self, node, memref):
+        """Find a store operation for a specific memref in a node."""
+        for store_op in node.stores:
+            if self._get_memref(store_op) == memref:
+                return store_op
+        return None
+    
+    def _find_load_op(self, node, memref):
+        """Find a load operation for a specific memref in a node."""
+        for load_op in node.loads:
+            if self._get_memref(load_op) == memref:
+                return load_op
+        return None
+    
+    def topological_sort(self) -> list[int]:
+        """Sort nodes in topological order."""
+        visited = set()
+        temp_mark = set()  
+        order = []
+        
+        def visit(node_id):
+            if node_id in temp_mark:
+                # Cycle detected
+                return False
+            if node_id in visited:
+                return True
+            
+            temp_mark.add(node_id)
+            
+            for edge in self.out_edges.get(node_id, []):
+                if not visit(edge.id):
+                    return False
+            
+            temp_mark.remove(node_id)
+            visited.add(node_id)
+            order.append(node_id)
+            return True
+        
+        for node_id in self.nodes:
+            if node_id not in visited:
+                if not visit(node_id):
+                    # Cycle detected
+                    return []
+        
+        return list(reversed(order))
+    
+    def print_as_dot(self, output_file_path):
+        # if output_file_path is None, write to stdout
+        with open(output_file_path, "w", encoding="utf-8") if output_file_path else sys.stdout as f:
+            f.write("digraph DataFlowGraph {\n")
+            
+            f.write("  node [shape=box, style=filled, fontname=\"Arial\"];\n")
+            f.write("  edge [fontname=\"Arial\"];\n\n")
+            
+            f.write("  // Nodes\n")
+            for node_id, node in self.nodes.items():
+                if node.type == DFGNodeType.AFFINE:
+                    color = "lightblue"
+                    label = f"Node {node_id} (AFFINE)"
+                    
+                    if node.op:
+                        loads = [load.operands[0].get_name() for load in node.loads]
+                        stores = [store.operands[1].get_name() for store in node.stores]
+                        op_str = f"Loads: {loads}\nStores: {stores}"
+                        op_str = op_str.replace('"', '\\"').replace('\n', '\\n')
+                        label = f"{label}\\n{op_str}"
+                elif node.type == DFGNodeType.RET:
+                    color = "pink"
+                    label = f"Node {node_id} (RETURN)"
+                elif node.type == DFGNodeType.ALLOC:
+                    color = "lightgray"
+                    label = f"(ALLOC) {node.allocations[0].memref.get_name()}"
+                elif node.type == DFGNodeType.CONST:
+                    color = "lightyellow"
+                    label = f"(CONST) {node.op}"
+                else:
+                    color = "white"
+                    label = f"Node {node_id} (UNKNOWN)"
+                
+                f.write(f'  node{node_id} [label="{label}", fillcolor="{color}"];\n')
+            
+            f.write("\n  // Edges\n")
+            for src_id, dst_list in self.out_edges.items():
+                for edge in dst_list:
+                    dst_id = edge.id
+                    
+                    edge_attrs = []
+                    if edge.value:
+                        edge_label = edge.value.get_name().replace('"', '\\"')
+                        edge_attrs.append(f'label="{edge_label}"')
+
+                    f.write(f'  node{src_id} -> node{dst_id}')
+                    if edge_attrs:
+                        f.write(f' [{", ".join(edge_attrs)}]')
+                    f.write(';\n')
+            
+            f.write("}\n")
+        
+    # Optimization methods
+    def createGraphParallelismPerformanceModel(self):
+        pass
+
+    @classmethod
+    def from_module(cls, module, dsp_factors=None, mem_r_ports=None, mem_w_ports=None):
+        """Create a dataflow graph from an MLIR module."""
+        dfg = cls(dsp_factors=dsp_factors, mem_r_ports=mem_r_ports, mem_w_ports=mem_w_ports)
+        
+        for op in module.body.operations:
+            if isinstance(op, func_d.FuncOp):
+                dfg.block = op.entry_block
+                break
+        
+        dfg.init()
+        
+        return dfg

--- a/allo/autoscheduler/dfg.py
+++ b/allo/autoscheduler/dfg.py
@@ -16,8 +16,9 @@ from .util import (
     is_reduction_loop,
     is_terminator,
     get_minimal_access_pattern,
-    compute_loop_II
+    compute_loop_II,
 )
+
 
 class DFGNodeType(enum.Enum):
     AFFINE = 0
@@ -25,64 +26,71 @@ class DFGNodeType(enum.Enum):
     ALLOC = 2
     CONST = 3
 
+
 class Edge:
     """Represents a data dependency between nodes in the dataflow graph."""
+
     def __init__(self, dst_id: int, value=None, src_op=None, dst_op=None):
-        self.id = dst_id        # Destination node ID
-        self.value = value      # The value/memref being communicated
-        self.src_op = src_op    # Source operation (e.g., store)
-        self.dst_op = dst_op    # Destination operation (e.g., load)
-    
+        self.id = dst_id  # Destination node ID
+        self.value = value  # The value/memref being communicated
+        self.src_op = src_op  # Source operation (e.g., store)
+        self.dst_op = dst_op  # Destination operation (e.g., load)
+
     def __repr__(self):
-        return f"Edge(id={self.id}, value={self.value.get_name()})"    
+        return f"Edge(id={self.id}, value={self.value.get_name()})"
+
 
 class EdgeInfo:
-    def __init__(self, accessMap: AffineMap): 
+    def __init__(self, accessMap: AffineMap):
         self.accessMap = accessMap
         self.first_element_time = 0
         self.last_element_time = 0
 
-    def __repr__(self): 
+    def __repr__(self):
         return f"EdgeInfo(accessMap={self.accessMap}"
+
 
 class NodeInfo:
     def __init__(self, permutation):
         # Map permutation to edge info associated with that permutation
-        self.stores_map = {} 
+        self.stores_map = {}
         self.loads_map = {}
         self.II = 0
         self.trip_count = 0
         self.permutation = permutation
+
     def __repr__(self):
         return f"NodeInfo(permutation={self.permutation})"
 
+
 class Node:
     """Represents a computation node (typically a loop nest) in the dataflow graph."""
+
     def __init__(self, node_id: int, op=None, op_type=None):
-        self.id = node_id                 # Unique identifier
-        self.op = op                 # The operation (typically a loop)
-        self.loads = []              # Load operations within this node
-        self.stores = []             # Store operations within this node
-        self.allocations = []        # Allocation operations
-        self.loop_info = []          # Loop information (in the original permutation)
-        self.node_info = []          # Node information precomputed per permutation
-        self.type = op_type          # Node type (AFFINE, RET, ALLOC, CONST)
-        self.DSP_factor = 0          # DSP factor for this node
-        self.is_reduction = None     # Whether this node is a reduction loop
-    
+        self.id = node_id  # Unique identifier
+        self.op = op  # The operation (typically a loop)
+        self.loads = []  # Load operations within this node
+        self.stores = []  # Store operations within this node
+        self.allocations = []  # Allocation operations
+        self.loop_info = []  # Loop information (in the original permutation)
+        self.node_info = []  # Node information precomputed per permutation
+        self.type = op_type  # Node type (AFFINE, RET, ALLOC, CONST)
+        self.DSP_factor = 0  # DSP factor for this node
+        self.is_reduction = None  # Whether this node is a reduction loop
+
     def __repr__(self):
         return f"Node(id={self.id}, op={str(self.op.operation.name) if self.op else 'None'})"
-    
+
     def get_load_op_count(self, memref) -> int:
         """Count load operations for a specific memref."""
-        return sum(1 for load_op in self.loads 
-                  if self._get_memref(load_op) == memref)
-    
+        return sum(1 for load_op in self.loads if self._get_memref(load_op) == memref)
+
     def get_store_op_count(self, memref) -> int:
         """Count store operations for a specific memref."""
-        return sum(1 for store_op in self.stores 
-                  if self._get_memref(store_op) == memref)
-    
+        return sum(
+            1 for store_op in self.stores if self._get_memref(store_op) == memref
+        )
+
     def _get_memref(self, op):
         """Get the memref from an operation."""
         if hasattr(op, "memref"):
@@ -92,66 +100,78 @@ class Node:
             if hasattr(operand, "type") and "memref" in str(operand.type):
                 return operand
         return None
-    
+
+
 class DFG:
     """Dataflow Graph representing an MLIR module."""
-    def __init__(self, block=None, dsp_factors=None, mem_r_ports=None, mem_w_ports=None):
+
+    def __init__(
+        self, block=None, dsp_factors=None, mem_r_ports=None, mem_w_ports=None
+    ):
         self.block: Block = block
-        self.nodes: dict[int, Node] = {}    # Map from node ID to Node
-        self.in_edges = defaultdict(list)   # Map from node ID to incoming edges
+        self.nodes: dict[int, Node] = {}  # Map from node ID to Node
+        self.in_edges = defaultdict(list)  # Map from node ID to incoming edges
         self.out_edges = defaultdict(list)  # Map from node ID to outgoing edges
-        self.edges = []         # list of all edges
+        self.edges = []  # list of all edges
         self.memref_edge_count = defaultdict(int)  # Count edges per memref
         self.next_node_id = 0
-        self.dsp_factors = {
-            'arith.mulf': 3, 
-            'arith.addf': 0,      
-            'arith.subf': 0,      
-            'arith.divf': 14,     
-            'arith.remf': 14,
-            'arith.muli': 1,    
-            'arith.addi': 0,      
-            'arith.subi': 0,    
-            'arith.divi': 8,   
-            'arith.divu': 8, 
-            'arith.remi': 8,   
-            'arith.remu': 8, 
-        } if not dsp_factors else dsp_factors
+        self.dsp_factors = (
+            {
+                "arith.mulf": 3,
+                "arith.addf": 0,
+                "arith.subf": 0,
+                "arith.divf": 14,
+                "arith.remf": 14,
+                "arith.muli": 1,
+                "arith.addi": 0,
+                "arith.subi": 0,
+                "arith.divi": 8,
+                "arith.divu": 8,
+                "arith.remi": 8,
+                "arith.remu": 8,
+            }
+            if not dsp_factors
+            else dsp_factors
+        )
         self.mem_r_ports = mem_r_ports
         self.mem_w_ports = mem_w_ports
-    
+
     def add_node(self, op, op_type) -> int:
         """Add a node to the graph and return its ID."""
         node = Node(self.next_node_id, op, op_type)
         self.nodes[node.id] = node
         self.next_node_id += 1
         return node.id
-    
+
     def get_node(self, node_id: int) -> Node:
         """Get a node by its ID."""
         if node_id not in self.nodes:
             raise KeyError(f"Node ID {node_id} not found in graph")
         return self.nodes[node_id]
-    
+
     def has_edge(self, src_id: int, dst_id: int, value=None) -> bool:
         """Check if there's an edge from src_id to dst_id."""
         if src_id not in self.out_edges or dst_id not in self.in_edges:
             return False
-            
-        has_out_edge = any(edge.id == dst_id and (not value or edge.value == value)
-                          for edge in self.out_edges[src_id])
-        has_in_edge = any(edge.id == src_id and (not value or edge.value == value)
-                          for edge in self.in_edges[dst_id])
-        
+
+        has_out_edge = any(
+            edge.id == dst_id and (not value or edge.value == value)
+            for edge in self.out_edges[src_id]
+        )
+        has_in_edge = any(
+            edge.id == src_id and (not value or edge.value == value)
+            for edge in self.in_edges[dst_id]
+        )
+
         return has_out_edge and has_in_edge
-    
+
     def add_edge(self, src_id: int, dst_id: int, value=None, src_op=None, dst_op=None):
         """Add an edge from src_id to dst_id."""
         if not self.has_edge(src_id, dst_id, value):
             self.out_edges[src_id].append(Edge(dst_id, value, src_op, dst_op))
             self.in_edges[dst_id].append(Edge(src_id, value, src_op, dst_op))
             self.edges.append((src_id, dst_id, value))
-            
+
             if value and hasattr(value, "type") and "memref" in str(value.type):
                 self.memref_edge_count[value] += 1
 
@@ -161,35 +181,43 @@ class DFG:
         upper_bound = int(str(loop_op.upperBoundMap.value.results[0]))
 
         step = 1
-        if loop_op.step is not None: 
+        if loop_op.step is not None:
             step = int(loop_op.step)
-        
+
         if step == 0:
-            return 0 
-        
+            return 0
+
         if upper_bound < lower_bound:
-            return 0 
-        
+            return 0
+
         inner_for_ops = [op for op in loop_op.body.operations if self._is_loop_op(op)]
-        current_trip_count = (upper_bound - lower_bound + step - 1) // step 
+        current_trip_count = (upper_bound - lower_bound + step - 1) // step
 
         if len(inner_for_ops) == 0:
-            return [LoopInfo(loop_op, lower_bound, upper_bound, step, current_trip_count)]
+            return [
+                LoopInfo(loop_op, lower_bound, upper_bound, step, current_trip_count)
+            ]
 
         if len(inner_for_ops) == 1:
             inner_loop_infos = self._compute_loop_info(inner_for_ops[0])
-            return [LoopInfo(loop_op, lower_bound, upper_bound, step, current_trip_count)] + inner_loop_infos
-       
-        raise NotImplementedError("Nested loops with more than 1 inner loop are not supported")
-        
-    def _compute_first_and_last_element_time(self, op: Operation, loop_band: list[LoopInfo]) -> tuple[int, int]:
+            return [
+                LoopInfo(loop_op, lower_bound, upper_bound, step, current_trip_count)
+            ] + inner_loop_infos
+
+        raise NotImplementedError(
+            "Nested loops with more than 1 inner loop are not supported"
+        )
+
+    def _compute_first_and_last_element_time(
+        self, op: Operation, loop_band: list[LoopInfo]
+    ) -> tuple[int, int]:
         """Compute the first and last element time for an operation."""
         op = op.opview
         if isinstance(op, (affine_d.AffineLoadOp, affine_d.AffineStoreOp)):
             mapOperands = op.indices
         else:
             assert False, "op is not an affine load or store operation"
-        
+
         # Compute the first and last element time
         first_element_time = 0
         last_element_time = 0
@@ -200,18 +228,18 @@ class DFG:
             curr_factor *= prev_trip_count
             iv = loop.op.opview.induction_variable
             if iv in mapOperands:
-                first_element_time += 0 
-                last_element_time += (loop.trip_count - 1) * curr_factor 
+                first_element_time += 0
+                last_element_time += (loop.trip_count - 1) * curr_factor
 
             # not in loop bound, compute conservative estimate. for loads it is 0, for stores it is trip_count - 1
             elif isinstance(op, affine_d.AffineLoadOp):
-                    first_element_time += 0
-                    last_element_time += 0
-            else: 
+                first_element_time += 0
+                last_element_time += 0
+            else:
                 first_element_time += (loop.trip_count - 1) * curr_factor
                 last_element_time += (loop.trip_count - 1) * curr_factor
         return first_element_time, last_element_time
-                    
+
     def _populate_node_info(self, node_id: int) -> bool:
         """Populate node information for a specific node."""
         node: Node = self.get_node(node_id)
@@ -219,18 +247,23 @@ class DFG:
             return False
 
         top_level_for = node.loop_info[0].op
+
         def update_dsp_count(op):
-            if hasattr(op, 'opview') and hasattr(op.opview, 'operation') and hasattr(op.opview.operation, 'name'):
+            if (
+                hasattr(op, "opview")
+                and hasattr(op.opview, "operation")
+                and hasattr(op.opview.operation, "name")
+            ):
                 op_name = op.opview.operation.name
-                if op_name.startswith('arith.'):
+                if op_name.startswith("arith."):
                     node.DSP_factor += self.dsp_factors.get(op_name, 0)
             return WalkResult(0)
-        
+
         top_level_for.walk(update_dsp_count)
         node.is_reduction = is_reduction_loop(top_level_for)
 
         num_loops = len(node.loop_info)
-        
+
         all_permutations = itertools.permutations(range(num_loops))
 
         for perm in all_permutations:
@@ -240,17 +273,21 @@ class DFG:
             for load in node.loads:
                 access_map = get_minimal_access_pattern(load, permuted_loops)
                 node_info.loads_map[load] = EdgeInfo(access_map)
-                first_element_time, last_element_time = self._compute_first_and_last_element_time(load, permuted_loops)
+                first_element_time, last_element_time = (
+                    self._compute_first_and_last_element_time(load, permuted_loops)
+                )
                 node_info.loads_map[load].first_element_time = first_element_time
                 node_info.loads_map[load].last_element_time = last_element_time
 
             for store in node.stores:
                 access_map = get_minimal_access_pattern(store, permuted_loops)
                 node_info.stores_map[store] = EdgeInfo(access_map)
-                first_element_time, last_element_time = self._compute_first_and_last_element_time(store, permuted_loops)
+                first_element_time, last_element_time = (
+                    self._compute_first_and_last_element_time(store, permuted_loops)
+                )
                 node_info.stores_map[store].first_element_time = first_element_time
                 node_info.stores_map[store].last_element_time = last_element_time
-            
+
             # Compute II
             node_info.II = compute_loop_II(top_level_for, permuted_loops)
         return True
@@ -259,29 +296,29 @@ class DFG:
         """Initialize the dataflow graph from the MLIR module."""
         if not self.block:
             return False
-            
+
         # Map from loops to node IDs
         loop_to_node_id = {}
-        
+
         # Map from memrefs to set of nodes that access them
         memref_stores = defaultdict(set)
         memref_loads = defaultdict(set)
         memref_allocs = defaultdict(set)
-        
+
         # Create nodes
         for op in self.block.operations:
             if self._is_loop_op(op):
                 node_id = self.add_node(op, DFGNodeType.AFFINE)
                 loop_to_node_id[op] = node_id
-                
+
                 self._collect_memory_ops(op, self.nodes[node_id])
                 self.nodes[node_id].loop_info = self._compute_loop_info(op)
-                                
+
                 for load_op in self.nodes[node_id].loads:
                     memref = self._get_memref(load_op)
                     if memref:
                         memref_loads[memref].add((node_id, load_op))
-                
+
                 for store_op in self.nodes[node_id].stores:
                     memref = self._get_memref(store_op)
                     if memref:
@@ -308,9 +345,11 @@ class DFG:
             elif self._is_constant_op(op):
                 node_id = self.add_node(op, DFGNodeType.CONST)
 
-            else: 
-                raise NotImplementedError(f"Unsupported operation found in kernel: {op}")
-        
+            else:
+                raise NotImplementedError(
+                    f"Unsupported operation found in kernel: {op}"
+                )
+
         # add edges
         for memref, node_ids in memref_loads.items():
             loads_node_list = sorted(list(node_ids), key=lambda x: x[0])
@@ -318,53 +357,66 @@ class DFG:
             for load_node_id, load_op in loads_node_list:
                 for store_node_id, store_op in stores_node_list:
                     if load_node_id != store_node_id:
-                        self.add_edge(store_node_id, load_node_id, value=memref, src_op=store_op, dst_op=load_op)
-            
+                        self.add_edge(
+                            store_node_id,
+                            load_node_id,
+                            value=memref,
+                            src_op=store_op,
+                            dst_op=load_op,
+                        )
+
             for alloc_node_id, alloc_op in memref_allocs[memref]:
                 for store_node_id, store_op in stores_node_list:
-                    self.add_edge(alloc_node_id, store_node_id, value=memref, src_op=store_op, dst_op=alloc_op)
-            
-        
+                    self.add_edge(
+                        alloc_node_id,
+                        store_node_id,
+                        value=memref,
+                        src_op=store_op,
+                        dst_op=alloc_op,
+                    )
+
         # Third pass: populate node information for each loop permutation
         for node in self.nodes.values():
             self._populate_node_info(node.id)
-        
+
         return True
-    
+
     def _is_loop_op(self, op) -> bool:
         """Check if an operation is a loop."""
         return isinstance(op.opview, affine_d.AffineForOp)
-    
+
     def _is_load_op(self, op) -> bool:
         """Check if an operation is a load."""
         return isinstance(op.opview, (affine_d.AffineLoadOp, memref_d.LoadOp))
-    
+
     def _is_store_op(self, op) -> bool:
         """Check if an operation is a store."""
         return isinstance(op.opview, (affine_d.AffineStoreOp, memref_d.StoreOp))
-        
+
     def _is_alloc_op(self, op) -> bool:
         """Check if an operation is an allocation."""
         return isinstance(op.opview, memref_d.AllocOp)
-    
+
     def _is_constant_op(self, op) -> bool:
         """Check if an operation is a constant."""
         return op.OPERATION_NAME.endswith(".constant")
-        
+
     def _get_memref(self, op):
         """Get the memrefs from operation."""
         assert not isinstance(op.opview, func_d.ReturnOp)
         if hasattr(op, "memref"):
             return op.memref
-        
+
         for operand in op.operands:
             if hasattr(operand, "type") and isinstance(operand.type, MemRefType):
                 return operand
         return None
-    
+
     def _get_memrefs_for_return(self, op) -> list:
-        return [operand for operand in op.operands if isinstance(operand.type, MemRefType)]
-    
+        return [
+            operand for operand in op.operands if isinstance(operand.type, MemRefType)
+        ]
+
     def _collect_memory_ops(self, op: Operation, node: Node):
         def collector_callback(current_op):
             if self._is_load_op(current_op):
@@ -375,75 +427,79 @@ class DFG:
                 node.allocations.append(current_op)
 
             return WalkResult(0)
-        
+
         assert self._is_loop_op(op)
         op.walk(collector_callback)
-    
+
     def _find_store_op(self, node, memref):
         """Find a store operation for a specific memref in a node."""
         for store_op in node.stores:
             if self._get_memref(store_op) == memref:
                 return store_op
         return None
-    
+
     def _find_load_op(self, node, memref):
         """Find a load operation for a specific memref in a node."""
         for load_op in node.loads:
             if self._get_memref(load_op) == memref:
                 return load_op
         return None
-    
+
     def topological_sort(self) -> list[int]:
         """Sort nodes in topological order."""
         visited = set()
-        temp_mark = set()  
+        temp_mark = set()
         order = []
-        
+
         def visit(node_id):
             if node_id in temp_mark:
                 # Cycle detected
                 return False
             if node_id in visited:
                 return True
-            
+
             temp_mark.add(node_id)
-            
+
             for edge in self.out_edges.get(node_id, []):
                 if not visit(edge.id):
                     return False
-            
+
             temp_mark.remove(node_id)
             visited.add(node_id)
             order.append(node_id)
             return True
-        
+
         for node_id in self.nodes:
             if node_id not in visited:
                 if not visit(node_id):
                     # Cycle detected
                     return []
-        
+
         return list(reversed(order))
-    
+
     def print_as_dot(self, output_file_path):
         # if output_file_path is None, write to stdout
-        with open(output_file_path, "w", encoding="utf-8") if output_file_path else sys.stdout as f:
+        with (
+            open(output_file_path, "w", encoding="utf-8")
+            if output_file_path
+            else sys.stdout
+        ) as f:
             f.write("digraph DataFlowGraph {\n")
-            
-            f.write("  node [shape=box, style=filled, fontname=\"Arial\"];\n")
-            f.write("  edge [fontname=\"Arial\"];\n\n")
-            
+
+            f.write('  node [shape=box, style=filled, fontname="Arial"];\n')
+            f.write('  edge [fontname="Arial"];\n\n')
+
             f.write("  // Nodes\n")
             for node_id, node in self.nodes.items():
                 if node.type == DFGNodeType.AFFINE:
                     color = "lightblue"
                     label = f"Node {node_id} (AFFINE)"
-                    
+
                     if node.op:
                         loads = [load.operands[0].get_name() for load in node.loads]
                         stores = [store.operands[1].get_name() for store in node.stores]
                         op_str = f"Loads: {loads}\nStores: {stores}"
-                        op_str = op_str.replace('"', '\\"').replace('\n', '\\n')
+                        op_str = op_str.replace('"', '\\"').replace("\n", "\\n")
                         label = f"{label}\\n{op_str}"
                 elif node.type == DFGNodeType.RET:
                     color = "pink"
@@ -457,26 +513,26 @@ class DFG:
                 else:
                     color = "white"
                     label = f"Node {node_id} (UNKNOWN)"
-                
+
                 f.write(f'  node{node_id} [label="{label}", fillcolor="{color}"];\n')
-            
+
             f.write("\n  // Edges\n")
             for src_id, dst_list in self.out_edges.items():
                 for edge in dst_list:
                     dst_id = edge.id
-                    
+
                     edge_attrs = []
                     if edge.value:
                         edge_label = edge.value.get_name().replace('"', '\\"')
                         edge_attrs.append(f'label="{edge_label}"')
 
-                    f.write(f'  node{src_id} -> node{dst_id}')
+                    f.write(f"  node{src_id} -> node{dst_id}")
                     if edge_attrs:
                         f.write(f' [{", ".join(edge_attrs)}]')
-                    f.write(';\n')
-            
+                    f.write(";\n")
+
             f.write("}\n")
-        
+
     # Optimization methods
     def createGraphParallelismPerformanceModel(self):
         pass
@@ -484,13 +540,15 @@ class DFG:
     @classmethod
     def from_module(cls, module, dsp_factors=None, mem_r_ports=None, mem_w_ports=None):
         """Create a dataflow graph from an MLIR module."""
-        dfg = cls(dsp_factors=dsp_factors, mem_r_ports=mem_r_ports, mem_w_ports=mem_w_ports)
-        
+        dfg = cls(
+            dsp_factors=dsp_factors, mem_r_ports=mem_r_ports, mem_w_ports=mem_w_ports
+        )
+
         for op in module.body.operations:
             if isinstance(op, func_d.FuncOp):
                 dfg.block = op.entry_block
                 break
-        
+
         dfg.init()
-        
+
         return dfg

--- a/allo/autoscheduler/passes.py
+++ b/allo/autoscheduler/passes.py
@@ -149,7 +149,6 @@ def canonicalize_alloc(alloc_op):
 
     # multiple loads and multiple stores
     if len(stores) >= 2 and len(loads) >= 2:
-        print(stores, loads)
         raise NotImplementedError(
             f"Complex pattern detected in alloc op {alloc_op}; additional canonicalization not implemented yet."
         )

--- a/allo/autoscheduler/util.py
+++ b/allo/autoscheduler/util.py
@@ -1,9 +1,14 @@
 # Copyright Allo authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 from collections import defaultdict
+from typing import NamedTuple
 from allo._mlir.ir import (
     Location,
     Module,
+    Operation,
+    AffineMap,
+    AffineExpr,
+    Block,
 )
 from allo._mlir.dialects import (
     func as func_d,
@@ -15,7 +20,8 @@ from allo.ir.types import MemRefType
 from allo._mlir.ir import WalkResult
 
 
-def is_terminator(op):
+# PREPROCESSING
+def is_terminator(op: Operation) -> bool:
     ## TODO: can we do trait inspection with python bindings?
     return isinstance(op, (affine_d.AffineYieldOp, func_d.ReturnOp))
 
@@ -89,8 +95,9 @@ def check_perfect_affine_kernel(module: Module) -> bool:
         # Check each top-level op
         for op in top_level_ops:
             # Allow allocs and returns at top level
+            # TODO: we could theoretically allow constant loads/stores here as well
             if (
-                isinstance(op, memref_d.AllocOp)
+                isinstance(op, (memref_d.AllocOp))
                 or is_terminator(op)
                 or op.OPERATION_NAME.endswith(".constant")
             ):
@@ -153,7 +160,7 @@ def check_all_functions_inlined(mod: Module, top_fn_name: str) -> bool:
     return True
 
 
-def check_single_producer_single_consumer(module):
+def check_single_producer_single_consumer(module: Module) -> bool:
     spsc = True
 
     def checker(op):
@@ -199,3 +206,292 @@ def check_preprocess_ok(schedule: Schedule) -> bool:
         and check_all_functions_inlined(module, top_fn_name)
         and check_single_producer_single_consumer(module)
     )
+
+
+# DFG
+LoopInfo = NamedTuple(
+    "LoopInfo",
+    [
+        ("op", Operation),
+        ("lower_bound", int),
+        ("upper_bound", int),
+        ("step", int),
+        ("trip_count", int),
+    ],
+)
+
+
+def get_minimal_access_pattern(op: Operation, loop_info: list[LoopInfo]) -> AffineMap:
+    """
+    Analyzes an affine load or store operation and returns an AffineMap representing
+    minimal access function under the permutation provided in loop_info.
+    """
+    # Handle load or store
+    mapOperands = []
+    accessMap = None
+    op = op.opview
+    if isinstance(op, (affine_d.AffineLoadOp, affine_d.AffineStoreOp)):
+        accessMap = op.map.value
+        mapOperands = op.indices
+    else:
+        assert False, "op is not an affine load or store operation"
+
+    if len(mapOperands) == 0:
+        return accessMap
+
+    band = [loop.op for loop in loop_info]
+    relevantLoops = []
+    relevantOperands = []
+
+    for forOp in band:
+        iv = forOp.induction_variable
+        if any(operand == iv for operand in mapOperands):
+            relevantLoops.append(forOp)
+            relevantOperands.append(iv)
+
+    assert len(relevantOperands) == len(
+        mapOperands
+    ), "Complex access patterns are not supported"
+
+    # at this point, relevantOperands holds the induction variables in the order of the loop nest
+    # and mapOperands holds the operands in the order they appear for the AffineMap
+    # build a permutation map of the relevant induction variables
+    orderingIndices = []
+    for operand in mapOperands:
+        orderingIndices.append(relevantOperands.index(operand))
+
+    permutationMap = AffineMap.get_permutation(orderingIndices, op.context)
+    return compose_affine_maps(permutationMap, accessMap)
+
+
+def inverse_permutation(permutation: list[int]) -> list[int]:
+    inverse = [0] * len(permutation)
+    for i, j in enumerate(permutation):
+        inverse[j] = i
+    return inverse
+
+
+def compose_affine_maps(inner_map: AffineMap, outer_map: AffineMap) -> AffineMap:
+    """
+    Compose two affine maps. Reimplementation of MLIR's AffineMap::compose.
+    """
+    assert len(inner_map.results) == outer_map.n_dims, (
+        f"Composition error: Inner map produces {len(inner_map.results)} results, "
+        f"but outer map expects {outer_map.n_dims} dimensions"
+    )
+
+    composed_exprs = []
+    for expr in outer_map.results:
+        composed_expr = expr.compose(inner_map)
+        composed_exprs.append(composed_expr)
+
+    return AffineMap.get(
+        inner_map.n_dims,
+        inner_map.n_symbols + outer_map.n_symbols,
+        composed_exprs,
+        inner_map.context,
+    )
+
+
+def is_reduction_loop(for_op: affine_d.AffineForOp) -> bool:
+    """
+    Determines if an AffineForOp represents a reduction loop.
+    """
+    assert isinstance(for_op, affine_d.AffineForOp), "Expected an AffineForOp"
+
+    load_ops = []
+    store_ops = []
+    unsupported_ops = False
+
+    def is_locally_defined(memref, loop_op):
+        if not hasattr(memref, "owner") or not memref.owner:
+            return False
+
+        current = memref.owner
+
+        if isinstance(current, Block):
+            return False
+
+        while current:
+            if current.parent == loop_op:
+                return True
+            current = current.parent
+        return False
+
+    def walk_callback(op):
+        op_view = op.opview
+
+        if isinstance(op_view, affine_d.AffineLoadOp):
+            if not is_locally_defined(op_view.memref, for_op):
+                load_ops.append(op)
+
+        elif isinstance(op_view, affine_d.AffineStoreOp):
+            if not is_locally_defined(op_view.memref, for_op):
+                store_ops.append(op)
+
+        # check for unsupported operations
+        elif (
+            not isinstance(
+                op_view,
+                (affine_d.AffineForOp, affine_d.AffineYieldOp, affine_d.AffineIfOp),
+            )
+            and not isinstance(op_view, memref_d.AllocOp)
+            and not (
+                op_view.OPERATION_NAME.endswith(".constant")
+                or op_view.OPERATION_NAME.startswith("arith.")
+            )
+        ):
+            nonlocal unsupported_ops
+            unsupported_ops = True
+            return WalkResult(1)
+
+        return WalkResult(0)
+
+    for_op.operation.walk(walk_callback)
+
+    if unsupported_ops:
+        return False
+
+    for store_op in store_ops:
+        store_memref = store_op.opview.memref
+        store_block = store_op.parent
+
+        for load_op in load_ops:
+            load_memref = load_op.opview.memref
+            load_block = load_op.parent
+
+            if store_memref == load_memref and store_block == load_block:
+                return True
+
+    return False
+
+
+def compute_loop_II(
+    for_op: affine_d.AffineForOp,
+    loop_info: list[LoopInfo],
+    mem_r_port=2,
+    mem_w_port=1,
+    latencies=None,
+) -> int:
+    """
+    Calculate a rough estimate for the innermost loop pipeline initiation interval.
+    """
+    if latencies is None:
+        latencies = {
+            "arith.addf": 4,
+            "arith.subf": 4,
+            "arith.mulf": 5,
+            "arith.divf": 10,
+            "arith.addi": 1,
+            "arith.subi": 1,
+            "arith.muli": 2,
+            "default": 1,
+        }
+
+    loads = []
+    stores = []
+
+    def collect_mem_ops(op):
+        op_view = op.opview
+        if isinstance(op_view, affine_d.AffineLoadOp):
+            loads.append(op.opview)
+        elif isinstance(op_view, affine_d.AffineStoreOp):
+            stores.append(op.opview)
+        return WalkResult(0)
+
+    for_op.operation.walk(collect_mem_ops)
+
+    load_res_mii = (len(loads) + mem_r_port - 1) // mem_r_port
+    store_res_mii = (len(stores) + mem_w_port - 1) // mem_w_port
+    ii = max(load_res_mii, store_res_mii)
+    innermost_loop = loop_info[-1]
+    inner_loop_iv = innermost_loop.op.opview.induction_variable
+    innermost_loop_dim = AffineExpr.get_dim(len(loop_info) - 1, for_op.context)
+
+    for load in loads:
+        load_memref = load.memref
+        load_parent = load.parent
+        for store in stores:
+            store_memref = store.memref
+            store_parent = store.parent
+            if (
+                store_parent == load_parent
+                and load_memref == store_memref
+                and inner_loop_iv in store.indices
+                and inner_loop_iv in load.indices
+            ):
+                store_map = get_minimal_access_pattern(store, loop_info)
+                load_map = get_minimal_access_pattern(load, loop_info)
+                load_dependencies = [
+                    res
+                    for res in load_map.results
+                    if str(innermost_loop_dim) in str(res)
+                ]
+                store_dependencies = [
+                    res
+                    for res in store_map.results
+                    if str(innermost_loop_dim) in str(res)
+                ]
+                # if there are dependencies to diff loop iter, there is a carried loop dependency
+                if any(dep not in store_dependencies for dep in load_dependencies):
+                    ii = max(ii, estimate_critical_path(load, store, latencies))
+            ii = max(1, ii)
+
+    return ii
+
+
+def estimate_critical_path(load_op, store_op, latencies):
+    """
+    Estimate the critical path latency from load to store using a simple approach.
+    """
+    # minimum latency for a load and store operation
+    min_latency = 2
+
+    current_value = load_op.result
+
+    stored_value = store_op.value
+
+    if not current_value or not stored_value:
+        return min_latency
+
+    path_latency = latencies.get(load_op.operation.name, 1)
+
+    visited = set([load_op.operation])
+
+    max_steps = 10
+    step_count = 0
+
+    while current_value != stored_value and step_count < max_steps:
+        step_count += 1
+
+        users = list(current_value.uses)
+        if not users:
+            break
+
+        found_next = False
+        for use in users:
+            next_op = use.owner
+
+            if next_op in visited:
+                continue
+
+            visited.add(next_op)
+
+            if next_op == store_op.operation:
+                path_latency += latencies.get(next_op.name, latencies["default"])
+                found_next = True
+                break
+
+            if not next_op.results:
+                continue
+
+            op_latency = latencies.get(next_op.name, latencies["default"])
+            path_latency += op_latency
+            current_value = next_op.results[0]
+            found_next = True
+            break
+
+        if not found_next:
+            break
+
+    return max(path_latency, min_latency)

--- a/allo/autoscheduler/util.py
+++ b/allo/autoscheduler/util.py
@@ -225,6 +225,10 @@ def get_minimal_access_pattern(op: Operation, loop_info: list[LoopInfo]) -> Affi
     """
     Analyzes an affine load or store operation and returns an AffineMap representing
     minimal access function under the permutation provided in loop_info.
+
+    For instance, if the loop nest is [i, j, k], and we load fromm buffer[j, i],
+    the minimal access function would be (i, j) -> (j, i) since the load is independent
+    of the last induction variable k.
     """
     # Handle load or store
     mapOperands = []
@@ -442,7 +446,7 @@ def compute_loop_II(
 
 def estimate_critical_path(load_op, store_op, latencies):
     """
-    Estimate the critical path latency from load to store using a simple approach.
+    Estimate the critical path latency from load to store.
     """
     # minimum latency for a load and store operation
     min_latency = 2

--- a/tests/test_dfg.py
+++ b/tests/test_dfg.py
@@ -1,0 +1,189 @@
+# Copyright Allo authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import math
+import pytest
+import allo
+from allo.ir.types import int32, float32
+
+from allo.autoscheduler.dfg import DFG, DFGNodeType, Node
+from allo.autoscheduler.passes import dataflow_optimization_pass
+from allo.autoscheduler.util import compose_affine_maps
+from allo._mlir.ir import WalkResult, AffineMap
+
+def check_edges(dfg: DFG):
+    for src, dst, val in dfg.edges:
+        assert any(edge.id == dst for edge in dfg.out_edges[src]), f"Edge from {src} to {dst} not in out_edges"
+        assert any(edge.id == src for edge in dfg.in_edges[dst]), f"Edge from {src} to {dst} not in in_edges"
+        if dfg.get_node(src).type in (DFGNodeType.ALLOC, DFGNodeType.RET) or dfg.get_node(dst).type in (DFGNodeType.ALLOC, DFGNodeType.RET):
+            continue
+        assert any(store.operands[1] == val for store in dfg.get_node(src).stores), f"Value {val} not in stores of {dfg.get_node(src)}"
+        assert any(load.operands[0] == val for load in dfg.get_node(dst).loads), f"Value {val} not in loads of {dfg.get_node(dst)}"
+
+def check_node_info(dfg: DFG): 
+    for node_id, node in dfg.nodes.items():
+        if node.type != DFGNodeType.AFFINE:
+            continue
+            
+        assert len(node.loop_info) > 0, f"Node {node_id} has no loop info"
+        
+        num_loops = len(node.loop_info)
+        expected_permutations = math.factorial(num_loops)
+        assert len(node.node_info) == expected_permutations, f"Node {node_id} has {len(node.node_info)} permutations, expected {expected_permutations}"
+        assert node.DSP_factor >= 0, f"Node {node_id} has negative DSP factor: {node.DSP_factor}"
+
+def matrix_multiply(A: int32[8, 8], B: int32[8, 8]) -> int32[8, 8]:
+    C: int32[8, 8] = 0
+    for i in range(8):
+        for j in range(8):
+            for k in range(8):
+                C[i, j] = C[i, j] + A[i, k] * B[k, j]
+    return C
+
+def test_3mm():
+    def three_mm(A: int32[8, 8], B: int32[8, 8], C: int32[8, 8], D: int32[8, 8]) -> int32[8, 8]:
+        E: int32[8, 8] = matrix_multiply(A, B)
+        F: int32[8, 8] = matrix_multiply(C, D)
+        return matrix_multiply(E, F)
+
+    s = allo.customize(three_mm)
+    s = dataflow_optimization_pass(s, debugPoint="dataflow_canonicaliation")
+    module = s.module
+
+    dfg = DFG.from_module(module)
+    
+    check_edges(dfg)
+    check_node_info(dfg)
+
+def func() -> int32[10, 10, 10]:
+    A: int32[10, 10, 10]
+    for i, j in allo.grid(10, 10):
+        for k in range(0, 10, 2):
+            A[k, i, j] += 0
+    return A
+
+def test_loop_info():
+    s = allo.customize(func)
+    module = s.module
+    dfg = DFG.from_module(module)
+    affine_nodes = [node for node in dfg.nodes.values() if node.type == DFGNodeType.AFFINE]
+    assert len(affine_nodes) == 1
+    node = affine_nodes[0]
+    assert len(node.loop_info) == 3
+    assert all(loop.lower_bound == 0 for loop in node.loop_info)
+    assert all(loop.upper_bound == 10 for loop in node.loop_info)
+    assert all(loop.step == 1 and loop.trip_count == 10 for loop in node.loop_info[:2])
+    assert node.loop_info[2].step == 2 and node.loop_info[2].trip_count == 5
+    
+def test_node_info():
+    s = allo.customize(func)
+    s = dataflow_optimization_pass(s, debugPoint="dataflow_canonicaliation")
+
+    module = s.module
+    dfg = DFG.from_module(module)
+    print(module)
+
+    affine_node: Node = [node for node in dfg.nodes.values() if node.type == DFGNodeType.AFFINE][0]
+
+    assert len(affine_node.node_info) == math.factorial(len(affine_node.loop_info))
+    original_access_map = AffineMap.get_permutation([2, 0, 1], module.context)
+    for info in affine_node.node_info:
+        # check access map 
+        perm = info.permutation
+        inverted_perm = [perm.index(i) for i in range(len(perm))]
+        inverse_loop_map = AffineMap.get_permutation(inverted_perm, module.context)
+        # sanity check composing function with inverse is identity
+        assert compose_affine_maps(AffineMap.get_permutation(perm, module.context), inverse_loop_map) == AffineMap.get_identity(3, module.context)
+
+        # check access pattern
+        permuted_access_map = compose_affine_maps(inverse_loop_map, original_access_map)
+        assert permuted_access_map == info.stores_map[affine_node.stores[0]].accessMap
+        assert permuted_access_map == info.loads_map[affine_node.loads[0]].accessMap
+
+        # check II is 1 for all permutations
+        assert info.II == 1
+
+        # check first and last access times 
+        assert info.stores_map[affine_node.stores[0]].first_element_time == 0
+        assert info.loads_map[affine_node.loads[0]].first_element_time == 0
+
+        assert info.stores_map[affine_node.stores[0]].last_element_time == 499
+        assert info.loads_map[affine_node.loads[0]].last_element_time == 499
+
+def test_DSP():
+    def dsp_test() -> int32[10, 10]:
+        A: int32[10, 10]
+        for i in range(10):
+            for j in range(10):
+                A[i, j] = 0
+        B: float32
+        for i in range(10):
+            B += 1.8 # 0 DSP
+            B *= 2.0 # 3 DSP
+            B *= 5.1 # 3 DSP
+            B /= 1.1 # 14 DSP
+        return A
+    
+    s = allo.customize(dsp_test)
+    s = dataflow_optimization_pass(s, debugPoint="dataflow_canonicaliation")
+    module = s.module
+    dfg = DFG.from_module(module)
+    affine_nodes = [node for node in dfg.nodes.values() if node.type == DFGNodeType.AFFINE]
+    for i, affine_node in enumerate(affine_nodes):
+        assert affine_node.DSP_factor == [0, 20][i]
+    
+def test_II():
+    def loop_with_dependency(A: int32[10,10]) -> int32[10,10]:
+        for j in range(10):
+            for i in range(1, 10):
+                A[i, j] = A[i - 1, j] + 1
+        return A
+    
+    s = allo.customize(loop_with_dependency)
+    s = dataflow_optimization_pass(s, debugPoint="dataflow_canonicaliation")
+
+    module = s.module
+    dfg = DFG.from_module(module)
+    affine_node = [node for node in dfg.nodes.values() if node.type == DFGNodeType.AFFINE][0]   
+    for info in affine_node.node_info:
+         # original loop order has carried dependency on i 
+        if list(info.permutation) == [0, 1]:
+            assert info.II == 4
+
+        # permuted loop order has no carried dependency on innermost loop (j)
+        elif list(info.permutation) == [1, 0]:
+            assert info.II == 1
+
+def test_reduction():
+    def reduction(A: int32[10]) -> int32[1]:
+        sum: int32[1]
+        for i in range(10):
+            sum[0] += A[i]
+        return sum
+
+    s = allo.customize(reduction)
+    s = dataflow_optimization_pass(s, debugPoint="dataflow_canonicaliation")
+    module = s.module
+    print(s.module)
+    dfg = DFG.from_module(module)
+    affine_node = [node for node in dfg.nodes.values() if node.type == DFGNodeType.AFFINE][0]
+    assert affine_node.is_reduction == True
+
+    def not_reduction() -> int32[10]:
+        B: int32[10]
+        for i in range(10):
+            B[i] = 0 
+        return B
+    
+    s = allo.customize(not_reduction)
+    s = dataflow_optimization_pass(s, debugPoint="dataflow_canonicaliation")
+    module = s.module
+    
+    dfg = DFG.from_module(module)
+    affine_node = [node for node in dfg.nodes.values() if node.type == DFGNodeType.AFFINE][0]
+    assert affine_node.is_reduction == False
+
+    
+#     assert False
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/test_dfg.py
+++ b/tests/test_dfg.py
@@ -11,26 +11,44 @@ from allo.autoscheduler.passes import dataflow_optimization_pass
 from allo.autoscheduler.util import compose_affine_maps
 from allo._mlir.ir import WalkResult, AffineMap
 
+
 def check_edges(dfg: DFG):
     for src, dst, val in dfg.edges:
-        assert any(edge.id == dst for edge in dfg.out_edges[src]), f"Edge from {src} to {dst} not in out_edges"
-        assert any(edge.id == src for edge in dfg.in_edges[dst]), f"Edge from {src} to {dst} not in in_edges"
-        if dfg.get_node(src).type in (DFGNodeType.ALLOC, DFGNodeType.RET) or dfg.get_node(dst).type in (DFGNodeType.ALLOC, DFGNodeType.RET):
+        assert any(
+            edge.id == dst for edge in dfg.out_edges[src]
+        ), f"Edge from {src} to {dst} not in out_edges"
+        assert any(
+            edge.id == src for edge in dfg.in_edges[dst]
+        ), f"Edge from {src} to {dst} not in in_edges"
+        if dfg.get_node(src).type in (
+            DFGNodeType.ALLOC,
+            DFGNodeType.RET,
+        ) or dfg.get_node(dst).type in (DFGNodeType.ALLOC, DFGNodeType.RET):
             continue
-        assert any(store.operands[1] == val for store in dfg.get_node(src).stores), f"Value {val} not in stores of {dfg.get_node(src)}"
-        assert any(load.operands[0] == val for load in dfg.get_node(dst).loads), f"Value {val} not in loads of {dfg.get_node(dst)}"
+        assert any(
+            store.operands[1] == val for store in dfg.get_node(src).stores
+        ), f"Value {val} not in stores of {dfg.get_node(src)}"
+        assert any(
+            load.operands[0] == val for load in dfg.get_node(dst).loads
+        ), f"Value {val} not in loads of {dfg.get_node(dst)}"
 
-def check_node_info(dfg: DFG): 
+
+def check_node_info(dfg: DFG):
     for node_id, node in dfg.nodes.items():
         if node.type != DFGNodeType.AFFINE:
             continue
-            
+
         assert len(node.loop_info) > 0, f"Node {node_id} has no loop info"
-        
+
         num_loops = len(node.loop_info)
         expected_permutations = math.factorial(num_loops)
-        assert len(node.node_info) == expected_permutations, f"Node {node_id} has {len(node.node_info)} permutations, expected {expected_permutations}"
-        assert node.DSP_factor >= 0, f"Node {node_id} has negative DSP factor: {node.DSP_factor}"
+        assert (
+            len(node.node_info) == expected_permutations
+        ), f"Node {node_id} has {len(node.node_info)} permutations, expected {expected_permutations}"
+        assert (
+            node.DSP_factor >= 0
+        ), f"Node {node_id} has negative DSP factor: {node.DSP_factor}"
+
 
 def matrix_multiply(A: int32[8, 8], B: int32[8, 8]) -> int32[8, 8]:
     C: int32[8, 8] = 0
@@ -40,8 +58,11 @@ def matrix_multiply(A: int32[8, 8], B: int32[8, 8]) -> int32[8, 8]:
                 C[i, j] = C[i, j] + A[i, k] * B[k, j]
     return C
 
+
 def test_3mm():
-    def three_mm(A: int32[8, 8], B: int32[8, 8], C: int32[8, 8], D: int32[8, 8]) -> int32[8, 8]:
+    def three_mm(
+        A: int32[8, 8], B: int32[8, 8], C: int32[8, 8], D: int32[8, 8]
+    ) -> int32[8, 8]:
         E: int32[8, 8] = matrix_multiply(A, B)
         F: int32[8, 8] = matrix_multiply(C, D)
         return matrix_multiply(E, F)
@@ -51,9 +72,10 @@ def test_3mm():
     module = s.module
 
     dfg = DFG.from_module(module)
-    
+
     check_edges(dfg)
     check_node_info(dfg)
+
 
 def func() -> int32[10, 10, 10]:
     A: int32[10, 10, 10]
@@ -62,11 +84,14 @@ def func() -> int32[10, 10, 10]:
             A[k, i, j] += 0
     return A
 
+
 def test_loop_info():
     s = allo.customize(func)
     module = s.module
     dfg = DFG.from_module(module)
-    affine_nodes = [node for node in dfg.nodes.values() if node.type == DFGNodeType.AFFINE]
+    affine_nodes = [
+        node for node in dfg.nodes.values() if node.type == DFGNodeType.AFFINE
+    ]
     assert len(affine_nodes) == 1
     node = affine_nodes[0]
     assert len(node.loop_info) == 3
@@ -74,7 +99,8 @@ def test_loop_info():
     assert all(loop.upper_bound == 10 for loop in node.loop_info)
     assert all(loop.step == 1 and loop.trip_count == 10 for loop in node.loop_info[:2])
     assert node.loop_info[2].step == 2 and node.loop_info[2].trip_count == 5
-    
+
+
 def test_node_info():
     s = allo.customize(func)
     s = dataflow_optimization_pass(s, debugPoint="dataflow_canonicaliation")
@@ -83,17 +109,21 @@ def test_node_info():
     dfg = DFG.from_module(module)
     print(module)
 
-    affine_node: Node = [node for node in dfg.nodes.values() if node.type == DFGNodeType.AFFINE][0]
+    affine_node: Node = [
+        node for node in dfg.nodes.values() if node.type == DFGNodeType.AFFINE
+    ][0]
 
     assert len(affine_node.node_info) == math.factorial(len(affine_node.loop_info))
     original_access_map = AffineMap.get_permutation([2, 0, 1], module.context)
     for info in affine_node.node_info:
-        # check access map 
+        # check access map
         perm = info.permutation
         inverted_perm = [perm.index(i) for i in range(len(perm))]
         inverse_loop_map = AffineMap.get_permutation(inverted_perm, module.context)
         # sanity check composing function with inverse is identity
-        assert compose_affine_maps(AffineMap.get_permutation(perm, module.context), inverse_loop_map) == AffineMap.get_identity(3, module.context)
+        assert compose_affine_maps(
+            AffineMap.get_permutation(perm, module.context), inverse_loop_map
+        ) == AffineMap.get_identity(3, module.context)
 
         # check access pattern
         permuted_access_map = compose_affine_maps(inverse_loop_map, original_access_map)
@@ -103,12 +133,13 @@ def test_node_info():
         # check II is 1 for all permutations
         assert info.II == 1
 
-        # check first and last access times 
+        # check first and last access times
         assert info.stores_map[affine_node.stores[0]].first_element_time == 0
         assert info.loads_map[affine_node.loads[0]].first_element_time == 0
 
         assert info.stores_map[affine_node.stores[0]].last_element_time == 499
         assert info.loads_map[affine_node.loads[0]].last_element_time == 499
+
 
 def test_DSP():
     def dsp_test() -> int32[10, 10]:
@@ -118,41 +149,47 @@ def test_DSP():
                 A[i, j] = 0
         B: float32
         for i in range(10):
-            B += 1.8 # 0 DSP
-            B *= 2.0 # 3 DSP
-            B *= 5.1 # 3 DSP
-            B /= 1.1 # 14 DSP
+            B += 1.8  # 0 DSP
+            B *= 2.0  # 3 DSP
+            B *= 5.1  # 3 DSP
+            B /= 1.1  # 14 DSP
         return A
-    
+
     s = allo.customize(dsp_test)
     s = dataflow_optimization_pass(s, debugPoint="dataflow_canonicaliation")
     module = s.module
     dfg = DFG.from_module(module)
-    affine_nodes = [node for node in dfg.nodes.values() if node.type == DFGNodeType.AFFINE]
+    affine_nodes = [
+        node for node in dfg.nodes.values() if node.type == DFGNodeType.AFFINE
+    ]
     for i, affine_node in enumerate(affine_nodes):
         assert affine_node.DSP_factor == [0, 20][i]
-    
+
+
 def test_II():
-    def loop_with_dependency(A: int32[10,10]) -> int32[10,10]:
+    def loop_with_dependency(A: int32[10, 10]) -> int32[10, 10]:
         for j in range(10):
             for i in range(1, 10):
                 A[i, j] = A[i - 1, j] + 1
         return A
-    
+
     s = allo.customize(loop_with_dependency)
     s = dataflow_optimization_pass(s, debugPoint="dataflow_canonicaliation")
 
     module = s.module
     dfg = DFG.from_module(module)
-    affine_node = [node for node in dfg.nodes.values() if node.type == DFGNodeType.AFFINE][0]   
+    affine_node = [
+        node for node in dfg.nodes.values() if node.type == DFGNodeType.AFFINE
+    ][0]
     for info in affine_node.node_info:
-         # original loop order has carried dependency on i 
+        # original loop order has carried dependency on i
         if list(info.permutation) == [0, 1]:
             assert info.II == 4
 
         # permuted loop order has no carried dependency on innermost loop (j)
         elif list(info.permutation) == [1, 0]:
             assert info.II == 1
+
 
 def test_reduction():
     def reduction(A: int32[10]) -> int32[1]:
@@ -166,24 +203,28 @@ def test_reduction():
     module = s.module
     print(s.module)
     dfg = DFG.from_module(module)
-    affine_node = [node for node in dfg.nodes.values() if node.type == DFGNodeType.AFFINE][0]
+    affine_node = [
+        node for node in dfg.nodes.values() if node.type == DFGNodeType.AFFINE
+    ][0]
     assert affine_node.is_reduction == True
 
     def not_reduction() -> int32[10]:
         B: int32[10]
         for i in range(10):
-            B[i] = 0 
+            B[i] = 0
         return B
-    
+
     s = allo.customize(not_reduction)
     s = dataflow_optimization_pass(s, debugPoint="dataflow_canonicaliation")
     module = s.module
-    
+
     dfg = DFG.from_module(module)
-    affine_node = [node for node in dfg.nodes.values() if node.type == DFGNodeType.AFFINE][0]
+    affine_node = [
+        node for node in dfg.nodes.values() if node.type == DFGNodeType.AFFINE
+    ][0]
     assert affine_node.is_reduction == False
 
-    
+
 #     assert False
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
Parses a MLIR module into a dataflow graph for autoscheduler analysis (https://github.com/cornell-zhang/allo/discussions/297)

### Proposed Solutions ###
MLIR module can now be parsed into a dataflow graph. Each node in the graph represents an affine kernel and is annotated with information regarding the access pattern, achievable II, relative first/last read/write times for each possible loop permutation of the affine kernel. An approximate DSP factor for the affine kernel is also computed. This information will be used to build the performance model described in stream-hls. 

DFG implementation also includes printing to dotgraph format for easy debugging. 
### Examples ###
The 3-Matmul example 
```python
def three_mm(A: int32[8, 8], B: int32[8, 8], C: int32[8, 8], D: int32[8, 8]) -> int32[8, 8]:
        E: int32[8, 8] = matrix_multiply(A, B)
        F: int32[8, 8] = matrix_multiply(C, D)
        return matrix_multiply(E, F)
```

will produce the dataflow graph with this structure 

<img width="596" alt="image" src="https://github.com/user-attachments/assets/3b5fa47d-7a4e-4a45-9fba-40560bbb459c" />


## Checklist ##

- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [x] Code is well-documented
