### PR TITLE
Fix allo.dsl typing rules

### DIFF
--- a/allo/ir/builder.py
+++ b/allo/ir/builder.py
@@ -2022,13 +2022,13 @@ class ASTTransformer(ASTBuilder):
             arg_types = []
             if isinstance(new_args[0].result, OpResultList):
                 for arg in new_args:
-                    if hasattr(arg, "result"):
+                    if hasattr(arg, "result") and isinstance(arg.result, OpResultList):
                         for result in arg.result:
                             if hasattr(result, "type"):
                                 arg_types.append(result.type)
             else:
                 for arg in new_args:
-                    if hasattr(arg, "result"):
+                    if hasattr(arg, "result") and hasattr(arg.result, "type"):
                         arg_types.append(arg.result.type)
             if all(
                 isinstance(arg_type, (F32Type, IntegerType)) for arg_type in arg_types

--- a/allo/ir/builder.py
+++ b/allo/ir/builder.py
@@ -1942,6 +1942,7 @@ class ASTTransformer(ASTBuilder):
                 return opcls(lhs.result, rhs.result, ip=ctx.get_ip())
             raise RuntimeError(f"Cannot resolve function `{node.func.id}`")
 
+        # pylint: disable=too-many-nested-blocks
         if (
             obj.__module__.startswith("allo")
             and not obj.__module__.startswith("allo.library")
@@ -2021,11 +2022,14 @@ class ASTTransformer(ASTBuilder):
             arg_types = []
             if isinstance(new_args[0].result, OpResultList):
                 for arg in new_args:
-                    for result in arg.result:
-                        arg_types.append(result.type)
+                    if hasattr(arg, "result"):
+                        for result in arg.result:
+                            if hasattr(result, "type"):
+                                arg_types.append(result.type)
             else:
                 for arg in new_args:
-                    arg_types.append(arg.result.type)
+                    if hasattr(arg, "result"):
+                        arg_types.append(arg.result.type)
             if all(
                 isinstance(arg_type, (F32Type, IntegerType)) for arg_type in arg_types
             ):

--- a/allo/ir/builder.py
+++ b/allo/ir/builder.py
@@ -2026,7 +2026,9 @@ class ASTTransformer(ASTBuilder):
             else:
                 for arg in new_args:
                     arg_types.append(arg.result.type)
-            if all(isinstance(arg_type, (F32Type, IntegerType)) for arg_type in arg_types):
+            if all(
+                isinstance(arg_type, (F32Type, IntegerType)) for arg_type in arg_types
+            ):
                 opcls = {
                     "exp": math_d.ExpOp,
                     "log": math_d.LogOp,
@@ -2040,7 +2042,10 @@ class ASTTransformer(ASTBuilder):
                     "abs": math_d.AbsIOp,
                 }.get(fn_name)
                 return opcls(*[x.result for x in new_args], ip=ctx.get_ip())
-            if any(isinstance(arg_type, (MemRefType, RankedTensorType)) for arg_type in arg_types) and fn_name in {
+            if any(
+                isinstance(arg_type, (MemRefType, RankedTensorType))
+                for arg_type in arg_types
+            ) and fn_name in {
                 "matmul",
                 "bmm",
                 "softmax",
@@ -2098,7 +2103,7 @@ class ASTTransformer(ASTBuilder):
                     ip=ctx.get_ip(),
                 )
                 return call_op
-            raise RuntimeError(f"Unsupported function {fn_name} with type {arg_type}")
+            raise RuntimeError(f"Unsupported function {fn_name} with type {arg_types}")
 
         # User-defined subfunction
         func = ctx.global_vars[obj_name]

--- a/allo/ir/infer.py
+++ b/allo/ir/infer.py
@@ -858,11 +858,12 @@ class TypeInferer(ASTVisitor):
                     node.shape = None
                     node.dtype = None
                 return node
-            if len(new_args[0].shape) == 0:
+            if all(len(arg.shape) == 0 for arg in new_args):
                 # element-wise operation
                 node.shape = tuple()
                 node.dtype = new_args[0].dtype
                 return node
+            # return node
             return TypeInferer.visit_library_op(
                 ctx, node=node, op_name=fn_name, new_args=new_args
             )

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -777,80 +777,23 @@ def test_line_trace():
     assert 'loc("' in mlir_string
 
 
-def test_dsl_broadcast_add():
+def test_dsl_broadcast_binary_ops():
     def kernel1(A: int32[10]) -> int32[10]:
-        return allo.add(A, 1)
+        return allo.div(allo.mul(allo.sub(allo.add(A, 3), 1), 2), 2)
 
     def kernel2(A: int32[10]) -> int32[10]:
-        return allo.add(1, A)
+        return allo.sub(50, allo.mul(2, allo.add(3, allo.div(10, A))))
 
     s1 = allo.customize(kernel1)
     s2 = allo.customize(kernel2)
     mod1 = s1.build()
     mod2 = s2.build()
-    np_A = np.random.randint(0, 10, size=(10,)).astype(np.int32)
+    np_A = np.random.randint(1, 10, size=(10,)).astype(np.int32)
     np_B_1 = mod1(np_A)
     np_B_2 = mod2(np_A)
-    np.testing.assert_allclose(np_B_1, np_A + 1)
-    np.testing.assert_allclose(np_B_2, np_A + 1)
-
-
-def test_dsl_broadcast_sub():
-    def kernel1(A: int32[10]) -> int32[10]:
-        return allo.sub(A, 1)
-
-    def kernel2(A: int32[10]) -> int32[10]:
-        return allo.sub(1, A)
-
-    s1 = allo.customize(kernel1)
-    s2 = allo.customize(kernel2)
-    mod1 = s1.build()
-    mod2 = s2.build()
-    np_A = np.random.randint(0, 10, size=(10,)).astype(np.int32)
-    np_B_1 = mod1(np_A)
-    np_B_2 = mod2(np_A)
-    np.testing.assert_allclose(np_B_1, np_A - 1)
-    np.testing.assert_allclose(np_B_2, 1 - np_A)
-
-
-def test_dsl_broadcast_mul():
-    def kernel1(A: int32[10]) -> int32[10]:
-        return allo.mul(A, 2)
-
-    def kernel2(A: int32[10]) -> int32[10]:
-        return allo.mul(2, A)
-
-    s1 = allo.customize(kernel1)
-    s2 = allo.customize(kernel2)
-    mod1 = s1.build()
-    mod2 = s2.build()
-    np_A = np.random.randint(0, 10, size=(10,)).astype(np.int32)
-    np_B_1 = mod1(np_A)
-    np_B_2 = mod2(np_A)
-    np.testing.assert_allclose(np_B_1, np_A * 2)
-    np.testing.assert_allclose(np_B_2, np_A * 2)
-
-
-def test_dsl_broadcast_div():
-    def kernel1(A: int32[10]) -> int32[10]:
-        return allo.div(A, 2)
-
-    def kernel2(A: int32[10]) -> int32[10]:
-        return allo.div(2, A)
-
-    s1 = allo.customize(kernel1)
-    s2 = allo.customize(kernel2)
-    print(s1.module)
-    mod1 = s1.build()
-    mod2 = s2.build()
-    np_A_1 = np.random.randint(0, 10, size=(10,)).astype(np.int32)
-    np_A_2 = np.random.randint(1, 10, size=(10,)).astype(np.int32)
-    np_B_1 = mod1(np_A_1)
-    np_B_2 = mod2(np_A_2)
-    np.testing.assert_allclose(np_B_1, np_A_1 // 2)
-    np.testing.assert_allclose(np_B_2, 2 // np_A_2)
+    np.testing.assert_allclose(np_B_1, ((np_A + 3) - 1) * 2 // 2)
+    np.testing.assert_allclose(np_B_2, 50 - 2 * (3 + 10 // np_A))
 
 
 if __name__ == "__main__":
-    # pytest.main([__file__])
-    test_dsl_broadcast_div()
+    pytest.main([__file__])

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -777,5 +777,80 @@ def test_line_trace():
     assert 'loc("' in mlir_string
 
 
+def test_dsl_broadcast_add():
+    def kernel1(A: int32[10]) -> int32[10]:
+        return allo.add(A, 1)
+
+    def kernel2(A: int32[10]) -> int32[10]:
+        return allo.add(1, A)
+
+    s1 = allo.customize(kernel1)
+    s2 = allo.customize(kernel2)
+    mod1 = s1.build()
+    mod2 = s2.build()
+    np_A = np.random.randint(0, 10, size=(10,)).astype(np.int32)
+    np_B_1 = mod1(np_A)
+    np_B_2 = mod2(np_A)
+    np.testing.assert_allclose(np_B_1, np_A + 1)
+    np.testing.assert_allclose(np_B_2, np_A + 1)
+
+
+def test_dsl_broadcast_sub():
+    def kernel1(A: int32[10]) -> int32[10]:
+        return allo.sub(A, 1)
+
+    def kernel2(A: int32[10]) -> int32[10]:
+        return allo.sub(1, A)
+
+    s1 = allo.customize(kernel1)
+    s2 = allo.customize(kernel2)
+    mod1 = s1.build()
+    mod2 = s2.build()
+    np_A = np.random.randint(0, 10, size=(10,)).astype(np.int32)
+    np_B_1 = mod1(np_A)
+    np_B_2 = mod2(np_A)
+    np.testing.assert_allclose(np_B_1, np_A - 1)
+    np.testing.assert_allclose(np_B_2, 1 - np_A)
+
+
+def test_dsl_broadcast_mul():
+    def kernel1(A: int32[10]) -> int32[10]:
+        return allo.mul(A, 2)
+
+    def kernel2(A: int32[10]) -> int32[10]:
+        return allo.mul(2, A)
+
+    s1 = allo.customize(kernel1)
+    s2 = allo.customize(kernel2)
+    mod1 = s1.build()
+    mod2 = s2.build()
+    np_A = np.random.randint(0, 10, size=(10,)).astype(np.int32)
+    np_B_1 = mod1(np_A)
+    np_B_2 = mod2(np_A)
+    np.testing.assert_allclose(np_B_1, np_A * 2)
+    np.testing.assert_allclose(np_B_2, np_A * 2)
+
+
+def test_dsl_broadcast_div():
+    def kernel1(A: int32[10]) -> int32[10]:
+        return allo.div(A, 2)
+
+    def kernel2(A: int32[10]) -> int32[10]:
+        return allo.div(2, A)
+
+    s1 = allo.customize(kernel1)
+    s2 = allo.customize(kernel2)
+    print(s1.module)
+    mod1 = s1.build()
+    mod2 = s2.build()
+    np_A_1 = np.random.randint(0, 10, size=(10,)).astype(np.int32)
+    np_A_2 = np.random.randint(1, 10, size=(10,)).astype(np.int32)
+    np_B_1 = mod1(np_A_1)
+    np_B_2 = mod2(np_A_2)
+    np.testing.assert_allclose(np_B_1, np_A_1 // 2)
+    np.testing.assert_allclose(np_B_2, 2 // np_A_2)
+
+
 if __name__ == "__main__":
-    pytest.main([__file__])
+    # pytest.main([__file__])
+    test_dsl_broadcast_div()


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
Fixes #322 

This PR fixes type inference rules for functions in `allo.dsl`, which can be handled as general binary ops with shape broadcasting.


## Checklist ##

Please make sure to review and check all of these items:
- [ ] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [ ] All changes have test coverage (It would be good to provide ~2 different test cases to test the robustness of your code)
- [ ] Pass the [formatting check](https://cornell-zhang.github.io/allo/developer/index.html#id1) locally
- [ ] Code is well-documented
