### PR TITLE
[Simulator][Dataflow] Support simulating AIE kernels

### DIFF
--- a/allo/backend/simulator.py
+++ b/allo/backend/simulator.py
@@ -515,7 +515,16 @@ class LLVMOMPModule(LLVMModule):
             func.attributes["top"] = UnitAttr.get()
 
             # Start lowering
-            # Lower StructType first
+            # Lower linalg for AIE
+            pm = PassManager.parse(
+                "builtin.module("
+                "one-shot-bufferize,"
+                "expand-strided-metadata,"
+                "func.func(convert-linalg-to-affine-loops)"
+                ")"
+            )
+            pm.run(self.module.operation)
+            # Lower StructType
             allo_d.lower_composite_type(self.module)
             # Reference: https://discourse.llvm.org/t/help-lowering-affine-loop-to-openmp/72441/9
             pm = PassManager.parse(

--- a/tests/dataflow/aie/test_gemm.py
+++ b/tests/dataflow/aie/test_gemm.py
@@ -1,6 +1,7 @@
 # Copyright Allo authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 import allo.dataflow as df
 from allo.ir.types import int16, int32
 import numpy as np
@@ -22,13 +23,21 @@ def _test_gemm_1D():
                 A[pi * Mt : (pi + 1) * Mt, :], B
             )
 
-    mod = df.build(top, target="aie")
     A = np.random.randint(0, 64, (M, K)).astype(np.int32)
     B = np.random.randint(0, 64, (K, N)).astype(np.int32)
+    if "MLIR_AIE_INSTALL_DIR" in os.environ:
+        mod = df.build(top, target="aie")
+        C = np.zeros((M, N)).astype(np.int32)
+        mod(A, B, C)
+        np.testing.assert_allclose(C, A @ B, atol=1e-5)
+        print("PASSED!")
+    else:
+        print("MLIR_AIE_INSTALL_DIR unset. Skipping AIE backend test.")
+    sim_mod = df.build(top, target="simulator")
     C = np.zeros((M, N)).astype(np.int32)
-    mod(A, B, C)
+    sim_mod(A, B, C)
     np.testing.assert_allclose(C, A @ B, atol=1e-5)
-    print("PASSED!")
+    print("Dataflow Simulator Passed!")
 
 
 def _test_gemm_2D():
@@ -46,13 +55,23 @@ def _test_gemm_2D():
                 A[p0 * Mt : (p0 + 1) * Mt, :], B[:, p1 * Nt : (p1 + 1) * Nt]
             )
 
-    mod = df.build(top, target="aie")
     A = np.random.randint(0, 64, (M, K)).astype(np.int32)
     B = np.random.randint(0, 64, (K, N)).astype(np.int32)
+
+    if "MLIR_AIE_INSTALL_DIR" in os.environ:
+        mod = df.build(top, target="aie")
+        C = np.zeros((M, N)).astype(np.int32)
+        mod(A, B, C)
+        np.testing.assert_allclose(C, A @ B, atol=1e-5)
+        print("PASSED!")
+    else:
+        print("MLIR_AIE_INSTALL_DIR unset. Skipping AIE backend test.")
+
+    sim_mod = df.build(top, target="simulator")
     C = np.zeros((M, N)).astype(np.int32)
-    mod(A, B, C)
+    sim_mod(A, B, C)
     np.testing.assert_allclose(C, A @ B, atol=1e-5)
-    print("PASSED!")
+    print("Dataflow Simulator Passed!")
 
 
 if __name__ == "__main__":

--- a/tests/dataflow/aie/test_multi_core.py
+++ b/tests/dataflow/aie/test_multi_core.py
@@ -1,6 +1,7 @@
 # Copyright Allo authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 import allo
 from allo.ir.types import int32
 import allo.dataflow as df
@@ -24,12 +25,22 @@ def _test_vector_scalar_add():
             pi = df.get_pid()
             B[pi * Mt : (pi + 1) * Mt] = allo.add(A[pi * Mt : (pi + 1) * Mt], 1)
 
-    mod = df.build(top, target="aie")
     A = np.random.randint(0, 100, M).astype(np.int32)
+
+    if "MLIR_AIE_INSTALL_DIR" in os.environ:
+        mod = df.build(top, target="aie")
+        B = np.zeros(M).astype(np.int32)
+        mod(A, B)
+        np.testing.assert_allclose(B, A + 1)
+        print("PASSED!")
+    else:
+        print("MLIR_AIE_INSTALL_DIR unset. Skipping AIE backend test.")
+
+    sim_mod = df.build(top, target="simulator")
     B = np.zeros(M).astype(np.int32)
-    mod(A, B)
+    sim_mod(A, B)
     np.testing.assert_allclose(B, A + 1)
-    print("PASSED!")
+    print("Dataflow Simulator Passed!")
 
 
 def _test_vector_vector_add():
@@ -51,13 +62,21 @@ def _test_vector_vector_add():
                 A[pi * Mt : (pi + 1) * Mt], B[pi * Mt : (pi + 1) * Mt]
             )
 
-    mod = df.build(top, target="aie")
     A = np.random.randint(0, 100, M).astype(np.int32)
     B = np.random.randint(0, 100, M).astype(np.int32)
+    if "MLIR_AIE_INSTALL_DIR" in os.environ:
+        mod = df.build(top, target="aie")
+        C = np.zeros(M).astype(np.int32)
+        mod(A, B, C)
+        np.testing.assert_allclose(C, A + B)
+        print("PASSED!")
+    else:
+        print("MLIR_AIE_INSTALL_DIR unset. Skipping AIE backend test.")
+    sim_mod = df.build(top, target="simulator")
     C = np.zeros(M).astype(np.int32)
-    mod(A, B, C)
+    sim_mod(A, B, C)
     np.testing.assert_allclose(C, A + B)
-    print("PASSED!")
+    print("Dataflow Simulator Passed!")
 
 
 if __name__ == "__main__":

--- a/tests/dataflow/aie/test_producer_consumer.py
+++ b/tests/dataflow/aie/test_producer_consumer.py
@@ -1,6 +1,7 @@
 # Copyright Allo authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 import allo
 from allo.ir.types import int32
 import allo.dataflow as df
@@ -40,10 +41,13 @@ def test_producer_consumer():
     np.testing.assert_allclose(B, A + 1)
     print("Dataflow Simulator Passed!")
 
-    mod = df.build(top, target="aie")
-    mod(A, B)
-    np.testing.assert_allclose(A + 1, B, atol=1e-5)
-    print("Passed!")
+    if "MLIR_AIE_INSTALL_DIR" in os.environ:
+        mod = df.build(top, target="aie")
+        mod(A, B)
+        np.testing.assert_allclose(A + 1, B, atol=1e-5)
+        print("Passed!")
+    else:
+        print("MLIR_AIE_INSTALL_DIR unset. Skipping AIE backend test.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR adds linalg dialect lowering passes to the pipeline of dataflow simulator, so that AIE kernels can be simulated.


### Examples ###
Tests of dataflow simulator are added to all testcases under `tests/dataflow/aie/`.


## Checklist ##

Please make sure to review and check all of these items:
- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] All changes have test coverage (It would be good to provide ~2 different test cases to test the robustness of your code)
- [x] Pass the [formatting check](https://cornell-zhang.github.io/allo/developer/index.html#id1) locally
- [x] Code is well-documented
