### PR TITLE
[Backend] Fix hash constants and softmax

### DIFF
--- a/allo/ir/builder.py
+++ b/allo/ir/builder.py
@@ -868,7 +868,7 @@ class ASTTransformer(ASTBuilder):
             if hasattr(node, "target"):
                 name = node.target.id
             else:
-                name = f"const_{hash(str(node) + str(np_values))}"
+                name = f"const_{abs(hash(str(node) + str(np_values)))}"
             sym_name = StringAttr.get(name)
             sym_visibility = StringAttr.get("private")
             memref_type = MemRefType.get(shape, dtype.build())
@@ -2095,14 +2095,14 @@ class ASTTransformer(ASTBuilder):
                 input_types = [arg.type for arg in arg_results]
                 output_types = [input_types[0]]
                 func_op = func_d.FuncOp(
-                    name=f"{fn_name}_{hash(node)}",
+                    name=f"{fn_name}_{abs(hash(node))}",
                     type=FunctionType.get(input_types, output_types),
                     ip=InsertionPoint(ctx.top_func),
                 )
                 func_op.attributes["sym_visibility"] = StringAttr.get("private")
                 call_op = func_d.CallOp(
                     [arg_results[0].type],
-                    FlatSymbolRefAttr.get(f"{fn_name}_{hash(node)}"),
+                    FlatSymbolRefAttr.get(f"{fn_name}_{abs(hash(node))}"),
                     arg_results,
                     ip=ctx.get_ip(),
                 )

--- a/docs/source/setup/index.rst
+++ b/docs/source/setup/index.rst
@@ -130,3 +130,14 @@ Now, you can run the following command to test if the installation is successful
   $ python3 -c "import allo as allo; import allo.ir as air"
 
 If you see no error messages, then the installation is successful. Otherwise, please contact us for help.
+
+
+Troubleshooting
+---------------
+
+If you encounter the following issue when building Allo, it is mostly because you source the Vitis environment at the same time, which may cause some library conflicts. Please disable it and try again.
+
+.. code-block:: console
+
+  running build_ext
+    cmake: error while loading shared libraries: libidn.so.11: cannot open shared object file: No such file or directory

--- a/mlir/lib/Translation/EmitVivadoHLS.cpp
+++ b/mlir/lib/Translation/EmitVivadoHLS.cpp
@@ -1822,14 +1822,18 @@ void ModuleEmitter::emitGeneralCast(UnrealizedConversionCastOp op) {
 
 void ModuleEmitter::emitCall(func::CallOp op) {
   // Handle returned value by the callee.
-  for (auto result : op.getResults()) {
-    if (!isDeclared(result)) {
-      indent();
-      if (result.getType().isa<ShapedType>())
-        emitArrayDecl(result);
-      else
-        emitValue(result);
-      os << ";\n";
+  if (op.getCallee().str().substr(0, 8) != "softmax_") {
+    // softmax result is also its last argument
+    // TODO: better handling mechanism
+    for (auto result : op.getResults()) {
+      if (!isDeclared(result)) {
+        indent();
+        if (result.getType().isa<ShapedType>())
+          emitArrayDecl(result);
+        else
+          emitValue(result);
+        os << ";\n";
+      }
     }
   }
 
@@ -1847,14 +1851,18 @@ void ModuleEmitter::emitCall(func::CallOp op) {
   }
 
   // Handle output arguments.
-  for (auto result : op.getResults()) {
-    // The address should be passed in for scalar result arguments.
-    if (result.getType().isa<ShapedType>())
-      os << ", ";
-    else
-      os << ", &";
+  if (op.getCallee().str().substr(0, 8) != "softmax_") {
+    // softmax result is also its last argument
+    // TODO: better handling mechanism
+    for (auto result : op.getResults()) {
+      // The address should be passed in for scalar result arguments.
+      if (result.getType().isa<ShapedType>())
+        os << ", ";
+      else
+        os << ", &";
 
-    emitValue(result);
+      emitValue(result);
+    }
   }
 
   os << ");";


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR fixes the hash values when creating constant values. Previously it may have variable names like `const_-34312`, which is because the hash values can be negative numbers. This PR adds `abs` to it.

Additionally, softmax function call in HLS is also fixed. As its last argument is also the return, no additional variable needs to be created.

### Problems ###
```
===>The following messages were generated while  performing high-level synthesis for kernel: forward Log file: /home/sumin/allo/examples/torch/gpt2/_x.hw.xilinx_u280_gen3x16_xdma_1_202211_1/forward/forward/vitis_hls.log :

ERROR: [v++ 207-2492] default initialization of an object of const type 'const int64_t' (aka 'const long') (/home/sumin/allo/examples/torch/gpt2/kernel.cpp:156:15)

ERROR: [v++ 207-1263] expected ';' after top level declarator (/home/sumin/allo/examples/torch/gpt2/kernel.cpp:156:21)

ERROR: [v++ 207-3430] redefinition of 'const_' (/home/sumin/allo/examples/torch/gpt2/kernel.cpp:157:15)

ERROR: [v++ 207-1263] expected ';' after top level declarator (/home/sumin/allo/examples/torch/gpt2/kernel.cpp:157:21)

ERROR: [v++ 207-3430] redefinition of 'const_' (/home/sumin/allo/examples/torch/gpt2/kernel.cpp:160:15)

ERROR: [v++ 207-1263] expected ';' after top level declarator (/home/sumin/allo/examples/torch/gpt2/kernel.cpp:160:21)

ERROR: [v++ 207-3339] no matching function for call to 'softmax_3930711769526157945' (/home/sumin/allo/examples/torch/gpt2/kernel.cpp:868:3)
```

## Checklist ##

Please make sure to review and check all of these items:
- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] All changes have test coverage (It would be good to provide ~2 different test cases to test the robustness of your code)
- [x] Pass the [formatting check](https://cornell-zhang.github.io/allo/developer/index.html#id1) locally
- [x] Code is well-documented
