### PR TITLE
[Autoscheduler] Implement MINLP for Graph Parallelism Model

### DIFF
--- a/allo/autoscheduler/dfg.py
+++ b/allo/autoscheduler/dfg.py
@@ -535,7 +535,7 @@ class DFG:
 
             f.write("}\n")
 
-    def createGraphParallelismPerformanceModel(self):
+    def createGraphParallelismPerformanceModel(self, debug_output=None):
         model = gp.Model("graph_parallelism_performance_model")
 
         # Get topological order and verify no cycles
@@ -567,7 +567,8 @@ class DFG:
         obj = lw_vars[sink_node_id]
         model.setObjective(obj, GRB.MINIMIZE)
         model.optimize()
-
+        if debug_output:
+            model.write(f"{debug_output}.lp")
         # Return optimal permutation assignments
         return [k for k, b_var in b_vars.items() if b_var.x > 0.5]
 

--- a/allo/autoscheduler/dfg.py
+++ b/allo/autoscheduler/dfg.py
@@ -4,12 +4,14 @@ from collections import defaultdict
 import enum
 import sys
 import itertools
+import gurobipy as gp
+from gurobipy import GRB
 from allo._mlir.dialects import (
     func as func_d,
     affine as affine_d,
     memref as memref_d,
 )
-from allo._mlir.ir import WalkResult, Operation, AffineMap
+from allo._mlir.ir import WalkResult, Operation, AffineMap, Block
 from allo.ir.types import MemRefType
 from .util import (
     LoopInfo,
@@ -365,15 +367,15 @@ class DFG:
                             dst_op=load_op,
                         )
 
-            for alloc_node_id, alloc_op in memref_allocs[memref]:
-                for store_node_id, store_op in stores_node_list:
-                    self.add_edge(
-                        alloc_node_id,
-                        store_node_id,
-                        value=memref,
-                        src_op=store_op,
-                        dst_op=alloc_op,
-                    )
+            # for alloc_node_id, alloc_op in memref_allocs[memref]:
+            #     for store_node_id, store_op in stores_node_list:
+            #         self.add_edge(
+            #             alloc_node_id,
+            #             store_node_id,
+            #             value=memref,
+            #             src_op=store_op,
+            #             dst_op=alloc_op,
+            #         )
 
         # Third pass: populate node information for each loop permutation
         for node in self.nodes.values():
@@ -533,9 +535,331 @@ class DFG:
 
             f.write("}\n")
 
-    # Optimization methods
     def createGraphParallelismPerformanceModel(self):
-        pass
+        model = gp.Model("graph_parallelism_performance_model")
+
+        # Get topological order and verify no cycles
+        topo_order = self.topological_sort()
+        if not topo_order:
+            print("Error: Cycle detected in graph")
+            return False
+
+        # Find sink node (return node)
+        sink_node_id = self._find_sink_node()
+
+        # Create variables for the optimization model
+        b_vars = self._create_permutation_variables(model)
+        st_vars, fw_vars, lw_vars = self._create_timing_variables(model)
+
+        # Add constraints
+        self._add_permutation_constraints(model, b_vars)
+        self._add_start_time_constraints(
+            model, b_vars, st_vars, fw_vars, lw_vars, topo_order
+        )
+        self._add_first_write_time_constraints(
+            model, b_vars, st_vars, fw_vars, topo_order
+        )
+        self._add_last_write_time_constraints(
+            model, b_vars, st_vars, lw_vars, topo_order
+        )
+
+        # Set objective function and optimize
+        obj = lw_vars[sink_node_id]
+        model.setObjective(obj, GRB.MINIMIZE)
+        model.optimize()
+
+        # Return optimal permutation assignments
+        return [k for k, b_var in b_vars.items() if b_var.x > 0.5]
+
+    def _find_sink_node(self):
+        """Find the sink node (return node) in the graph."""
+        sink_nodes = [
+            node_id
+            for node_id in self.nodes
+            if self.get_node(node_id).type == DFGNodeType.RET
+        ]
+        print(sink_nodes)
+        assert len(sink_nodes) == 1, "Expected a single sink node"
+        return sink_nodes[0]
+
+    def _create_permutation_variables(self, model):
+        """Create binary variables for node permutations."""
+        b_vars = {}
+        for node_id, node in self.nodes.items():
+            if node.type == DFGNodeType.AFFINE:
+                for perm_idx, node_info in enumerate(node.node_info):
+                    b_vars[(node_id, perm_idx)] = model.addVar(
+                        vtype=GRB.BINARY, name=f"b{node_id}_{perm_idx}"
+                    )
+        return b_vars
+
+    def _create_timing_variables(self, model):
+        """Create variables for start time, first write time, and last write time."""
+        st_vars = {}  # Start time variables
+        fw_vars = {}  # First write time variables
+        lw_vars = {}  # Last write time variables
+
+        for node_id in self.nodes:
+            st_vars[node_id] = model.addVar(
+                vtype=GRB.INTEGER, lb=0, name=f"st{node_id}"
+            )
+            fw_vars[node_id] = model.addVar(
+                vtype=GRB.INTEGER, lb=0, name=f"fw{node_id}"
+            )
+            lw_vars[node_id] = model.addVar(
+                vtype=GRB.INTEGER, lb=0, name=f"lw{node_id}"
+            )
+
+        return st_vars, fw_vars, lw_vars
+
+    def _add_permutation_constraints(self, model, b_vars):
+        """Add constraints to ensure exactly one permutation is chosen per node."""
+        for node_id, node in self.nodes.items():
+            if node.type == DFGNodeType.AFFINE and node.node_info:
+                perm_vars = [
+                    b_vars[(node_id, perm_idx)]
+                    for perm_idx in range(len(node.node_info))
+                ]
+                model.addConstr(
+                    gp.quicksum(perm_vars) == 1,
+                    name=f"permutation_constraint_{node_id}",
+                )
+
+    def _add_start_time_constraints(
+        self, model, b_vars, st_vars, fw_vars, lw_vars, topo_order
+    ):
+        """st(n) = max_{n' \in ins(n)} [\sum_{b \in B_n} \sum_{b' \in B_n'} Arrives(n, n') * b * b']"""
+        for node_id in topo_order:
+            in_edges = self.in_edges.get(node_id, [])
+            # Handle root nodes (no incoming edges)
+            if not in_edges:
+                model.addConstr(st_vars[node_id] == 0, name=f"st_root_{node_id}")
+                model.addConstr(fw_vars[node_id] == 0, name=f"fw_root_{node_id}")
+                model.addConstr(lw_vars[node_id] == 0, name=f"lw_root_{node_id}")
+                continue
+
+            arrives_terms = self._compute_arrival_terms(
+                model, node_id, in_edges, b_vars, fw_vars, lw_vars
+            )
+
+            if arrives_terms:
+                model.addConstr(
+                    st_vars[node_id] == gp.max_(arrives_terms),
+                    name=f"st_constr_{node_id}",
+                )
+
+    def _compute_arrival_terms(
+        self, model, node_id, in_edges, b_vars, fw_vars, lw_vars
+    ):
+        """Arrives(n, n') = fw(n') if dst_access == src_access else lw(n')"""
+        arrives_terms = []
+
+        for edge in in_edges:
+            src_id = edge.id
+            dst_node = self.get_node(node_id)
+            src_node = self.get_node(src_id)
+
+            if (
+                src_node.type != DFGNodeType.AFFINE
+                or dst_node.type != DFGNodeType.AFFINE
+            ):
+                continue
+
+            for dst_perm_idx, dst_info in enumerate(dst_node.node_info):
+                for src_perm_idx, src_info in enumerate(src_node.node_info):
+                    dst_op = edge.dst_op
+                    src_op = edge.src_op
+                    if dst_op in dst_info.loads_map and src_op in src_info.stores_map:
+                        dst_access = dst_info.loads_map[dst_op].accessMap
+                        src_access = src_info.stores_map[src_op].accessMap
+
+                        # TODO: need to check trip counts?
+                        # fifo case
+                        if dst_access == src_access:
+                            term = model.addVar(
+                                vtype=GRB.INTEGER,
+                                name=f"arrive_{src_id}_{node_id}_{src_perm_idx}_{dst_perm_idx}",
+                            )
+                            model.addConstr(
+                                term
+                                == b_vars[(src_id, src_perm_idx)]
+                                * b_vars[(node_id, dst_perm_idx)]
+                                * fw_vars[src_id]
+                            )
+
+                            arrives_terms.append(term)
+
+                        else:
+                            term = model.addVar(
+                                vtype=GRB.INTEGER,
+                                name=f"arrive_{src_id}_{node_id}_{src_perm_idx}_{dst_perm_idx}",
+                            )
+                            model.addConstr(
+                                term
+                                == b_vars[(src_id, src_perm_idx)]
+                                * b_vars[(node_id, dst_perm_idx)]
+                                * (lw_vars[src_id])
+                            )
+                            arrives_terms.append(term)
+
+        return arrives_terms
+
+    def _add_first_write_time_constraints(
+        self, model, b_vars, st_vars, fw_vars, topo_order
+    ):
+        """fw(n) = st(n) + \sum_{b \in B_n} [FW_n * II_n * b]"""
+        for node_id in topo_order:
+            node = self.get_node(node_id)
+            if node.type != DFGNodeType.AFFINE or not self.out_edges.get(node_id, []):
+                continue
+
+            fw_terms = [st_vars[node_id]]
+            for perm_idx, node_info in enumerate(node.node_info):
+                for out_edge in self.out_edges[node_id]:
+                    src_op = out_edge.src_op
+                    if src_op in node_info.stores_map:
+                        edge_info = node_info.stores_map[src_op]
+                        first_time = edge_info.first_element_time
+                        ii = node_info.II
+
+                        term = model.addVar(
+                            vtype=GRB.INTEGER, name=f"fw_term_{node_id}_{perm_idx}"
+                        )
+
+                        model.addConstr(
+                            term == ii * b_vars[(node_id, perm_idx)] * first_time,
+                            name=f"fw_term_{node_id}_{perm_idx}",
+                        )
+
+                        fw_terms.append(term)
+
+            model.addConstr(
+                fw_vars[node_id] == gp.quicksum(fw_terms), name=f"fw_constr_{node_id}"
+            )
+
+    def _add_last_write_time_constraints(
+        self, model, b_vars, st_vars, lw_vars, topo_order
+    ):
+        """lw(n) = max_{n' \in ins(n)} [Depend(n, n') + Epilogue(n, n')]"""
+        for node_id in topo_order:
+            in_edges = self.in_edges.get(node_id, [])
+            if not in_edges:
+                continue
+
+            lw_terms = []
+
+            # For each incoming edge, compute LW constraints
+            for edge in in_edges:
+                src_id = edge.id
+                dst_node = self.get_node(node_id)
+
+                # Compute relative last read terms
+                rlr_terms = self._compute_relative_last_read_terms(
+                    model, edge, node_id, dst_node, b_vars, st_vars
+                )
+
+                # Compute dependency term
+                depend_term, st_plus_lr = self._compute_depend_term(
+                    model, src_id, node_id, rlr_terms, st_vars, lw_vars
+                )
+
+                # Compute epilogue term
+                epilogue_term = self._compute_epilogue_term(
+                    model, src_id, node_id, dst_node, depend_term, lw_vars, b_vars
+                )
+
+                # Combine terms for this edge
+                lw_term = model.addVar(
+                    vtype=GRB.INTEGER, name=f"lw_term_{src_id}_{node_id}"
+                )
+
+                model.addConstr(
+                    lw_term == depend_term + epilogue_term,
+                    name=f"lw_term_{src_id}_{node_id}",
+                )
+                lw_terms.append(lw_term)
+
+            if lw_terms:
+                model.addGenConstrMax(
+                    lw_vars[node_id], lw_terms, name=f"lw_constr_{node_id}"
+                )
+
+    def _compute_relative_last_read_terms(
+        self, model, edge, node_id, dst_node, b_vars, st_vars
+    ):
+        """Compute relative last read terms for selected permutation [II * lr_time * b]"""
+        rlr_terms = []
+        src_id = edge.id
+
+        if dst_node.type == DFGNodeType.AFFINE:
+            rlr_terms.append(st_vars[node_id])
+
+            for perm_idx, node_info in enumerate(dst_node.node_info):
+                dst_op = edge.dst_op
+                if dst_op in node_info.loads_map:
+                    lr_time = node_info.loads_map[dst_op].last_element_time
+                    ii = node_info.II
+
+                    term = model.addVar(
+                        vtype=GRB.INTEGER,
+                        lb=0,
+                        name=f"rlr_term_{src_id}_{node_id}_{perm_idx}",
+                    )
+
+                    model.addConstr(term == lr_time * ii * b_vars[(node_id, perm_idx)])
+
+                    rlr_terms.append(term)
+
+        return rlr_terms
+
+    def _compute_depend_term(self, model, src_id, node_id, rlr_terms, st_vars, lw_vars):
+        """Depend(n, n') = max(st(n) + sum(b \in B_n) [LR_n^n'], lw(n'))"""
+        depend_term = model.addVar(vtype=GRB.INTEGER, name=f"depend_{src_id}_{node_id}")
+
+        st_plus_lr = model.addVar(
+            vtype=GRB.INTEGER, lb=0, name=f"st_plus_lr_{src_id}_{node_id}"
+        )
+        model.addConstr(
+            st_plus_lr == st_vars[node_id] + gp.quicksum(rlr_terms),
+            name=f"st_plus_lr_constr_{src_id}_{node_id}",
+        )
+
+        model.addConstr(
+            depend_term == gp.max_(st_plus_lr, lw_vars[src_id]),
+            name=f"depend_{src_id}_{node_id}",
+        )
+
+        return depend_term, st_plus_lr
+
+    def _compute_epilogue_term(
+        self, model, src_id, node_id, dst_node, depend_term, lw_vars, b_vars
+    ):
+        """Epilogue(n, n') = sum(b \in B_n) [(lw_n - LR_n^{n'}) * b]"""
+        epilogue_term = model.addVar(
+            vtype=GRB.INTEGER, name=f"epilogue_{src_id}_{node_id}"
+        )
+
+        epi_terms = []
+        if dst_node.type == DFGNodeType.AFFINE:
+            for dst_perm_idx, dst_info in enumerate(dst_node.node_info):
+                # (lw_n - lr_n^{n'}) * b
+                term = model.addVar(
+                    vtype=GRB.INTEGER,
+                    name=f"epi_term_{src_id}_{node_id}_{dst_perm_idx}",
+                )
+
+                model.addConstr(
+                    term
+                    == (depend_term - lw_vars[src_id]) * b_vars[(node_id, dst_perm_idx)]
+                )
+                epi_terms.append(term)
+
+        model.addConstr(
+            epilogue_term == gp.quicksum(epi_terms),
+            name=f"epilogue_{src_id}_{node_id}",
+        )
+
+        return epilogue_term
 
     @classmethod
     def from_module(cls, module, dsp_factors=None, mem_r_ports=None, mem_w_ports=None):

--- a/allo/autoscheduler/dfg.py
+++ b/allo/autoscheduler/dfg.py
@@ -367,16 +367,6 @@ class DFG:
                             dst_op=load_op,
                         )
 
-            # for alloc_node_id, alloc_op in memref_allocs[memref]:
-            #     for store_node_id, store_op in stores_node_list:
-            #         self.add_edge(
-            #             alloc_node_id,
-            #             store_node_id,
-            #             value=memref,
-            #             src_op=store_op,
-            #             dst_op=alloc_op,
-            #         )
-
         # Third pass: populate node information for each loop permutation
         for node in self.nodes.values():
             self._populate_node_info(node.id)
@@ -535,7 +525,7 @@ class DFG:
 
             f.write("}\n")
 
-    def createGraphParallelismPerformanceModel(self, debug_output=None):
+    def create_graph_parallelism_performance_model(self, debug_output=None):
         model = gp.Model("graph_parallelism_performance_model")
 
         # Get topological order and verify no cycles

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,5 @@ ninja
 sympy
 rich
 ml_dtypes
+gurobipy
 past @ https://github.com/cornell-zhang/past-python-bindings/releases/download/65f989b/past-0.7.2-cp312-cp312-linux_x86_64.whl

--- a/tests/autoscheduler/test_autoscheduler.py
+++ b/tests/autoscheduler/test_autoscheduler.py
@@ -1,0 +1,76 @@
+# Copyright Allo authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import allo
+import gurobipy as gp
+from gurobipy import GurobiError
+
+from allo.ir.types import int32, float32
+from allo.autoscheduler.dfg import DFG
+from allo.autoscheduler.passes import dataflow_optimization_pass
+
+
+def check_gurobi_license():
+    """Check if Gurobi license is valid for large tests."""
+    try:
+        env = gp.Env(empty=True)
+        env.start()
+    except GurobiError as e:
+        return False
+    return True
+
+
+def test_simple():
+    def simple() -> int32[10, 10]:
+        A: int32[10, 10]
+        B: int32[10, 10]
+        for i in range(10):
+            for j in range(10):
+                A[i, j] = i + j
+
+        for j in range(10):
+            for i in range(10):
+                B[i, j] = A[i, j] + 1
+
+        return B
+
+    s = allo.customize(simple)
+    s = dataflow_optimization_pass(s, debug_point="dataflow_canonicalization")
+    dfg = DFG.from_module(s.module)
+
+    permutations = dfg.createGraphParallelismPerformanceModel()
+    assert permutations[0][1] != permutations[1][1]
+
+
+def matrix_multiply(A: int32[8, 8], B: int32[8, 8]) -> int32[8, 8]:
+    C: int32[8, 8] = 0
+    for i in range(8):
+        for j in range(8):
+            for k in range(8):
+                C[i, j] = C[i, j] + A[i, k] * B[k, j]
+    return C
+
+
+def test_3mm():
+    if not check_gurobi_license():
+        print("❌ Gurobi license error: skipping test_3mm")
+        return
+
+    def three_mm(
+        A: int32[8, 8], B: int32[8, 8], C: int32[8, 8], D: int32[8, 8]
+    ) -> int32[8, 8]:
+        E: int32[8, 8] = matrix_multiply(A, B)
+        F: int32[8, 8] = matrix_multiply(C, D)
+        return matrix_multiply(E, F)
+
+    s = allo.customize(three_mm)
+    s = dataflow_optimization_pass(s, debug_point="dataflow_canonicalization")
+    module = s.module
+
+    dfg = DFG.from_module(module)
+    dfg.createGraphParallelismPerformanceModel()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/autoscheduler/test_autoscheduler.py
+++ b/tests/autoscheduler/test_autoscheduler.py
@@ -29,7 +29,7 @@ def test_simple():
     s = dataflow_optimization_pass(s, debug_point="dataflow_canonicalization")
     dfg = DFG.from_module(s.module)
 
-    permutations = dfg.createGraphParallelismPerformanceModel(debug_output="simple")
+    permutations = dfg.create_graph_parallelism_performance_model(debug_output="simple")
     assert permutations[0][1] != permutations[1][1]
 
 
@@ -56,7 +56,7 @@ def test_3mm():
 
     dfg = DFG.from_module(module)
     try:
-        dfg.createGraphParallelismPerformanceModel(debug_output="3mm")
+        dfg.create_graph_parallelism_performance_model(debug_output="3mm")
     except GurobiError as e:
         if "Model too large for size-limited license" in str(e):
             pytest.skip(


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
Implements the graph-level pipelining MINLP formulation from Stream-HLS. Future PRs will build on this one to extract the schedule from the optimal MINLP solution. 

Note that larger test cases are disabled in Github actions since it is not known how to add a gurobi license to that environment at this time. 

### Examples ###
For this simple sanity check case, the optimal solution of the MINLP should involve either the first loop nest or the second loop nest being permuted. 
```python
def simple() -> int32[10, 10]:
        A: int32[10, 10]
        B: int32[10, 10]
        for i in range(10):
            for j in range(10):
                A[i, j] = i + j

        for j in range(10):
            for i in range(10):
                B[i, j] = A[i, j] + 1

        return B
```
produces the following model 
```lp
\ Model graph_parallelism_performance_model
\ LP format - for model browsing. Use MPS format to capture full model detail.
\ Signature: 0x9f382c8f1cb9c6aa
Minimize
  0 lw4 + 0 fw5 + lw5 + 0 arrive_3_4_0_0 + 0 arrive_3_4_1_0
   + 0 arrive_3_4_0_1 + 0 arrive_3_4_1_1
Subject To
 permutation_constraint_3: b3_0 + b3_1 = 1
 permutation_constraint_4: b4_0 + b4_1 = 1
 st_root_3: st3 = 0
 fw_root_3: fw3 = 0
 lw_root_3: lw3 = 0
 st_root_2: st2 = 0
 fw_root_2: fw2 = 0
 lw_root_2: lw2 = 0
 st_root_1: st1 = 0
 fw_root_1: fw1 = 0
 lw_root_1: lw1 = 0
 st_root_0: st0 = 0
 fw_root_0: fw0 = 0
 lw_root_0: lw0 = 0
 fw_term_3_0: fw_term_3_0 = 0
 fw_term_3_1: fw_term_3_1 = 0
 fw_constr_3: - st3 + fw3 - fw_term_3_0 - fw_term_3_1 = 0
 fw_term_4_0: fw_term_4_0 = 0
 fw_term_4_1: fw_term_4_1 = 0
 fw_constr_4: - st4 + fw4 - fw_term_4_0 - fw_term_4_1 = 0
 R20: - 99 b4_0 + rlr_term_3_4_0 = 0
 R21: - 99 b4_1 + rlr_term_3_4_1 = 0
 st_plus_lr_constr_3_4: - 2 st4 - rlr_term_3_4_0 - rlr_term_3_4_1
   + st_plus_lr_3_4 = 0
 epilogue_3_4: epilogue_3_4 - epi_term_3_4_0 - epi_term_3_4_1 = 0
 lw_term_3_4: - depend_3_4 - epilogue_3_4 + lw_term_3_4 = 0
 st_plus_lr_constr_4_5: - st5 + st_plus_lr_4_5 = 0
 epilogue_4_5: epilogue_4_5 = 0
 lw_term_4_5: - depend_4_5 - epilogue_4_5 + lw_term_4_5 = 0
 qc0: epi_term_3_4_0 + [ b4_0 * lw3 - b4_0 * depend_3_4 ] = 0
 qc1: epi_term_3_4_1 + [ b4_1 * lw3 - b4_1 * depend_3_4 ] = 0
Bounds
Binaries
 b3_0 b3_1 b4_0 b4_1
Generals
 st0 fw0 lw0 st1 fw1 lw1 st2 fw2 lw2 st3 fw3 lw3 st4 fw4 lw4 st5 fw5 lw5
 arrive_3_4_0_0 arrive_3_4_1_0 arrive_3_4_0_1 arrive_3_4_1_1 fw_term_3_0
 fw_term_3_1 fw_term_4_0 fw_term_4_1 rlr_term_3_4_0 rlr_term_3_4_1
 depend_3_4 st_plus_lr_3_4 epilogue_3_4 epi_term_3_4_0 epi_term_3_4_1
 lw_term_3_4 depend_4_5 st_plus_lr_4_5 epilogue_4_5 lw_term_4_5
General Constraints
\ arrive_3_4_0_0 = (b3_0 * b4_0) * lw3
 GC0: arrive_3_4_0_0 = NL : ( MULTIPLY , -1 , -1 ) ( MULTIPLY , -1 , 0 ) 
  ( VARIABLE , b3_0 , 1 ) ( VARIABLE , b4_0 , 1 ) ( VARIABLE , lw3 , 0 )
\ arrive_3_4_1_0 = (b3_1 * b4_0) * fw3
 GC1: arrive_3_4_1_0 = NL : ( MULTIPLY , -1 , -1 ) ( MULTIPLY , -1 , 0 ) 
  ( VARIABLE , b3_1 , 1 ) ( VARIABLE , b4_0 , 1 ) ( VARIABLE , fw3 , 0 )
\ arrive_3_4_0_1 = (b3_0 * b4_1) * fw3
 GC2: arrive_3_4_0_1 = NL : ( MULTIPLY , -1 , -1 ) ( MULTIPLY , -1 , 0 ) 
  ( VARIABLE , b3_0 , 1 ) ( VARIABLE , b4_1 , 1 ) ( VARIABLE , fw3 , 0 )
\ arrive_3_4_1_1 = (b3_1 * b4_1) * lw3
 GC3: arrive_3_4_1_1 = NL : ( MULTIPLY , -1 , -1 ) ( MULTIPLY , -1 , 0 ) 
  ( VARIABLE , b3_1 , 1 ) ( VARIABLE , b4_1 , 1 ) ( VARIABLE , lw3 , 0 )
 st_constr_4: st4 = MAX ( arrive_3_4_0_0 , arrive_3_4_1_0 ,
   arrive_3_4_0_1 , arrive_3_4_1_1 )
 depend_3_4: depend_3_4 = MAX ( st_plus_lr_3_4 , lw3 )
 lw_constr_4: lw4 = MAX ( lw_term_3_4 )
 depend_4_5: depend_4_5 = MAX ( st_plus_lr_4_5 , lw4 )
 lw_constr_5: lw5 = MAX ( lw_term_4_5 )
End
```
After solving, it is verified that one of these loops should be permuted.
```python
    permutations = dfg.createGraphParallelismPerformanceModel()
    assert permutations[0][1] != permutations[1][1]
```
## Checklist ##

Please make sure to review and check all of these items:
- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] All changes have test coverage (It would be good to provide ~2 different test cases to test the robustness of your code)
- [x] Pass the [formatting check](https://cornell-zhang.github.io/allo/developer/index.html#id1) locally
- [x] Code is well-documented
