### PR TITLE
[Autoscheduler] Extract schedule from MINLP solution

### DIFF
--- a/allo/autoscheduler/dfg.py
+++ b/allo/autoscheduler/dfg.py
@@ -633,7 +633,7 @@ class DFG:
             arrives_terms = self._compute_arrival_terms(
                 model, node_id, in_edges, b_vars, fw_vars, lw_vars
             )
-            
+
             if arrives_terms:
                 model.addConstr(
                     st_vars[node_id] == gp.max_(arrives_terms),

--- a/allo/autoscheduler/dfg.py
+++ b/allo/autoscheduler/dfg.py
@@ -573,7 +573,6 @@ class DFG:
             for node_id in self.nodes
             if self.get_node(node_id).type == DFGNodeType.RET
         ]
-        print(sink_nodes)
         assert len(sink_nodes) == 1, "Expected a single sink node"
         return sink_nodes[0]
 
@@ -634,8 +633,7 @@ class DFG:
             arrives_terms = self._compute_arrival_terms(
                 model, node_id, in_edges, b_vars, fw_vars, lw_vars
             )
-            if node_id == 4:
-                print("node", node_id, arrives_terms, in_edges)
+            
             if arrives_terms:
                 model.addConstr(
                     st_vars[node_id] == gp.max_(arrives_terms),
@@ -669,9 +667,6 @@ class DFG:
                     # TODO: need to check trip counts?
                     # fifo case
                     if dst_access == src_access:
-                        print("access match", dst_access, src_access)
-                        print(dst_perm_idx, src_perm_idx)
-                        print(src_id, node_id)
                         term = model.addVar(
                             vtype=GRB.INTEGER,
                             name=f"arrive_{src_id}_{node_id}_{src_perm_idx}_{dst_perm_idx}",

--- a/allo/autoscheduler/dfg.py
+++ b/allo/autoscheduler/dfg.py
@@ -528,8 +528,12 @@ class DFG:
 
             f.write("}\n")
 
-    def create_graph_parallelism_performance_model(self, debug_output=None):
+    def create_graph_parallelism_performance_model(
+        self, debug_output=None, verbose=False
+    ):
         model = gp.Model("graph_parallelism_performance_model")
+
+        model.setParam("OutputFlag", 1 if verbose else 0)
 
         # Get topological order and verify no cycles
         topo_order = self.topological_sort()

--- a/allo/autoscheduler/dfg.py
+++ b/allo/autoscheduler/dfg.py
@@ -43,13 +43,14 @@ class Edge:
 
 
 class EdgeInfo:
-    def __init__(self, accessMap: AffineMap):
-        self.accessMap = accessMap
+    def __init__(self, access_map: AffineMap, op=None):
+        self.access_map = access_map
         self.first_element_time = 0
         self.last_element_time = 0
+        self.op = op
 
     def __repr__(self):
-        return f"EdgeInfo(accessMap={self.accessMap}"
+        return f"EdgeInfo(access_map={self.access_map}, op={self.op})"
 
 
 class NodeInfo:
@@ -273,22 +274,24 @@ class DFG:
             node.node_info.append(node_info)
             permuted_loops = [node.loop_info[i] for i in perm]
             for load in node.loads:
+                memref = self._get_memref(load)
                 access_map = get_minimal_access_pattern(load, permuted_loops)
-                node_info.loads_map[load] = EdgeInfo(access_map)
+                node_info.loads_map[memref] = EdgeInfo(access_map, load)
                 first_element_time, last_element_time = (
                     self._compute_first_and_last_element_time(load, permuted_loops)
                 )
-                node_info.loads_map[load].first_element_time = first_element_time
-                node_info.loads_map[load].last_element_time = last_element_time
+                node_info.loads_map[memref].first_element_time = first_element_time
+                node_info.loads_map[memref].last_element_time = last_element_time
 
             for store in node.stores:
+                memref = self._get_memref(store)
                 access_map = get_minimal_access_pattern(store, permuted_loops)
-                node_info.stores_map[store] = EdgeInfo(access_map)
+                node_info.stores_map[memref] = EdgeInfo(access_map, store)
                 first_element_time, last_element_time = (
                     self._compute_first_and_last_element_time(store, permuted_loops)
                 )
-                node_info.stores_map[store].first_element_time = first_element_time
-                node_info.stores_map[store].last_element_time = last_element_time
+                node_info.stores_map[memref].first_element_time = first_element_time
+                node_info.stores_map[memref].last_element_time = last_element_time
 
             # Compute II
             node_info.II = compute_loop_II(top_level_for, permuted_loops)
@@ -560,6 +563,7 @@ class DFG:
         if debug_output:
             model.write(f"{debug_output}.lp")
         # Return optimal permutation assignments
+        # format is list of (node_id, perm_idx)
         return [k for k, b_var in b_vars.items() if b_var.x > 0.5]
 
     def _find_sink_node(self):
@@ -625,14 +629,13 @@ class DFG:
             # Handle root nodes (no incoming edges)
             if not in_edges:
                 model.addConstr(st_vars[node_id] == 0, name=f"st_root_{node_id}")
-                model.addConstr(fw_vars[node_id] == 0, name=f"fw_root_{node_id}")
-                model.addConstr(lw_vars[node_id] == 0, name=f"lw_root_{node_id}")
                 continue
 
             arrives_terms = self._compute_arrival_terms(
                 model, node_id, in_edges, b_vars, fw_vars, lw_vars
             )
-
+            if node_id == 4:
+                print("node", node_id, arrives_terms, in_edges)
             if arrives_terms:
                 model.addConstr(
                     st_vars[node_id] == gp.max_(arrives_terms),
@@ -658,40 +661,42 @@ class DFG:
 
             for dst_perm_idx, dst_info in enumerate(dst_node.node_info):
                 for src_perm_idx, src_info in enumerate(src_node.node_info):
-                    dst_op = edge.dst_op
-                    src_op = edge.src_op
-                    if dst_op in dst_info.loads_map and src_op in src_info.stores_map:
-                        dst_access = dst_info.loads_map[dst_op].accessMap
-                        src_access = src_info.stores_map[src_op].accessMap
+                    val = edge.value
+                    assert val in dst_info.loads_map and val in src_info.stores_map
+                    dst_access = dst_info.loads_map[val].access_map
+                    src_access = src_info.stores_map[val].access_map
 
-                        # TODO: need to check trip counts?
-                        # fifo case
-                        if dst_access == src_access:
-                            term = model.addVar(
-                                vtype=GRB.INTEGER,
-                                name=f"arrive_{src_id}_{node_id}_{src_perm_idx}_{dst_perm_idx}",
-                            )
-                            model.addConstr(
-                                term
-                                == b_vars[(src_id, src_perm_idx)]
-                                * b_vars[(node_id, dst_perm_idx)]
-                                * fw_vars[src_id]
-                            )
+                    # TODO: need to check trip counts?
+                    # fifo case
+                    if dst_access == src_access:
+                        print("access match", dst_access, src_access)
+                        print(dst_perm_idx, src_perm_idx)
+                        print(src_id, node_id)
+                        term = model.addVar(
+                            vtype=GRB.INTEGER,
+                            name=f"arrive_{src_id}_{node_id}_{src_perm_idx}_{dst_perm_idx}",
+                        )
+                        model.addConstr(
+                            term
+                            == b_vars[(src_id, src_perm_idx)]
+                            * b_vars[(node_id, dst_perm_idx)]
+                            * fw_vars[src_id]
+                        )
 
-                            arrives_terms.append(term)
+                        arrives_terms.append(term)
 
-                        else:
-                            term = model.addVar(
-                                vtype=GRB.INTEGER,
-                                name=f"arrive_{src_id}_{node_id}_{src_perm_idx}_{dst_perm_idx}",
-                            )
-                            model.addConstr(
-                                term
-                                == b_vars[(src_id, src_perm_idx)]
-                                * b_vars[(node_id, dst_perm_idx)]
-                                * (lw_vars[src_id])
-                            )
-                            arrives_terms.append(term)
+                    else:
+                        term = model.addVar(
+                            vtype=GRB.INTEGER,
+                            name=f"arrive_{src_id}_{node_id}_{src_perm_idx}_{dst_perm_idx}",
+                        )
+                        model.addConstr(
+                            term
+                            == b_vars[(src_id, src_perm_idx)]
+                            * b_vars[(node_id, dst_perm_idx)]
+                            * (lw_vars[src_id])
+                        )
+                        arrives_terms.append(term)
 
         return arrives_terms
 

--- a/allo/autoscheduler/outline_loops.mlir
+++ b/allo/autoscheduler/outline_loops.mlir
@@ -6,7 +6,7 @@ module attributes {transform.with_named_sequence} {
              attributes{top_level} in %func 
              : (!transform.any_op) -> !transform.any_op
     
-    %outlined_funcs, %calls = transform.loop.outline %loops {func_name = "outlined_loop"} 
+    %outlined_funcs, %calls = transform.loop.outline %loops {func_name = "affine_kernel"} 
                              : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
     transform.yield
   }

--- a/allo/autoscheduler/passes.py
+++ b/allo/autoscheduler/passes.py
@@ -228,7 +228,6 @@ def canonicalize_alloc(alloc_op):
     # store-load-store-load loop redution pattern
     if len(stores) == 2 and (len(loads) == 2 or len(loads) == 1 and len(ret) == 1):
         l_ops = [l[0] for l in loads]
-        print("ok")
         if store_load_store_load_pattern(alloc_op, l_ops, stores, ret):
             return
     
@@ -257,7 +256,6 @@ def store_load_store_load_pattern(alloc_op, loads, stores, ret):
         if loop_load:
             break
     
-    print(loop_load, loop_store)
     if not loop_load or not loop_store:
         return False
 
@@ -511,9 +509,6 @@ def extract_buffer_to_fifo(permutations, dfg: DFG, node_to_fn: dict[int, str], s
             assert memref in dst_node_info.loads_map
             assert memref in src_node_info.stores_map
             if dst_node_info.loads_map[memref].access_map == src_node_info.stores_map[memref].access_map:
-                if memref.owner.attributes["name"].value == "output":
-                    print("dst", dst_node_info.loads_map[memref].op)
-                    print("src", src_node_info.stores_map[memref].op)
                 if "name" not in memref.owner.attributes:
                     with schedule.module.context:
                         memref.owner.attributes["name"] = StringAttr.get(f"fifo_buffer_{unnamed_ct}")

--- a/allo/autoscheduler/passes.py
+++ b/allo/autoscheduler/passes.py
@@ -21,20 +21,23 @@ from allo._mlir.dialects import (
 from allo._mlir.passmanager import PassManager as mlir_pass_manager
 from allo.customize import Schedule
 from allo.ir.transform import find_func_in_module
+from allo.ir.utils import MockBuffer
 from .util import (
     check_perfect_affine_kernel,
     check_call_graph_acyclic,
     check_all_functions_inlined,
 )
 
-from .dfg import DFG, DFGNodeType
+from .dfg import DFG, DFGNodeType, NodeInfo
+from .primitives import BufferToFifo, SchedulePrimitive, Reorder, Pipeline
+import allo
 
-DEBUG_POINTS = ["mlir_preprocess", "dataflow_canonicalization", "outline_loops"]
+DEBUG_POINTS = ["mlir_preprocess", "dataflow_canonicalization", "outline_loops", None]
 PARALLELISM_MODELS = ["graph", "node", "combined"]
 
 
 def dataflow_optimization_pass(
-    schedule: Schedule, debug_point=None, kind=None
+    schedule: Schedule, debug_point=None, kind=None, verify=True
 ) -> Schedule:
     """
     Applies autoscheduler optimization passes to the schedule.
@@ -79,35 +82,46 @@ def dataflow_optimization_pass(
 
     dfg = DFG.from_module(mod_dcp)
 
-    mod_outlined = outline_loops_pass(mod_dcp, dfg)
-    if debug_point == "outline_loops":
-        return Schedule(
-            mod_outlined,
-            find_func_in_module(mod_outlined, top_fn_name),
-            schedule.func_args,
-            schedule.ip,
-            schedule.ext_libs,
-            schedule.inst_list,
-        )
-
-    if kind == "graph":
-        # TODO: implement graph parallelism performance model
-        pass
-    elif kind == "node":
-        # TODO: implement node parallelism performance model
-        pass
-    elif kind == "combined":
-        # TODO: implement combined parallelism performance model
-        pass
-
-    return Schedule(
-        mod,
-        find_func_in_module(mod, top_fn_name),
+    mod_outlined, node_to_fn = outline_loops_pass(mod_dcp, dfg)
+    optimized_schedule = Schedule(
+        mod_outlined,
+        find_func_in_module(mod_outlined, top_fn_name),
         schedule.func_args,
         schedule.ip,
         schedule.ext_libs,
         schedule.inst_list,
     )
+
+    if debug_point == "outline_loops":
+        return optimized_schedule
+    
+    schedule_primitives = []
+
+    # build performance model
+    match kind:
+        case "graph":
+            permutations = dfg.create_graph_parallelism_performance_model()
+            schedule_primitives.extend(extract_reorder_and_pipeline(permutations, dfg, node_to_fn, optimized_schedule))
+            schedule_primitives.extend(extract_buffer_to_fifo(permutations, dfg, optimized_schedule.top_func_name, node_to_fn))
+        case "node":
+            # TODO: implement node parallelism performance model
+            pass
+        case "combined":
+            # TODO: implement combined parallelism performance model
+            pass
+        case _:
+            raise ValueError(f"Invalid parallelism model: {kind}")
+    
+    # apply schedule primitives
+    for primitive in schedule_primitives:
+        print(primitive)
+        primitive.applyTo(optimized_schedule)
+
+    if verify:
+        verifier = allo.verify(optimized_schedule, schedule)
+        assert verifier, "Schedule is not equivalent to original schedule"
+        
+    return optimized_schedule
 
 
 # pylint: enable=unused-argument
@@ -177,9 +191,11 @@ def canonicalize_alloc(alloc_op):
         store = stores[0]
         for i, (load, idx) in enumerate(loads[1:]):
             new_alloc = alloc_op.operation.clone(ip=InsertionPoint(alloc_op))
-            new_alloc.attributes["name"] = StringAttr.get(f"{orig_name}_split_{i}")
+            name = f"{orig_name}_split_{i}"
+            new_alloc.attributes["name"] = StringAttr.get(name)
             store_dup = store.clone(ip=InsertionPoint(store))
             store_dup.operation.replace_uses_of_with(alloc_op.result, new_alloc.result)
+            store_dup.attributes["from"] = StringAttr.get(name)
             load.operation.operands[idx] = new_alloc.result
         return
 
@@ -307,7 +323,7 @@ def store_load_store_load_pattern(alloc_op, loads, stores):
     return True
 
 
-def outline_loops_pass(module: Module, dfg: DFG = None) -> Module:
+def outline_loops_pass(module: Module, dfg: DFG = None) -> tuple[Module, dict[int, str]]:
     with module.context:
         for func in module.body.operations:
             if not isinstance(func, func_d.FuncOp):
@@ -340,16 +356,123 @@ def outline_loops_pass(module: Module, dfg: DFG = None) -> Module:
             combined_module = Module.parse(combined_content, ctx)
             pipeline = "builtin.module(transform-interpreter{entry-point=outline_affine_loops},canonicalize)"
             mlir_pass_manager.parse(pipeline).run(combined_module.operation)
-            return Module.parse(
+            processed_module, node_to_fn_map = post_process_module(Module.parse(
                 combined_module.operation.regions[0].blocks[0].operations[0].get_asm(),
                 ctx,
-            )
+            ))
+            return processed_module, node_to_fn_map
 
         except Exception as e:
             print("Error: failed to run MLIR passes, printing module...")
             print(combined_content)
             raise e
+        
+def post_process_module(module: Module) -> tuple[Module, dict[int, str]]:
+    """
+    Post-processes a module by adding loop names and operation names
+    and builds a mapping from node IDs to function names.
+    
+    Args:
+        module: The MLIR module to process.
+        
+    Returns:
+        the processed module and a dictionary mapping node IDs to function names.
+    """
+    loop_counter = 0
+    node_to_fn = {}
+    
+    def process_op(op, func_name):
+        nonlocal loop_counter
+        
+        if isinstance(op, affine_d.AffineForOp):
+            if "loop_name" not in op.attributes:
+                op.attributes["loop_name"] = StringAttr.get(f"L_{loop_counter}")
+                loop_counter += 1
+            
+            if "top_level" in op.attributes:
+                assert "node_id" in op.attributes
+                node_id = int(op.attributes["node_id"].value)
+                
+                node_to_fn[node_id] = func_name
+            
+                if "op_name" not in op.attributes:
+                    op.attributes["op_name"] = StringAttr.get(f"kernel_{node_id}")
 
+                del op.attributes["top_level"]
+                del op.attributes["node_id"]
+            
+            for nested_op in op.body.operations:
+                process_op(nested_op, func_name)
+        elif hasattr(op, "regions"):
+            for region in op.regions:
+                for block in region.blocks:
+                    for nested_op in block.operations:
+                        process_op(nested_op, func_name)
+    
+    with module.context:
+        for func in module.body.operations:
+            if not isinstance(func, func_d.FuncOp):
+                continue
+            
+            func_name = func.name.value
+            
+            for op in func.body.blocks[0]:
+                process_op(op, func_name)
+                
+    return module, node_to_fn
+
+            
+def extract_reorder_and_pipeline(permutations, dfg: DFG, node_to_fn: dict[int, str], schedule: Schedule) -> list[SchedulePrimitive]:
+    schedule_primitives = []
+    for node_id, perm_idx in permutations:
+        loop_band_collection = list(v for _, v in schedule.get_loops(node_to_fn[node_id]).__iter__())
+        # support only perfect affine kernels
+        assert len(loop_band_collection) == 1, "Only perfect affine kernels are supported"
+        loop_band = list(loop_band_collection[0].loops.values())
+
+        node_info: NodeInfo = dfg.get_node(node_id).node_info[perm_idx]
+        print(perm_idx)
+        if perm_idx == 0:
+            schedule_primitives.append(
+                Pipeline(loop_band[-1], ii=node_info.II)
+            )
+        else: 
+            perm = node_info.permutation
+            new_loop_order = [loop_band[i] for i in perm]
+            schedule_primitives.append(
+                Reorder(new_loop_order)
+            )
+            schedule_primitives.append(
+                Pipeline(new_loop_order[-1], ii=node_info.II)
+            )
+    
+    return schedule_primitives
+
+def extract_buffer_to_fifo(permutations, dfg: DFG, top_level_fn_name: str, node_to_fn: dict[int, str]):
+    permutations = {node_idx: perm_idx for node_idx, perm_idx in permutations}
+    schedule_primitives = []
+    for node_idx, node in dfg.nodes.items():
+        if node.type != DFGNodeType.AFFINE:
+            continue
+        dst_node_info = node.node_info[permutations[node_idx]]
+        for edge in dfg.in_edges[node_idx]:
+            src_node = dfg.nodes[edge.id]
+            if src_node.type != DFGNodeType.AFFINE:
+                continue 
+            src_node_info = src_node.node_info[permutations[edge.id]]
+            memref = edge.value 
+            assert memref in dst_node_info.loads_map
+            assert memref in src_node_info.stores_map
+            if dst_node_info.loads_map[memref].access_map == src_node_info.stores_map[memref].access_map:
+                print(memref.owner)
+                buffer = MockBuffer(top_level_fn_name, memref.owner.attributes["name"].value)
+                fn_name = node_to_fn[node_idx]
+                schedule_primitives.append(
+                    BufferToFifo(buffer, fn_name)
+                )
+            
+    return schedule_primitives
+            
 
 # def build_dataflow_graph(module: Module):
 #     pass

--- a/allo/autoscheduler/passes.py
+++ b/allo/autoscheduler/passes.py
@@ -23,6 +23,8 @@ from allo._mlir.passmanager import PassManager as mlir_pass_manager
 from allo.customize import Schedule
 from allo.ir.transform import find_func_in_module
 from allo.ir.utils import MockBuffer
+import allo
+
 from .util import (
     check_perfect_affine_kernel,
     check_call_graph_acyclic,
@@ -31,14 +33,19 @@ from .util import (
 
 from .dfg import DFG, DFGNodeType, NodeInfo
 from .primitives import BufferToFifo, SchedulePrimitive, Reorder, Pipeline
-import allo
 
-DEBUG_POINTS = ["mlir_preprocess", "dataflow_canonicalization", "outline_loops", None]
+DEBUG_POINTS = [
+    "mlir_preprocess",
+    "dataflow_canonicalization",
+    "outline_loops",
+    "loop_opts",
+    None,
+]
 PARALLELISM_MODELS = ["graph", "node", "combined"]
 
 
 def dataflow_optimization_pass(
-    schedule: Schedule, debug_point=None, kind=None, verify=True
+    schedule: Schedule, debug_point=None, kind=None, verify=False
 ) -> Schedule:
     """
     Applies autoscheduler optimization passes to the schedule.
@@ -92,7 +99,7 @@ def dataflow_optimization_pass(
     mod_dcp = name_buffers_pass(mod_dcp)
 
     mod_outlined, node_to_fn = outline_loops_pass(mod_dcp, dfg)
-    
+
     schedule = Schedule(
         mod_outlined,
         find_func_in_module(mod_outlined, top_fn_name),
@@ -104,15 +111,17 @@ def dataflow_optimization_pass(
 
     if debug_point == "outline_loops":
         return schedule
-    
+
     try:
-        import past 
+        import past  # pylint: disable=unused-import
     except ImportError:
         verify = False
 
     if verify:
         # hacky clone
-        mod_outlined_clone = Module.parse(mod_outlined.operation.get_asm(), mod_outlined.context)
+        mod_outlined_clone = Module.parse(
+            mod_outlined.operation.get_asm(), mod_outlined.context
+        )
         original_schedule = Schedule(
             mod_outlined_clone,
             find_func_in_module(mod_outlined_clone, top_fn_name),
@@ -121,15 +130,19 @@ def dataflow_optimization_pass(
             schedule.ext_libs,
             schedule.inst_list,
         )
-    
-    schedule_primitives = []
-    fifo_primitives = []
+
+    loop_opts = []
+    fifos = []
     # build performance model
     match kind:
         case "graph":
             permutations = dfg.create_graph_parallelism_performance_model()
-            schedule_primitives.extend(extract_reorder_and_pipeline(permutations, dfg, node_to_fn, schedule))
-            fifo_primitives.extend(extract_buffer_to_fifo(permutations, dfg, node_to_fn, schedule))
+            loop_opts.extend(
+                extract_reorder_and_pipeline(permutations, dfg, node_to_fn, schedule)
+            )
+            fifos.extend(
+                extract_buffer_to_fifo(permutations, dfg, node_to_fn, schedule)
+            )
         case "node":
             # TODO: implement node parallelism performance model
             pass
@@ -138,21 +151,23 @@ def dataflow_optimization_pass(
             pass
         case _:
             raise ValueError(f"Invalid parallelism model: {kind}")
-    
-    for primitive in schedule_primitives:
+
+    for primitive in loop_opts:
         primitive.applyTo(schedule)
-    
+
+    if debug_point == "loop_opts":
+        return schedule
+
     if verify:
         verifier = allo.verify(schedule, original_schedule)
-        assert verifier, "Failed verification: Schedule is not equivalent to original schedule"
-    
-    for primitive in fifo_primitives:
+        assert (
+            verifier
+        ), "Failed verification: Schedule is not equivalent to original schedule"
+
+    for primitive in fifos:
         primitive.applyTo(schedule)
-        
+
     return schedule
-
-
-# pylint: enable=unused-argument
 
 
 def _mlir_preprocess(module, top_func_name):
@@ -170,6 +185,7 @@ def _mlir_preprocess(module, top_func_name):
         print("Error: failed to run MLIR passes, printing module...")
         print(module)
         raise e
+
 
 def _dataflow_canonicalization_pass(module):
     """
@@ -233,13 +249,13 @@ def canonicalize_alloc(alloc_op):
         l_ops = [l[0] for l in loads]
         if store_load_store_load_pattern(alloc_op, l_ops, stores, ret):
             return
-    
+
     # multiple loads and multiple stores
     if len(stores) >= 2 and len(loads) >= 1:
         raise NotImplementedError(
             f"Complex pattern detected in alloc op {alloc_op}; additional canonicalization not implemented yet."
         )
-    
+
 
 def store_load_store_load_pattern(alloc_op, loads, stores, ret):
     """
@@ -258,12 +274,12 @@ def store_load_store_load_pattern(alloc_op, loads, stores, ret):
                 break
         if loop_load:
             break
-    
+
     if not loop_load or not loop_store:
         return False
 
     store_op = [s for s in stores if s != loop_store][0]
-    
+
     load_op = [l for l in loads if l != loop_load][0] if len(ret) == 0 else ret[0]
 
     # check for unsupported store_op in an if block
@@ -347,13 +363,15 @@ def store_load_store_load_pattern(alloc_op, loads, stores, ret):
             final_loop_load.result, new_alloc2.result, loop_load.indices, loop_load.map
         )
         affine_d.AffineYieldOp([])
-    
+
     load_op.operation.replace_uses_of_with(alloc_op.result, new_alloc2.result)
 
     return True
 
+
 def name_buffers_pass(module: Module):
     unnamed_ct = 0
+
     def name_buffer_helper(op):
         nonlocal unnamed_ct
         if isinstance(op.opview, memref_d.AllocOp):
@@ -361,16 +379,24 @@ def name_buffers_pass(module: Module):
                 op.attributes["name"] = StringAttr.get(f"_buffer_{unnamed_ct}")
                 for use in op.result.uses:
                     if isinstance(use.owner, memref_d.LoadOp):
-                        use.owner.attributes["from"] = StringAttr.get(f"_buffer_{unnamed_ct}")
+                        use.owner.attributes["from"] = StringAttr.get(
+                            f"_buffer_{unnamed_ct}"
+                        )
                     elif isinstance(use.owner, memref_d.StoreOp):
-                        use.owner.attributes["to"] = StringAttr.get(f"_buffer_{unnamed_ct}")
+                        use.owner.attributes["to"] = StringAttr.get(
+                            f"_buffer_{unnamed_ct}"
+                        )
                 unnamed_ct += 1
         return WalkResult(0)
+
     with module.context:
         module.operation.walk(name_buffer_helper)
         return module
-        
-def outline_loops_pass(module: Module, dfg: DFG = None) -> tuple[Module, dict[int, str]]:
+
+
+def outline_loops_pass(
+    module: Module, dfg: DFG = None
+) -> tuple[Module, dict[int, str]]:
     with module.context:
         for func in module.body.operations:
             if not isinstance(func, func_d.FuncOp):
@@ -403,51 +429,57 @@ def outline_loops_pass(module: Module, dfg: DFG = None) -> tuple[Module, dict[in
             combined_module = Module.parse(combined_content, ctx)
             pipeline = "builtin.module(transform-interpreter{entry-point=outline_affine_loops},canonicalize)"
             mlir_pass_manager.parse(pipeline).run(combined_module.operation)
-            processed_module, node_to_fn_map = post_process_module(Module.parse(
-                combined_module.operation.regions[0].blocks[0].operations[0].get_asm(),
-                ctx,
-            ))
+            processed_module, node_to_fn_map = post_process_module(
+                Module.parse(
+                    combined_module.operation.regions[0]
+                    .blocks[0]
+                    .operations[0]
+                    .get_asm(),
+                    ctx,
+                )
+            )
             return processed_module, node_to_fn_map
 
         except Exception as e:
             print("Error: failed to run MLIR passes, printing module...")
             print(combined_content)
             raise e
-        
+
+
 def post_process_module(module: Module) -> tuple[Module, dict[int, str]]:
     """
     Post-processes a module by adding loop names and operation names
     and builds a mapping from node IDs to function names.
-    
+
     Args:
         module: The MLIR module to process.
-        
+
     Returns:
         the processed module and a dictionary mapping node IDs to function names.
     """
     loop_counter = 0
     node_to_fn = {}
-    
+
     def process_op(op, func_name):
         nonlocal loop_counter
-        
+
         if isinstance(op, affine_d.AffineForOp):
             if "loop_name" not in op.attributes:
                 op.attributes["loop_name"] = StringAttr.get(f"L_{loop_counter}")
                 loop_counter += 1
-            
+
             if "top_level" in op.attributes:
                 assert "node_id" in op.attributes
                 node_id = int(op.attributes["node_id"].value)
-                
+
                 node_to_fn[node_id] = func_name
-            
+
                 if "op_name" not in op.attributes:
                     op.attributes["op_name"] = StringAttr.get(f"kernel_{node_id}")
 
                 del op.attributes["top_level"]
                 del op.attributes["node_id"]
-            
+
             for nested_op in op.body.operations:
                 process_op(nested_op, func_name)
         elif hasattr(op, "regions"):
@@ -455,49 +487,52 @@ def post_process_module(module: Module) -> tuple[Module, dict[int, str]]:
                 for block in region.blocks:
                     for nested_op in block.operations:
                         process_op(nested_op, func_name)
-    
+
     with module.context:
         for func in module.body.operations:
             if not isinstance(func, func_d.FuncOp):
                 continue
-            
+
             func_name = func.name.value
-            
+
             for op in func.body.blocks[0]:
                 process_op(op, func_name)
 
     return module, node_to_fn
 
-            
-def extract_reorder_and_pipeline(permutations, dfg: DFG, node_to_fn: dict[int, str], schedule: Schedule) -> list[SchedulePrimitive]:
+
+def extract_reorder_and_pipeline(
+    permutations, dfg: DFG, node_to_fn: dict[int, str], schedule: Schedule
+) -> list[SchedulePrimitive]:
     schedule_primitives = []
     for node_id, perm_idx in permutations:
-        loop_band_collection = list(v for _, v in schedule.get_loops(node_to_fn[node_id]).__iter__())
+        loop_band_collection = list(
+            v for _, v in schedule.get_loops(node_to_fn[node_id])
+        )
         # support only perfect affine kernels
-        assert len(loop_band_collection) == 1, "Only perfect affine kernels are supported"
+        assert (
+            len(loop_band_collection) == 1
+        ), "Only perfect affine kernels are supported"
         loop_band = list(loop_band_collection[0].loops.values())
 
         node_info: NodeInfo = dfg.get_node(node_id).node_info[perm_idx]
         if perm_idx == 0:
-            schedule_primitives.append(
-                Pipeline(loop_band[-1], ii=node_info.II)
-            )
-        else: 
+            schedule_primitives.append(Pipeline(loop_band[-1], ii=node_info.II))
+        else:
             perm = node_info.permutation
             new_loop_order = [loop_band[i] for i in perm]
-            schedule_primitives.append(
-                Reorder(new_loop_order)
-            )
-            schedule_primitives.append(
-                Pipeline(new_loop_order[-1], ii=node_info.II)
-            )
-    
+            schedule_primitives.append(Reorder(new_loop_order))
+            schedule_primitives.append(Pipeline(new_loop_order[-1], ii=node_info.II))
+
     return schedule_primitives
 
-def extract_buffer_to_fifo(permutations, dfg: DFG, node_to_fn: dict[int, str], schedule: Schedule):
+
+def extract_buffer_to_fifo(
+    permutations, dfg: DFG, node_to_fn: dict[int, str], schedule: Schedule
+):
     unnamed_ct = 0
     top_level_fn_name = schedule.top_func_name
-    permutations = {node_idx: perm_idx for node_idx, perm_idx in permutations}
+    permutations = dict(permutations)
     schedule_primitives = []
     for node_idx, node in dfg.nodes.items():
         if node.type != DFGNodeType.AFFINE:
@@ -506,23 +541,31 @@ def extract_buffer_to_fifo(permutations, dfg: DFG, node_to_fn: dict[int, str], s
         for edge in dfg.in_edges[node_idx]:
             src_node = dfg.nodes[edge.id]
             if src_node.type != DFGNodeType.AFFINE:
-                continue 
+                continue
             src_node_info = src_node.node_info[permutations[edge.id]]
-            memref = edge.value 
+            memref = edge.value
             assert memref in dst_node_info.loads_map
             assert memref in src_node_info.stores_map
-            if dst_node_info.loads_map[memref].access_map == src_node_info.stores_map[memref].access_map:
+            if (
+                dst_node_info.loads_map[memref].access_map
+                == src_node_info.stores_map[memref].access_map
+            ):
                 if "name" not in memref.owner.attributes:
                     with schedule.module.context:
-                        memref.owner.attributes["name"] = StringAttr.get(f"fifo_buffer_{unnamed_ct}")
-                        dst_node_info.loads_map[memref].op.attributes["from"] = StringAttr.get(f"fifo_buffer_{unnamed_ct}")
-                        src_node_info.stores_map[memref].op.attributes["to"] = StringAttr.get(f"fifo_buffer_{unnamed_ct}")
+                        memref.owner.attributes["name"] = StringAttr.get(
+                            f"fifo_buffer_{unnamed_ct}"
+                        )
+                        dst_node_info.loads_map[memref].op.attributes["from"] = (
+                            StringAttr.get(f"fifo_buffer_{unnamed_ct}")
+                        )
+                        src_node_info.stores_map[memref].op.attributes["to"] = (
+                            StringAttr.get(f"fifo_buffer_{unnamed_ct}")
+                        )
                     unnamed_ct += 1
-                buffer = MockBuffer(top_level_fn_name, memref.owner.attributes["name"].value)
-                fn_name = node_to_fn[node_idx]
-                schedule_primitives.append(
-                    BufferToFifo(buffer, fn_name)
+                buffer = MockBuffer(
+                    top_level_fn_name, memref.owner.attributes["name"].value
                 )
-            
+                fn_name = node_to_fn[node_idx]
+                schedule_primitives.append(BufferToFifo(buffer, fn_name))
+
     return schedule_primitives
-            

--- a/allo/autoscheduler/passes.py
+++ b/allo/autoscheduler/passes.py
@@ -111,6 +111,7 @@ def dataflow_optimization_pass(
         verify = False
 
     if verify:
+        # hacky clone
         mod_outlined_clone = Module.parse(mod_outlined.operation.get_asm(), mod_outlined.context)
         original_schedule = Schedule(
             mod_outlined_clone,
@@ -138,14 +139,8 @@ def dataflow_optimization_pass(
         case _:
             raise ValueError(f"Invalid parallelism model: {kind}")
     
-    # apply schedule primitives
-    print(schedule.module)
-
     for primitive in schedule_primitives:
-        print(primitive)
         primitive.applyTo(schedule)
-
-    print("+"*100)
     
     if verify:
         verifier = allo.verify(schedule, original_schedule)
@@ -533,10 +528,3 @@ def extract_buffer_to_fifo(permutations, dfg: DFG, node_to_fn: dict[int, str], s
             
     return schedule_primitives
             
-
-# def build_dataflow_graph(module: Module):
-#     pass
-
-
-# def build_performance_model(module: Module, dfg):
-#     pass

--- a/allo/autoscheduler/passes.py
+++ b/allo/autoscheduler/passes.py
@@ -123,13 +123,13 @@ def dataflow_optimization_pass(
         )
     
     schedule_primitives = []
-
+    fifo_primitives = []
     # build performance model
     match kind:
         case "graph":
             permutations = dfg.create_graph_parallelism_performance_model()
             schedule_primitives.extend(extract_reorder_and_pipeline(permutations, dfg, node_to_fn, schedule))
-            schedule_primitives.extend(extract_buffer_to_fifo(permutations, dfg, node_to_fn, schedule))
+            fifo_primitives.extend(extract_buffer_to_fifo(permutations, dfg, node_to_fn, schedule))
         case "node":
             # TODO: implement node parallelism performance model
             pass
@@ -144,7 +144,10 @@ def dataflow_optimization_pass(
     
     if verify:
         verifier = allo.verify(schedule, original_schedule)
-        assert verifier, "Schedule is not equivalent to original schedule"
+        assert verifier, "Failed verification: Schedule is not equivalent to original schedule"
+    
+    for primitive in fifo_primitives:
+        primitive.applyTo(schedule)
         
     return schedule
 

--- a/allo/autoscheduler/primitives.py
+++ b/allo/autoscheduler/primitives.py
@@ -4,30 +4,38 @@ from typing import Any
 from allo.customize import Schedule
 from allo.ir.utils import MockBuffer
 
+
 class SchedulePrimitive:
-    def __init__(self, args: list[Any]=None, kwargs: dict[str, Any]=None):
+    def __init__(self, args: list[Any] = None, kwargs: dict[str, Any] = None):
         self.args = args or []
         self.kwargs = kwargs or {}
+
     def __repr__(self):
         return f"{self.__class__.__name__}: {self.args}"
-    
+
     def applyTo(self, _schedule: Schedule):
         pass
+
 
 class Reorder(SchedulePrimitive):
     def __init__(self, order: list[str]):
         super().__init__(order)
+
     def applyTo(self, schedule: Schedule):
         schedule.reorder(*self.args)
+
 
 class Pipeline(SchedulePrimitive):
     def __init__(self, axis: str, ii: int):
         super().__init__([axis], {"initiation_interval": ii})
+
     def applyTo(self, schedule: Schedule):
         schedule.pipeline(*self.args, **self.kwargs)
+
 
 class BufferToFifo(SchedulePrimitive):
     def __init__(self, target: MockBuffer, dst: str):
         super().__init__([target, dst])
+
     def applyTo(self, schedule: Schedule):
         schedule.to(*self.args)

--- a/allo/autoscheduler/primitives.py
+++ b/allo/autoscheduler/primitives.py
@@ -1,0 +1,33 @@
+# Copyright Allo authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+from typing import Any
+from allo.customize import Schedule
+from allo.ir.utils import MockBuffer
+
+class SchedulePrimitive:
+    def __init__(self, args: list[Any]=None, kwargs: dict[str, Any]=None):
+        self.args = args or []
+        self.kwargs = kwargs or {}
+    def __repr__(self):
+        return f"{self.__class__.__name__}: {self.args}"
+    
+    def applyTo(self, _schedule: Schedule):
+        pass
+
+class Reorder(SchedulePrimitive):
+    def __init__(self, order: list[str]):
+        super().__init__(order)
+    def applyTo(self, schedule: Schedule):
+        schedule.reorder(*self.args)
+
+class Pipeline(SchedulePrimitive):
+    def __init__(self, axis: str, ii: int):
+        super().__init__([axis], {"initiation_interval": ii})
+    def applyTo(self, schedule: Schedule):
+        schedule.pipeline(*self.args, **self.kwargs)
+
+class BufferToFifo(SchedulePrimitive):
+    def __init__(self, target: MockBuffer, dst: str):
+        super().__init__([target, dst])
+    def applyTo(self, schedule: Schedule):
+        schedule.to(*self.args)

--- a/allo/autoscheduler/util.py
+++ b/allo/autoscheduler/util.py
@@ -1,7 +1,7 @@
 # Copyright Allo authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 from collections import defaultdict
-from typing import NamedTuple, Any
+from typing import NamedTuple
 
 from allo._mlir.ir import (
     Location,

--- a/allo/autoscheduler/util.py
+++ b/allo/autoscheduler/util.py
@@ -500,4 +500,3 @@ def estimate_critical_path(load_op, store_op, latencies):
             break
 
     return max(path_latency, min_latency)
-

--- a/allo/autoscheduler/util.py
+++ b/allo/autoscheduler/util.py
@@ -1,7 +1,8 @@
 # Copyright Allo authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 from collections import defaultdict
-from typing import NamedTuple
+from typing import NamedTuple, Any
+
 from allo._mlir.ir import (
     Location,
     Module,
@@ -499,3 +500,4 @@ def estimate_critical_path(load_op, store_op, latencies):
             break
 
     return max(path_latency, min_latency)
+

--- a/allo/ir/transform.py
+++ b/allo/ir/transform.py
@@ -57,10 +57,12 @@ class LoopBand:
             case LoopWrapper():
                 return outer.loop
             case LoopBand():
-                raise ValueError("get_outer_most() is not supported for top-level LoopBand collection, use __iter__() instead")
+                raise ValueError(
+                    "get_outer_most() is not supported for top-level LoopBand collection, use __iter__() instead"
+                )
             case _:
                 raise ValueError(f"Unexpected type: {type(outer)}")
-    
+
     def __repr__(self):
         return f"LoopBand({list(self.loops.keys())})"
 

--- a/allo/ir/transform.py
+++ b/allo/ir/transform.py
@@ -52,8 +52,15 @@ class LoopBand:
         setattr(self, name, loop)
 
     def get_outer_most(self):
-        return next(self.loops.values().__iter__()).loop
-
+        outer = next(self.loops.values().__iter__())
+        match outer:
+            case LoopWrapper():
+                return outer.loop
+            case LoopBand():
+                raise ValueError("get_outer_most() is not supported for top-level LoopBand collection, use __iter__() instead")
+            case _:
+                raise ValueError(f"Unexpected type: {type(outer)}")
+    
     def __repr__(self):
         return f"LoopBand({list(self.loops.keys())})"
 

--- a/examples/polybench/gesummv.py
+++ b/examples/polybench/gesummv.py
@@ -45,7 +45,7 @@ def compute_y[T: (float32, int32), N: int32](y_in: "T[N]", y_out: "T[N]", tmp: "
 def kernel_gesummv[
     T: (float32, int32), N: int32
 ](A: "T[N, N]", B: "T[N, N]", x: "T[N]", y: "T[N]"):
-    y_init: T[N]
+    y_init: T[N] = 0
     y_fifo: T[N]
     tmp: T[N]
     compute_tmp(y_init, y_fifo, A, B, x, tmp)

--- a/examples/polybench/gesummv.py
+++ b/examples/polybench/gesummv.py
@@ -45,9 +45,9 @@ def compute_y[T: (float32, int32), N: int32](y_in: "T[N]", y_out: "T[N]", tmp: "
 def kernel_gesummv[
     T: (float32, int32), N: int32
 ](A: "T[N, N]", B: "T[N, N]", x: "T[N]", y: "T[N]"):
-    y_init: T[N] = 0.0
-    y_fifo: T[N] = 0.0
-    tmp: T[N] = 0.0
+    y_init: T[N]
+    y_fifo: T[N]
+    tmp: T[N]
     compute_tmp(y_init, y_fifo, A, B, x, tmp)
     compute_y(y_fifo, y, tmp)
 

--- a/tests/autoscheduler/test_autoscheduler.py
+++ b/tests/autoscheduler/test_autoscheduler.py
@@ -32,6 +32,27 @@ def test_simple():
     permutations = dfg.create_graph_parallelism_performance_model(debug_output="simple")
     assert permutations[0][1] != permutations[1][1]
 
+def test_simple2():
+    def simple() -> int32[10, 10]:
+        A: int32[10, 10]
+        B: int32[10, 10]
+        for i in range(10):
+            for j in range(10):
+                A[i, j] = i + j
+
+        for i in range(10):
+            for j in range(10):
+                B[i, j] = A[i, j] + 1
+
+        return B
+
+    s = allo.customize(simple)
+    s = dataflow_optimization_pass(s, debug_point="dataflow_canonicalization")
+    dfg = DFG.from_module(s.module)
+    dfg.print_as_dot("simple2.dot")
+    permutations = dfg.create_graph_parallelism_performance_model(debug_output="simple2")
+    assert permutations[0][1] == permutations[1][1]
+
 
 def matrix_multiply(A: int32[8, 8], B: int32[8, 8]) -> int32[8, 8]:
     C: int32[8, 8] = 0

--- a/tests/autoscheduler/test_autoscheduler.py
+++ b/tests/autoscheduler/test_autoscheduler.py
@@ -32,6 +32,7 @@ def test_simple():
     permutations = dfg.create_graph_parallelism_performance_model(debug_output="simple")
     assert permutations[0][1] != permutations[1][1]
 
+
 def test_simple2():
     def simple() -> int32[10, 10]:
         A: int32[10, 10]
@@ -50,7 +51,9 @@ def test_simple2():
     s = dataflow_optimization_pass(s, debug_point="dataflow_canonicalization")
     dfg = DFG.from_module(s.module)
     dfg.print_as_dot("simple2.dot")
-    permutations = dfg.create_graph_parallelism_performance_model(debug_output="simple2")
+    permutations = dfg.create_graph_parallelism_performance_model(
+        debug_output="simple2"
+    )
     assert permutations[0][1] == permutations[1][1]
 
 

--- a/tests/autoscheduler/test_dfg.py
+++ b/tests/autoscheduler/test_dfg.py
@@ -127,18 +127,33 @@ def test_node_info():
 
         # check access pattern
         permuted_access_map = compose_affine_maps(inverse_loop_map, original_access_map)
-        assert permuted_access_map == info.stores_map[affine_node.stores[0]].accessMap
-        assert permuted_access_map == info.loads_map[affine_node.loads[0]].accessMap
+        assert (
+            permuted_access_map
+            == info.stores_map[affine_node.stores[0].opview.memref].access_map
+        )
+        assert (
+            permuted_access_map
+            == info.loads_map[affine_node.loads[0].opview.memref].access_map
+        )
 
         # check II is 1 for all permutations
         assert info.II == 1
 
         # check first and last access times
-        assert info.stores_map[affine_node.stores[0]].first_element_time == 0
-        assert info.loads_map[affine_node.loads[0]].first_element_time == 0
+        assert (
+            info.stores_map[affine_node.stores[0].opview.memref].first_element_time == 0
+        )
+        assert (
+            info.loads_map[affine_node.loads[0].opview.memref].first_element_time == 0
+        )
 
-        assert info.stores_map[affine_node.stores[0]].last_element_time == 499
-        assert info.loads_map[affine_node.loads[0]].last_element_time == 499
+        assert (
+            info.stores_map[affine_node.stores[0].opview.memref].last_element_time
+            == 499
+        )
+        assert (
+            info.loads_map[affine_node.loads[0].opview.memref].last_element_time == 499
+        )
 
 
 def test_DSP():

--- a/tests/autoscheduler/test_passes.py
+++ b/tests/autoscheduler/test_passes.py
@@ -50,12 +50,11 @@ def test_simple(debug_point, kind):
         else optimized_schedule.build(target="vitis_hls")
     )
 
-    expected = np.zeros((10, 10))
-    for i in range(10):
-        for j in range(10):
-            expected[i, j] = i + j + 1
-
     if debug_point is not None or is_available("vitis_hls"):
+        expected = np.zeros((10, 10))
+        for i in range(10):
+            for j in range(10):
+                expected[i, j] = i + j + 1
         np.testing.assert_allclose(mod(), expected)
 
 

--- a/tests/autoscheduler/test_passes.py
+++ b/tests/autoscheduler/test_passes.py
@@ -67,7 +67,7 @@ def test_three_mm(debug_point, kind):
     )
     try:
         optimized_schedule = dataflow_optimization_pass(
-            schedule, debug_point=debug_point, kind=kind
+            schedule, debug_point=debug_point, kind=kind, verbose=True
         )
     except GurobiError as e:
         if "Model too large for size-limited license" in str(e):

--- a/tests/autoscheduler/test_passes.py
+++ b/tests/autoscheduler/test_passes.py
@@ -1,118 +1,185 @@
 # Copyright Allo authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from allo.ir.utils import MockBuffer
 import numpy as np
 import pytest
-from allo.ir.types import float32
+from allo.ir.types import float32, int32
 from allo.autoscheduler.passes import dataflow_optimization_pass, DEBUG_POINTS
 from tests.autoscheduler.polybench import get_polybench
+import allo
 
+kinds = [
+    None,
+    "graph",
+    # "node",
+    # "combined"
+]
 
-@pytest.mark.parametrize("debug_point", DEBUG_POINTS)
-def test_three_mm(debug_point):
-    schedule, inputs, expected = get_polybench(
-        "three_mm", size="small", concrete_type=float32
-    )
-    optimized_schedule = dataflow_optimization_pass(schedule, debug_point=debug_point)
+@pytest.mark.parametrize("debug_point", DEBUG_POINTS)   
+@pytest.mark.parametrize("kind", kinds)
+def test_simple(debug_point, kind):
+    if (debug_point is not None and kind is None) or (debug_point is None and kind is None):
+        pytest.skip("Skipping redundant test")
+
+    def simple() -> int32[10, 10]:
+        def stageA() -> int32[10, 10]:
+            A: int32[10, 10]
+            for j in range(10):
+                for i in range(10):
+                    A[i, j] = i + j
+            return A
+
+        def stageB(A: int32[10, 10]) -> int32[10, 10]:
+            B: int32[10, 10]
+            for i in range(10):
+                for j in range(10):
+                    B[i, j] = A[i, j] + 1
+            return B
+
+        A = stageA()
+        B = stageB(A)
+        return B
+
+    s = allo.customize(simple)
+    optimized_schedule = dataflow_optimization_pass(s, debug_point=debug_point, kind=kind)
+    expected = np.zeros((10, 10))
+    for i in range(10):
+        for j in range(10):
+            expected[i, j] = i + j + 1
+
+    if debug_point is None and kind is not None: 
+        print(optimized_schedule.module)
+        assert False
+
     mod = optimized_schedule.build()
 
-    actual = mod(*inputs)
+    np.testing.assert_allclose(mod(), expected)
 
-    np.testing.assert_allclose(actual, expected, rtol=1e-5, atol=1e-5)
+# @pytest.mark.parametrize("debug_point", DEBUG_POINTS)
+# @pytest.mark.parametrize("kind", kinds)
+# def test_three_mm(debug_point, kind):
+#     if debug_point is not None and kind is None:
+#         pytest.skip("Skipping redundant test")
 
+#     schedule, inputs, expected = get_polybench(
+#         "three_mm", size="small", concrete_type=float32
+#     )
+#     optimized_schedule = dataflow_optimization_pass(schedule, debug_point=debug_point, kind=kind)
+#     mod = optimized_schedule.build()
 
-@pytest.mark.parametrize("debug_point", DEBUG_POINTS)
-def test_two_mm(debug_point):
-    schedule, inputs, expected = get_polybench(
-        "two_mm", size="small", concrete_type=float32
-    )
-    optimized_schedule = dataflow_optimization_pass(schedule, debug_point=debug_point)
-    mod = optimized_schedule.build()
+#     actual = mod(*inputs)
 
-    actual = mod(*inputs)
-
-    np.testing.assert_allclose(actual, expected, rtol=1e-5, atol=1e-5)
-
-
-@pytest.mark.parametrize("debug_point", DEBUG_POINTS)
-def test_atax(debug_point):
-    schedule, inputs, expected = get_polybench(
-        "atax", size="small", concrete_type=float32
-    )
-    optimized_schedule = dataflow_optimization_pass(schedule, debug_point=debug_point)
-    mod = optimized_schedule.build()
-
-    A, x, y = inputs
-    y_out = np.zeros_like(y)
-    mod(A, x, y_out)
-
-    np.testing.assert_allclose(y_out, expected, rtol=1e-5, atol=1e-5)
+#     np.testing.assert_allclose(actual, expected, rtol=1e-5, atol=1e-5)
 
 
 # @pytest.mark.parametrize("debug_point", DEBUG_POINTS)
-# def test_bicg(debug_point):
+# @pytest.mark.parametrize("kind", kinds)
+# def test_two_mm(debug_point, kind):
+#     if debug_point is not None and kind is None:
+#         pytest.skip("Skipping redundant test")
+
 #     schedule, inputs, expected = get_polybench(
-#         "bicg", size="small", concrete_type=float32
+#         "two_mm", size="small", concrete_type=float32
 #     )
-#     optimized_schedule = dataflow_optimization_pass(schedule, debug_point=debug_point)
+#     optimized_schedule = dataflow_optimization_pass(schedule, debug_point=debug_point, kind=kind)
 #     mod = optimized_schedule.build()
 
-#     A, A_copy, s, q, p, r = inputs
-#     q_out = np.zeros_like(q)
-#     s_out = np.zeros_like(s)
-#     mod(A, A_copy, p, r, q_out, s_out)
+#     actual = mod(*inputs)
 
-#     expected_q, expected_s = expected
-#     np.testing.assert_allclose(q_out, expected_q)
-#     np.testing.assert_allclose(s_out, expected_s)
+#     np.testing.assert_allclose(actual, expected, rtol=1e-5, atol=1e-5)
 
+# @pytest.mark.parametrize("debug_point", DEBUG_POINTS)
+# @pytest.mark.parametrize("kind", kinds)
+# def test_atax(debug_point, kind):
+#     if debug_point is not None and kind is None:
+#         pytest.skip("Skipping redundant test")
 
-@pytest.mark.parametrize("debug_point", DEBUG_POINTS)
-def test_gemm(debug_point):
-    schedule, inputs, expected = get_polybench(
-        "gemm", size="small", concrete_type=float32
-    )
-    optimized_schedule = dataflow_optimization_pass(schedule, debug_point=debug_point)
-    mod = optimized_schedule.build()
+#     schedule, inputs, expected = get_polybench(
+#         "atax", size="small", concrete_type=float32
+#     )
+#     optimized_schedule = dataflow_optimization_pass(schedule, debug_point=debug_point, kind=kind)
+#     mod = optimized_schedule.build()
 
-    A, B, C = inputs
-    output = np.zeros_like(expected)
-    mod(A, B, C, output)
+#     A, x, y = inputs
+#     y_out = np.zeros_like(y)
+#     mod(A, x, y_out)
 
-    np.testing.assert_allclose(output, expected, rtol=1e-5, atol=1e-5)
+#     np.testing.assert_allclose(y_out, expected, rtol=1e-5, atol=1e-5)
 
 
-@pytest.mark.parametrize("debug_point", DEBUG_POINTS)
-def test_gesummv(debug_point):
-    schedule, inputs, expected = get_polybench(
-        "gesummv", size="small", concrete_type=float32
-    )
-    optimized_schedule = dataflow_optimization_pass(schedule, debug_point=debug_point)
-    mod = optimized_schedule.build()
+# # @pytest.mark.parametrize("debug_point", DEBUG_POINTS)
+# # def test_bicg(debug_point):
+# #     schedule, inputs, expected = get_polybench(
+# #         "bicg", size="small", concrete_type=float32
+# #     )
+# #     optimized_schedule = dataflow_optimization_pass(schedule, debug_point=debug_point)
+# #     mod = optimized_schedule.build()
 
-    A, B, x = inputs
-    y = np.zeros_like(expected)
-    mod(A, B, x, y)
+# #     A, A_copy, s, q, p, r = inputs
+# #     q_out = np.zeros_like(q)
+# #     s_out = np.zeros_like(s)
+# #     mod(A, A_copy, p, r, q_out, s_out)
 
-    np.testing.assert_allclose(y, expected, rtol=1e-5, atol=1e-5)
+# #     expected_q, expected_s = expected
+# #     np.testing.assert_allclose(q_out, expected_q)
+# #     np.testing.assert_allclose(s_out, expected_s)
 
 
 # @pytest.mark.parametrize("debug_point", DEBUG_POINTS)
-# def test_mvt(debug_point):
+# @pytest.mark.parametrize("kind", kinds)
+# def test_gemm(debug_point, kind):
+#     if debug_point is not None and kind is None:
+#         pytest.skip("Skipping redundant test")
+
 #     schedule, inputs, expected = get_polybench(
-#         "mvt", size="small", concrete_type=float32
+#         "gemm", size="small", concrete_type=float32
 #     )
-#     optimized_schedule = dataflow_optimization_pass(schedule, debug_point=debug_point)
+#     optimized_schedule = dataflow_optimization_pass(schedule, debug_point=debug_point, kind=kind)
 #     mod = optimized_schedule.build()
 
-#     A, A_copy, y1, y2, x1, x2, x1_out, x2_out = inputs
-#     expected_x1, expected_x2 = expected
-#     out_x1 = np.zeros_like(x1)
-#     out_x2 = np.zeros_like(x2)
-#     mod(A, A_copy, y1, y2, x1, x2, out_x1, out_x2)
+#     A, B, C = inputs
+#     output = np.zeros_like(expected)
+#     mod(A, B, C, output)
 
-#     np.testing.assert_allclose(out_x1, expected_x1, rtol=1e-5, atol=1e-5)
-#     np.testing.assert_allclose(out_x2, expected_x2, rtol=1e-5, atol=1e-5)
+#     np.testing.assert_allclose(output, expected, rtol=1e-5, atol=1e-5)
+
+
+# @pytest.mark.parametrize("debug_point", DEBUG_POINTS)
+# @pytest.mark.parametrize("kind", kinds)
+# def test_gesummv(debug_point, kind):
+#     if debug_point is not None and kind is None:
+#         pytest.skip("Skipping redundant test")
+
+#     schedule, inputs, expected = get_polybench(
+#         "gesummv", size="small", concrete_type=float32
+#     )
+#     optimized_schedule = dataflow_optimization_pass(schedule, debug_point=debug_point, kind=kind)
+#     mod = optimized_schedule.build()
+
+#     A, B, x = inputs
+#     y = np.zeros_like(expected)
+#     mod(A, B, x, y)
+
+#     np.testing.assert_allclose(y, expected, rtol=1e-5, atol=1e-5)
+
+
+# # @pytest.mark.parametrize("debug_point", DEBUG_POINTS)
+# # def test_mvt(debug_point):
+# #     schedule, inputs, expected = get_polybench(
+# #         "mvt", size="small", concrete_type=float32
+# #     )
+# #     optimized_schedule = dataflow_optimization_pass(schedule, debug_point=debug_point)
+# #     mod = optimized_schedule.build()
+
+# #     A, A_copy, y1, y2, x1, x2, x1_out, x2_out = inputs
+# #     expected_x1, expected_x2 = expected
+# #     out_x1 = np.zeros_like(x1)
+# #     out_x2 = np.zeros_like(x2)
+# #     mod(A, A_copy, y1, y2, x1, x2, out_x1, out_x2)
+
+# #     np.testing.assert_allclose(out_x1, expected_x1, rtol=1e-5, atol=1e-5)
+# #     np.testing.assert_allclose(out_x2, expected_x2, rtol=1e-5, atol=1e-5)
 
 
 if __name__ == "__main__":

--- a/tests/autoscheduler/test_passes.py
+++ b/tests/autoscheduler/test_passes.py
@@ -1,6 +1,7 @@
 # Copyright Allo authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from gurobipy import GurobiError
 from allo.ir.utils import MockBuffer
 import numpy as np
 import pytest
@@ -64,9 +65,18 @@ def test_three_mm(debug_point, kind):
     schedule, inputs, expected = get_polybench(
         "three_mm", size="small", concrete_type=float32
     )
-    optimized_schedule = dataflow_optimization_pass(
-        schedule, debug_point=debug_point, kind=kind
-    )
+    try:
+        optimized_schedule = dataflow_optimization_pass(
+            schedule, debug_point=debug_point, kind=kind
+        )
+    except GurobiError as e:
+        if "Model too large for size-limited license" in str(e):
+            pytest.skip(
+                "Skipping test: model too large for size-limited Gurobi license"
+            )
+        else:
+            raise e
+
     mod = (
         optimized_schedule.build()
         if debug_point is not None
@@ -84,9 +94,15 @@ def test_two_mm(debug_point, kind):
     schedule, inputs, expected = get_polybench(
         "two_mm", size="small", concrete_type=float32
     )
-    optimized_schedule = dataflow_optimization_pass(
-        schedule, debug_point=debug_point, kind=kind
-    )
+    try:
+        optimized_schedule = dataflow_optimization_pass(
+            schedule, debug_point=debug_point, kind=kind
+        )
+    except GurobiError as e:
+        if "Model too large for size-limited license" in str(e):
+            pytest.skip(
+                "Skipping test: model too large for size-limited Gurobi license"
+            )
     mod = (
         optimized_schedule.build()
         if debug_point is not None
@@ -104,9 +120,18 @@ def test_atax(debug_point, kind):
     schedule, inputs, expected = get_polybench(
         "atax", size="small", concrete_type=float32
     )
-    optimized_schedule = dataflow_optimization_pass(
-        schedule, debug_point=debug_point, kind=kind
-    )
+    try:
+        optimized_schedule = dataflow_optimization_pass(
+            schedule, debug_point=debug_point, kind=kind
+        )
+    except GurobiError as e:
+        if "Model too large for size-limited license" in str(e):
+            pytest.skip(
+                "Skipping test: model too large for size-limited Gurobi license"
+            )
+        else:
+            raise e
+
     mod = (
         optimized_schedule.build()
         if debug_point is not None
@@ -144,9 +169,18 @@ def test_gemm(debug_point, kind):
     schedule, inputs, expected = get_polybench(
         "gemm", size="small", concrete_type=float32
     )
-    optimized_schedule = dataflow_optimization_pass(
-        schedule, debug_point=debug_point, kind=kind
-    )
+    try:
+        optimized_schedule = dataflow_optimization_pass(
+            schedule, debug_point=debug_point, kind=kind
+        )
+    except GurobiError as e:
+        if "Model too large for size-limited license" in str(e):
+            pytest.skip(
+                "Skipping test: model too large for size-limited Gurobi license"
+            )
+        else:
+            raise e
+
     mod = (
         optimized_schedule.build()
         if debug_point is not None
@@ -166,9 +200,17 @@ def test_gesummv(debug_point, kind):
     schedule, inputs, expected = get_polybench(
         "gesummv", size="small", concrete_type=float32
     )
-    optimized_schedule = dataflow_optimization_pass(
-        schedule, debug_point=debug_point, kind=kind
-    )
+    try:
+        optimized_schedule = dataflow_optimization_pass(
+            schedule, debug_point=debug_point, kind=kind
+        )
+    except GurobiError as e:
+        if "Model too large for size-limited license" in str(e):
+            pytest.skip(
+                "Skipping test: model too large for size-limited Gurobi license"
+            )
+        else:
+            raise e
 
     mod = (
         optimized_schedule.build()

--- a/tests/autoscheduler/test_passes.py
+++ b/tests/autoscheduler/test_passes.py
@@ -8,9 +8,9 @@ from allo.ir.types import float32, int32
 from allo.autoscheduler.passes import dataflow_optimization_pass, DEBUG_POINTS
 from tests.autoscheduler.polybench import get_polybench
 import allo
+from allo.backend.hls import is_available
 
 kinds = [
-    None,
     "graph",
     # "node",
     # "combined"
@@ -19,9 +19,6 @@ kinds = [
 @pytest.mark.parametrize("debug_point", DEBUG_POINTS)   
 @pytest.mark.parametrize("kind", kinds)
 def test_simple(debug_point, kind):
-    if (debug_point is not None and kind is None) or (debug_point is None and kind is None):
-        pytest.skip("Skipping redundant test")
-
     def simple() -> int32[10, 10]:
         def stageA() -> int32[10, 10]:
             A: int32[10, 10]
@@ -43,143 +40,131 @@ def test_simple(debug_point, kind):
 
     s = allo.customize(simple)
     optimized_schedule = dataflow_optimization_pass(s, debug_point=debug_point, kind=kind)
+    
+    mod = optimized_schedule.build() if debug_point is not None else optimized_schedule.build(target="vitis_hls")
+
+    
     expected = np.zeros((10, 10))
     for i in range(10):
         for j in range(10):
             expected[i, j] = i + j + 1
+    
+    if debug_point is not None or is_available("vitis_hls"):   
+        np.testing.assert_allclose(mod(), expected)
 
-    if debug_point is None and kind is not None: 
-        print(optimized_schedule.module)
-        assert False
-
-    mod = optimized_schedule.build()
-
-    np.testing.assert_allclose(mod(), expected)
-
-# @pytest.mark.parametrize("debug_point", DEBUG_POINTS)
-# @pytest.mark.parametrize("kind", kinds)
-# def test_three_mm(debug_point, kind):
-#     if debug_point is not None and kind is None:
-#         pytest.skip("Skipping redundant test")
-
-#     schedule, inputs, expected = get_polybench(
-#         "three_mm", size="small", concrete_type=float32
-#     )
-#     optimized_schedule = dataflow_optimization_pass(schedule, debug_point=debug_point, kind=kind)
-#     mod = optimized_schedule.build()
-
-#     actual = mod(*inputs)
-
-#     np.testing.assert_allclose(actual, expected, rtol=1e-5, atol=1e-5)
+@pytest.mark.parametrize("debug_point", DEBUG_POINTS)
+@pytest.mark.parametrize("kind", kinds)
+def test_three_mm(debug_point, kind):
+    schedule, inputs, expected = get_polybench(
+        "three_mm", size="small", concrete_type=float32
+    )
+    optimized_schedule = dataflow_optimization_pass(schedule, debug_point=debug_point, kind=kind)
+    mod = optimized_schedule.build() if debug_point is not None else optimized_schedule.build(target="vitis_hls")
 
 
-# @pytest.mark.parametrize("debug_point", DEBUG_POINTS)
-# @pytest.mark.parametrize("kind", kinds)
-# def test_two_mm(debug_point, kind):
-#     if debug_point is not None and kind is None:
-#         pytest.skip("Skipping redundant test")
-
-#     schedule, inputs, expected = get_polybench(
-#         "two_mm", size="small", concrete_type=float32
-#     )
-#     optimized_schedule = dataflow_optimization_pass(schedule, debug_point=debug_point, kind=kind)
-#     mod = optimized_schedule.build()
-
-#     actual = mod(*inputs)
-
-#     np.testing.assert_allclose(actual, expected, rtol=1e-5, atol=1e-5)
-
-# @pytest.mark.parametrize("debug_point", DEBUG_POINTS)
-# @pytest.mark.parametrize("kind", kinds)
-# def test_atax(debug_point, kind):
-#     if debug_point is not None and kind is None:
-#         pytest.skip("Skipping redundant test")
-
-#     schedule, inputs, expected = get_polybench(
-#         "atax", size="small", concrete_type=float32
-#     )
-#     optimized_schedule = dataflow_optimization_pass(schedule, debug_point=debug_point, kind=kind)
-#     mod = optimized_schedule.build()
-
-#     A, x, y = inputs
-#     y_out = np.zeros_like(y)
-#     mod(A, x, y_out)
-
-#     np.testing.assert_allclose(y_out, expected, rtol=1e-5, atol=1e-5)
+    if debug_point is not None or is_available("vitis_hls"):
+        actual = mod(*inputs)
+        np.testing.assert_allclose(actual, expected, rtol=1e-5, atol=1e-5)
 
 
-# # @pytest.mark.parametrize("debug_point", DEBUG_POINTS)
-# # def test_bicg(debug_point):
-# #     schedule, inputs, expected = get_polybench(
-# #         "bicg", size="small", concrete_type=float32
-# #     )
-# #     optimized_schedule = dataflow_optimization_pass(schedule, debug_point=debug_point)
-# #     mod = optimized_schedule.build()
+@pytest.mark.parametrize("debug_point", DEBUG_POINTS)
+@pytest.mark.parametrize("kind", kinds)
+def test_two_mm(debug_point, kind): 
+    schedule, inputs, expected = get_polybench(
+        "two_mm", size="small", concrete_type=float32
+    )
+    optimized_schedule = dataflow_optimization_pass(schedule, debug_point=debug_point, kind=kind)
+    mod = optimized_schedule.build() if debug_point is not None else optimized_schedule.build(target="vitis_hls")
 
-# #     A, A_copy, s, q, p, r = inputs
-# #     q_out = np.zeros_like(q)
-# #     s_out = np.zeros_like(s)
-# #     mod(A, A_copy, p, r, q_out, s_out)
+    if debug_point is not None or is_available("vitis_hls"):
+        actual = mod(*inputs)
+        np.testing.assert_allclose(actual, expected, rtol=1e-5, atol=1e-5)
 
-# #     expected_q, expected_s = expected
-# #     np.testing.assert_allclose(q_out, expected_q)
-# #     np.testing.assert_allclose(s_out, expected_s)
+@pytest.mark.parametrize("debug_point", DEBUG_POINTS)
+@pytest.mark.parametrize("kind", kinds)
+def test_atax(debug_point, kind):
+    schedule, inputs, expected = get_polybench(
+        "atax", size="small", concrete_type=float32
+    )
+    optimized_schedule = dataflow_optimization_pass(schedule, debug_point=debug_point, kind=kind)
+    mod = optimized_schedule.build() if debug_point is not None else optimized_schedule.build(target="vitis_hls")
+
+
+    if debug_point is not None or is_available("vitis_hls"):
+        A, x, y = inputs
+        y_out = np.zeros_like(y)
+        mod(A, x, y_out)
+        np.testing.assert_allclose(y_out, expected, rtol=1e-5, atol=1e-5)
 
 
 # @pytest.mark.parametrize("debug_point", DEBUG_POINTS)
-# @pytest.mark.parametrize("kind", kinds)
-# def test_gemm(debug_point, kind):
-#     if debug_point is not None and kind is None:
-#         pytest.skip("Skipping redundant test")
-
+# def test_bicg(debug_point):
 #     schedule, inputs, expected = get_polybench(
-#         "gemm", size="small", concrete_type=float32
+#         "bicg", size="small", concrete_type=float32
 #     )
-#     optimized_schedule = dataflow_optimization_pass(schedule, debug_point=debug_point, kind=kind)
+#     optimized_schedule = dataflow_optimization_pass(schedule, debug_point=debug_point)
 #     mod = optimized_schedule.build()
 
-#     A, B, C = inputs
-#     output = np.zeros_like(expected)
-#     mod(A, B, C, output)
+#     A, A_copy, s, q, p, r = inputs
+#     q_out = np.zeros_like(q)
+#     s_out = np.zeros_like(s)
+#     mod(A, A_copy, p, r, q_out, s_out)
 
-#     np.testing.assert_allclose(output, expected, rtol=1e-5, atol=1e-5)
+#     expected_q, expected_s = expected
+#     np.testing.assert_allclose(q_out, expected_q)
+#     np.testing.assert_allclose(s_out, expected_s)
+
+
+@pytest.mark.parametrize("debug_point", DEBUG_POINTS)
+@pytest.mark.parametrize("kind", kinds)
+def test_gemm(debug_point, kind):
+    schedule, inputs, expected = get_polybench(
+        "gemm", size="small", concrete_type=float32
+    )
+    optimized_schedule = dataflow_optimization_pass(schedule, debug_point=debug_point, kind=kind)
+    mod = optimized_schedule.build() if debug_point is not None else optimized_schedule.build(target="vitis_hls")
+
+    if debug_point is not None or is_available("vitis_hls"):
+        A, B, C = inputs
+        output = np.zeros_like(expected)
+        mod(A, B, C, output)
+        np.testing.assert_allclose(output, expected, rtol=1e-5, atol=1e-5)
+
+
+@pytest.mark.parametrize("debug_point", DEBUG_POINTS)
+@pytest.mark.parametrize("kind", kinds)
+def test_gesummv(debug_point, kind):
+    schedule, inputs, expected = get_polybench(
+        "gesummv", size="small", concrete_type=float32
+    )
+    optimized_schedule = dataflow_optimization_pass(schedule, debug_point=debug_point, kind=kind)
+
+
+    mod = optimized_schedule.build() if debug_point is not None else optimized_schedule.build(target="vitis_hls")
+
+    if debug_point is not None or is_available("vitis_hls"):
+        A, B, x = inputs
+        y = np.zeros_like(expected)
+        mod(A, B, x, y)
+        np.testing.assert_allclose(y, expected, rtol=1e-5, atol=1e-5)
 
 
 # @pytest.mark.parametrize("debug_point", DEBUG_POINTS)
-# @pytest.mark.parametrize("kind", kinds)
-# def test_gesummv(debug_point, kind):
-#     if debug_point is not None and kind is None:
-#         pytest.skip("Skipping redundant test")
-
+# def test_mvt(debug_point):
 #     schedule, inputs, expected = get_polybench(
-#         "gesummv", size="small", concrete_type=float32
+#         "mvt", size="small", concrete_type=float32
 #     )
-#     optimized_schedule = dataflow_optimization_pass(schedule, debug_point=debug_point, kind=kind)
+#     optimized_schedule = dataflow_optimization_pass(schedule, debug_point=debug_point)
 #     mod = optimized_schedule.build()
 
-#     A, B, x = inputs
-#     y = np.zeros_like(expected)
-#     mod(A, B, x, y)
+#     A, A_copy, y1, y2, x1, x2, x1_out, x2_out = inputs
+#     expected_x1, expected_x2 = expected
+#     out_x1 = np.zeros_like(x1)
+#     out_x2 = np.zeros_like(x2)
+#     mod(A, A_copy, y1, y2, x1, x2, out_x1, out_x2)
 
-#     np.testing.assert_allclose(y, expected, rtol=1e-5, atol=1e-5)
-
-
-# # @pytest.mark.parametrize("debug_point", DEBUG_POINTS)
-# # def test_mvt(debug_point):
-# #     schedule, inputs, expected = get_polybench(
-# #         "mvt", size="small", concrete_type=float32
-# #     )
-# #     optimized_schedule = dataflow_optimization_pass(schedule, debug_point=debug_point)
-# #     mod = optimized_schedule.build()
-
-# #     A, A_copy, y1, y2, x1, x2, x1_out, x2_out = inputs
-# #     expected_x1, expected_x2 = expected
-# #     out_x1 = np.zeros_like(x1)
-# #     out_x2 = np.zeros_like(x2)
-# #     mod(A, A_copy, y1, y2, x1, x2, out_x1, out_x2)
-
-# #     np.testing.assert_allclose(out_x1, expected_x1, rtol=1e-5, atol=1e-5)
-# #     np.testing.assert_allclose(out_x2, expected_x2, rtol=1e-5, atol=1e-5)
+#     np.testing.assert_allclose(out_x1, expected_x1, rtol=1e-5, atol=1e-5)
+#     np.testing.assert_allclose(out_x2, expected_x2, rtol=1e-5, atol=1e-5)
 
 
 if __name__ == "__main__":

--- a/tests/autoscheduler/test_passes.py
+++ b/tests/autoscheduler/test_passes.py
@@ -16,7 +16,8 @@ kinds = [
     # "combined"
 ]
 
-@pytest.mark.parametrize("debug_point", DEBUG_POINTS)   
+
+@pytest.mark.parametrize("debug_point", DEBUG_POINTS)
 @pytest.mark.parametrize("kind", kinds)
 def test_simple(debug_point, kind):
     def simple() -> int32[10, 10]:
@@ -39,18 +40,24 @@ def test_simple(debug_point, kind):
         return B
 
     s = allo.customize(simple)
-    optimized_schedule = dataflow_optimization_pass(s, debug_point=debug_point, kind=kind)
-    
-    mod = optimized_schedule.build() if debug_point is not None else optimized_schedule.build(target="vitis_hls")
+    optimized_schedule = dataflow_optimization_pass(
+        s, debug_point=debug_point, kind=kind
+    )
 
-    
+    mod = (
+        optimized_schedule.build()
+        if debug_point is not None
+        else optimized_schedule.build(target="vitis_hls")
+    )
+
     expected = np.zeros((10, 10))
     for i in range(10):
         for j in range(10):
             expected[i, j] = i + j + 1
-    
-    if debug_point is not None or is_available("vitis_hls"):   
+
+    if debug_point is not None or is_available("vitis_hls"):
         np.testing.assert_allclose(mod(), expected)
+
 
 @pytest.mark.parametrize("debug_point", DEBUG_POINTS)
 @pytest.mark.parametrize("kind", kinds)
@@ -58,9 +65,14 @@ def test_three_mm(debug_point, kind):
     schedule, inputs, expected = get_polybench(
         "three_mm", size="small", concrete_type=float32
     )
-    optimized_schedule = dataflow_optimization_pass(schedule, debug_point=debug_point, kind=kind)
-    mod = optimized_schedule.build() if debug_point is not None else optimized_schedule.build(target="vitis_hls")
-
+    optimized_schedule = dataflow_optimization_pass(
+        schedule, debug_point=debug_point, kind=kind
+    )
+    mod = (
+        optimized_schedule.build()
+        if debug_point is not None
+        else optimized_schedule.build(target="vitis_hls")
+    )
 
     if debug_point is not None or is_available("vitis_hls"):
         actual = mod(*inputs)
@@ -69,16 +81,23 @@ def test_three_mm(debug_point, kind):
 
 @pytest.mark.parametrize("debug_point", DEBUG_POINTS)
 @pytest.mark.parametrize("kind", kinds)
-def test_two_mm(debug_point, kind): 
+def test_two_mm(debug_point, kind):
     schedule, inputs, expected = get_polybench(
         "two_mm", size="small", concrete_type=float32
     )
-    optimized_schedule = dataflow_optimization_pass(schedule, debug_point=debug_point, kind=kind)
-    mod = optimized_schedule.build() if debug_point is not None else optimized_schedule.build(target="vitis_hls")
+    optimized_schedule = dataflow_optimization_pass(
+        schedule, debug_point=debug_point, kind=kind
+    )
+    mod = (
+        optimized_schedule.build()
+        if debug_point is not None
+        else optimized_schedule.build(target="vitis_hls")
+    )
 
     if debug_point is not None or is_available("vitis_hls"):
         actual = mod(*inputs)
         np.testing.assert_allclose(actual, expected, rtol=1e-5, atol=1e-5)
+
 
 @pytest.mark.parametrize("debug_point", DEBUG_POINTS)
 @pytest.mark.parametrize("kind", kinds)
@@ -86,9 +105,14 @@ def test_atax(debug_point, kind):
     schedule, inputs, expected = get_polybench(
         "atax", size="small", concrete_type=float32
     )
-    optimized_schedule = dataflow_optimization_pass(schedule, debug_point=debug_point, kind=kind)
-    mod = optimized_schedule.build() if debug_point is not None else optimized_schedule.build(target="vitis_hls")
-
+    optimized_schedule = dataflow_optimization_pass(
+        schedule, debug_point=debug_point, kind=kind
+    )
+    mod = (
+        optimized_schedule.build()
+        if debug_point is not None
+        else optimized_schedule.build(target="vitis_hls")
+    )
 
     if debug_point is not None or is_available("vitis_hls"):
         A, x, y = inputs
@@ -121,8 +145,14 @@ def test_gemm(debug_point, kind):
     schedule, inputs, expected = get_polybench(
         "gemm", size="small", concrete_type=float32
     )
-    optimized_schedule = dataflow_optimization_pass(schedule, debug_point=debug_point, kind=kind)
-    mod = optimized_schedule.build() if debug_point is not None else optimized_schedule.build(target="vitis_hls")
+    optimized_schedule = dataflow_optimization_pass(
+        schedule, debug_point=debug_point, kind=kind
+    )
+    mod = (
+        optimized_schedule.build()
+        if debug_point is not None
+        else optimized_schedule.build(target="vitis_hls")
+    )
 
     if debug_point is not None or is_available("vitis_hls"):
         A, B, C = inputs
@@ -137,10 +167,15 @@ def test_gesummv(debug_point, kind):
     schedule, inputs, expected = get_polybench(
         "gesummv", size="small", concrete_type=float32
     )
-    optimized_schedule = dataflow_optimization_pass(schedule, debug_point=debug_point, kind=kind)
+    optimized_schedule = dataflow_optimization_pass(
+        schedule, debug_point=debug_point, kind=kind
+    )
 
-
-    mod = optimized_schedule.build() if debug_point is not None else optimized_schedule.build(target="vitis_hls")
+    mod = (
+        optimized_schedule.build()
+        if debug_point is not None
+        else optimized_schedule.build(target="vitis_hls")
+    )
 
     if debug_point is not None or is_available("vitis_hls"):
         A, B, x = inputs


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This Autoscheduler (https://github.com/cornell-zhang/allo/discussions/297) PR implements the functionality for extracting the schedule from the MINLP solution and applying the schedule primitives.

This PR also includes some bug fixes and improvements to `dfg.py`

The allo.verify() check is currently disabled by default and the correctness of output schedule is not guaranteed. 

### Examples ###
In the simple example 

```python
def simple() -> int32[10, 10]:
        def stageA() -> int32[10, 10]:
            A: int32[10, 10]
            for j in range(10):
                for i in range(10):
                    A[i, j] = i + j
            return A

        def stageB(A: int32[10, 10]) -> int32[10, 10]:
            B: int32[10, 10]
            for i in range(10):
                for j in range(10):
                    B[i, j] = A[i, j] + 1
            return B

        A = stageA()
        B = stageB(A)
        return B
```

after solving and extracting the schedule, we get the following primitives to be applied 

```python
Pipeline: [LoopWrapper(affine_kernel:S_j_0.i)], 
Reorder: [LoopWrapper(affine_kernel_0:S_i_0.j), 
LoopWrapper(affine_kernel_0:S_i_0.i)], 
Pipeline: [LoopWrapper(affine_kernel_0:S_i_0.i)], 
BufferToFifo: [MockBuffer(simple:A), 'affine_kernel_0']
```

which transforms the output MLIR to 

```mlir
module {
  func.func @affine_kernel(%arg0: memref<10x10xi32, "stream:100">) {
    affine.for %arg1 = 0 to 10 {
      affine.for %arg2 = 0 to 10 {
        %0 = arith.addi %arg2, %arg1 : index
        %1 = arith.index_cast %0 : index to i32
        affine.store %1, %arg0[%arg2, %arg1] {to = "A"} : memref<10x10xi32, "stream:100">
      } {loop_name = "i", op_name = "S_i_0", pipeline_ii = 1 : ui32}
    } {loop_name = "j", op_name = "S_j_0"}
    return
  }
  func.func @affine_kernel_0(%arg0: memref<10x10xi32, "stream:100">, %arg1: i33, %arg2: memref<10x10xi32>) {
    affine.for %arg3 = 0 to 10 {
      affine.for %arg4 = 0 to 10 {
        %0 = affine.load %arg0[%arg4, %arg3] {from = "A"} : memref<10x10xi32, "stream:100">
        %1 = arith.extsi %0 : i32 to i33
        %2 = arith.addi %1, %arg1 : i33
        %3 = arith.trunci %2 : i33 to i32
        affine.store %3, %arg2[%arg4, %arg3] {to = "B"} : memref<10x10xi32>
      } {loop_name = "i", pipeline_ii = 1 : ui32}
    } {loop_name = "j", op_name = "S_i_0"}
    return
  }
  func.func @simple() -> memref<10x10xi32> attributes {dataflow, itypes = "", otypes = "s"} {
    %c1_i33 = arith.constant 1 : i33
    %alloc = memref.alloc() {name = "A"} : memref<10x10xi32, "stream:100">
    call @affine_kernel(%alloc) : (memref<10x10xi32, "stream:100">) -> ()
    %alloc_0 = memref.alloc() {name = "B"} : memref<10x10xi32>
    call @affine_kernel_0(%alloc, %c1_i33, %alloc_0) : (memref<10x10xi32, "stream:100">, i33, memref<10x10xi32>) -> ()
    return %alloc_0 : memref<10x10xi32>
  }
}
```

## Checklist ##

Please make sure to review and check all of these items:
- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] All changes have test coverage (It would be good to provide ~2 different test cases to test the robustness of your code)
- [x] Pass the [formatting check](https://cornell-zhang.github.io/allo/developer/index.html#id1) locally
- [x] Code is well-documented
