### PR TITLE
[Dataflow][Backend] Support 3D mapping

### DIFF
--- a/allo/backend/aie.py
+++ b/allo/backend/aie.py
@@ -646,7 +646,7 @@ def codegen_aie_mlir(
     mem_tile_size = max_num_args // 2 + 1
     shim_tile_size = max_num_args // 2 + 1
     mapping = inputs["_global"][0].mapping
-    device = f"npu1_{4}col"
+    device = "npu1_4col"
     code += format_str(f"aie.device({device}) {{", indent=2)
 
     # Add external functions

--- a/allo/backend/aie.py
+++ b/allo/backend/aie.py
@@ -642,8 +642,7 @@ def codegen_aie_mlir(
     # Determine device based on maximum tensor arguments across all kernels
     max_num_args = 0
     for lst in (inputs, outputs):
-        for args in lst.values():
-            max_num_args += len(args)
+        max_num_args += len(lst["_global"])
     mem_tile_size = max_num_args // 2 + 1
     shim_tile_size = max_num_args // 2 + 1
     device = f"npu1_{mem_tile_size}col"
@@ -727,8 +726,10 @@ def codegen_aie_mlir(
     # Create object FIFOs for each kernel
     tile2fifo = {}
     for io, arg_lst in (("in", inputs), ("out", outputs)):
-        for func_name, dtensors in arg_lst.items():
-            for idx, dtensor in enumerate(dtensors):
+        for func_name, sub_func_lst in arg_lst.items():
+            if func_name == "_global":
+                continue
+            for idx, dtensor in enumerate(sub_func_lst["_global"]):
                 mapping = dtensor.mapping
                 spec = dtensor.layout
                 placement = spec.get_placement(mapping)
@@ -750,6 +751,9 @@ def codegen_aie_mlir(
                     tile_strs = []
                     mem_strs.append(f"@{io}_mem_{arg_name}")
                     for tile in target_pe_tiles:
+                        if dtensor not in sub_func_lst[tile]:
+                            # this arg is not used in this kernel
+                            continue
                         idx_str = "_".join(map(str, tile))
                         core_name = f"%tile_comp_{func_name}_{idx_str}"
                         if core_name not in tile2fifo:
@@ -808,15 +812,16 @@ def codegen_aie_mlir(
                 stream_ele_types[stream_name] = type_str
 
     # Create core computation for each kernel function
-    for func_id, (func, func_str) in enumerate(zip(all_funcs, func_strs)):
+    for func_gid, (func, func_str) in enumerate(zip(all_funcs, func_strs)):
         func_name_w_id = func.attributes["sym_name"].value
         func_name = re.match(r"^(.*?)_\d", func_name_w_id).group(1)
+        func_id = tuple(map(int, func_name_w_id.split(func_name + "_")[-1].split("_")))
         core_name = f"tile_comp_{func_name_w_id}"
         streams = stream_info[func_name_w_id]
 
         # Generate core computation
         code += format_str(
-            f"%core_0_{func_id + 2}_{core_name} = aie.core(%{core_name}) {{"
+            f"%core_0_{func_gid + 2}_{core_name} = aie.core(%{core_name}) {{"
         )
         with format_code(indent=6):
             code += format_str("%global_c0 = arith.constant 0 : index")
@@ -831,14 +836,20 @@ def codegen_aie_mlir(
                 # Helper function to process FIFOs (acquire or release)
                 def process_fifos(is_input, is_acquire):
                     nonlocal code, func_str
-                    tensors = inputs[func_name] if is_input else outputs[func_name]
+                    tensors = (
+                        inputs[func_name][func_id]
+                        if is_input
+                        else outputs[func_name][func_id]
+                    )
                     operation = "Consume" if is_input else "Produce"
-                    arg_offset = 0 if is_input else len(inputs[func_name])
+                    arg_offset = 0 if is_input else len(inputs[func_name][func_id])
 
                     for arg_id, tensor in enumerate(tensors):
                         # Calculate fifo index and get fifo name
                         fifo_idx = (
-                            arg_id if is_input else arg_id + len(inputs[func_name])
+                            arg_id
+                            if is_input
+                            else arg_id + len(inputs[func_name][func_id])
                         )
                         fifo_name = tile2fifo[f"%{core_name}"][fifo_idx]
 
@@ -879,7 +890,9 @@ def codegen_aie_mlir(
                 stream_code, func_str = process_stream_operations(
                     func_str,
                     streams,
-                    len(inputs[func_name]) + len(outputs[func_name]) + 1,
+                    len(inputs[func_name][func_id])
+                    + len(outputs[func_name][func_id])
+                    + 1,
                     stream_ele_types,
                 )
                 code += stream_code
@@ -902,15 +915,14 @@ def codegen_aie_mlir(
     in_args = []
     out_args = []
     global_idx = 0
-    for dtensors in inputs.values():
-        for i, dtensor in enumerate(dtensors):
+    for io_lst, io_args, io in ((inputs, in_args, "in"), (outputs, out_args, "out")):
+        for i, dtensor in enumerate(
+            io_lst["_global"], start=global_idx if io == "out" else 0
+        ):
             global_memref_type = get_memref_type_str(dtensor.dtype, dtensor.shape)
-            in_args.append(f"%arg{i}: {global_memref_type}")
-            global_idx += 1
-    for dtensors in outputs.values():
-        for i, dtensor in enumerate(dtensors, start=global_idx):
-            global_memref_type = get_memref_type_str(dtensor.dtype, dtensor.shape)
-            out_args.append(f"%arg{i}: {global_memref_type}")
+            io_args.append(f"%arg{i}: {global_memref_type}")
+            if io == "in":
+                global_idx += 1
 
     # Create dma transfer from off-chip mem to shim tile
     code += format_str(
@@ -941,10 +953,8 @@ def codegen_aie_mlir(
                 )
 
         # Process DMA operations for inputs and outputs
-        for dtensors in inputs.values():
-            process_dma_operations(dtensors, is_input=True)
-        for dtensors in outputs.values():
-            process_dma_operations(dtensors, is_input=False)
+        process_dma_operations(inputs["_global"], is_input=True)
+        process_dma_operations(outputs["_global"], is_input=False)
 
         # Helper function for DMA wait operations
         def process_dma_wait(tensor_lst, is_input):
@@ -956,10 +966,8 @@ def codegen_aie_mlir(
                 )
 
         # Wait for all DMAs to complete
-        for dtensors in inputs.values():
-            process_dma_wait(dtensors, is_input=True)
-        for dtensors in outputs.values():
-            process_dma_wait(dtensors, is_input=False)
+        process_dma_wait(inputs["_global"], is_input=True)
+        process_dma_wait(outputs["_global"], is_input=False)
 
     code += format_str("}")
     code += format_str("}", indent=2)
@@ -1045,20 +1053,35 @@ class AIEModule:
             func_groups[func_name].append(func)
         inputs = {}
         outputs = {}
-        for funcs in func_groups.values():
-            func_name_w_id = funcs[0].attributes["sym_name"].value
-            func_name = re.match(r"^(.*?)_\d", func_name_w_id).group(1)
-            in_idx, out_idx = [], []
+        for func_name, funcs in func_groups.items():
+            inputs[func_name] = {}
+            outputs[func_name] = {}
+            inputs[func_name]["_global"] = []
+            outputs[func_name]["_global"] = []
             for func in funcs:
-                inp, outp = analyze_read_write_patterns(func)
-                in_idx.extend(inp)
-                out_idx.extend(outp)
-            in_idx = list(set(in_idx))
-            out_idx = list(set(out_idx))
-            inputs[func_name] = [self.func_args[func_name_w_id][idx] for idx in in_idx]
-            outputs[func_name] = [
-                self.func_args[func_name_w_id][idx] for idx in out_idx
-            ]
+                # Even for functions inside the same group, the in/out arguments may be different
+                func_name_w_id = func.attributes["sym_name"].value
+                func_id = tuple(
+                    map(int, func_name_w_id.split(func_name + "_")[-1].split("_"))
+                )
+                in_idx, out_idx = analyze_read_write_patterns(func)
+                for io_lst, io_idx in ((inputs, in_idx), (outputs, out_idx)):
+                    io_lst[func_name][func_id] = []
+                    for idx in io_idx:
+                        dtensor = self.func_args[func_name_w_id][idx]
+                        if dtensor not in io_lst[func_name]["_global"]:
+                            io_lst[func_name]["_global"].append(dtensor)
+                        io_lst[func_name][func_id].append(dtensor)
+        for io_lst in (inputs, outputs):
+            io_lst["_global"] = []
+            for func_name, sub_func_lst in io_lst.items():
+                if func_name == "_global":
+                    continue
+                for tensor in sub_func_lst["_global"]:
+                    if tensor not in io_lst["_global"]:
+                        io_lst["_global"].append(tensor)
+        self.inputs = inputs
+        self.outputs = outputs
         code = codegen_aie_mlir(
             self.module,
             func_groups,
@@ -1092,13 +1115,7 @@ class AIEModule:
         path = os.path.dirname(__file__)
         path = os.path.join(path, "../harness/aie")
         os.system(f"cp -r {path}/* {self.project}")
-        self.all_inputs = []
-        for dtensors in inputs.values():
-            self.all_inputs.extend(dtensors)
-        self.all_outputs = []
-        for dtensors in outputs.values():
-            self.all_outputs.extend(dtensors)
-        host_code = codegen_host(self.all_inputs, self.all_outputs)
+        host_code = codegen_host(inputs["_global"], outputs["_global"])
         with open(os.path.join(self.project, "test.cpp"), "w", encoding="utf-8") as f:
             f.write(host_code)
         cmd = f"cd {self.project}/build && cmake .. -DTARGET_NAME=top -DMLIR_AIE_DIR=$MLIR_AIE_INSTALL_DIR/.. && cmake --build . --config Release"
@@ -1122,7 +1139,7 @@ class AIEModule:
             raise RuntimeError("Failed to execute AIE code.")
         # TODO: need to complete multiple outputs rules
         result = read_tensor_from_file(
-            self.all_outputs[-1].dtype,
+            self.outputs["_global"][-1].dtype,
             args[-1].shape,
             f"{self.project}/output.data",
         )

--- a/allo/backend/aie.py
+++ b/allo/backend/aie.py
@@ -1,7 +1,7 @@
 # Copyright Allo authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 # mlir-aie commit: 8329b6
-# pylint: disable=bad-builtin, no-name-in-module, too-many-branches, too-many-nested-blocks, consider-using-with
+# pylint: disable=bad-builtin, no-name-in-module, too-many-branches, too-many-nested-blocks, consider-using-with, cell-var-from-loop
 
 
 import os
@@ -693,7 +693,9 @@ def codegen_aie_mlir(
             elif len(ids) == 3:
                 ids = (ids[0] * mapping[-2] + ids[1], ids[2])
             ids = (max_ids[0] + ids[-2], max_ids[1] + ids[-1])
-            code += format_str(f"%tile_comp_{func_name} = aie.tile({ids[-2]}, {ids[-1]})")
+            code += format_str(
+                f"%tile_comp_{func_name} = aie.tile({ids[-2]}, {ids[-1]})"
+            )
             tmp_ids = (0, max(ids[1] + 1, max_ids[1]))
         max_ids = tmp_ids
 

--- a/tests/dataflow/aie/test_matrix.py
+++ b/tests/dataflow/aie/test_matrix.py
@@ -8,9 +8,9 @@ import allo.dataflow as df
 import numpy as np
 from allo.memory import Layout
 
-SpA = Layout("S0R")
-SpB = Layout("RS1")
-SpC = Layout("S0S1")
+LyA = Layout("S0R")
+LyB = Layout("RS1")
+LyC = Layout("S0S1")
 
 
 def _test_matrix_scalar_add():
@@ -21,7 +21,7 @@ def _test_matrix_scalar_add():
     @df.region()
     def top():
         @df.kernel(mapping=[P0])
-        def core(A: Ty[M, N] @ SpA, B: Ty[M, N] @ SpA):
+        def core(A: Ty[M, N] @ LyA, B: Ty[M, N] @ LyA):
             B[:, :] = allo.add(A, 1)
 
     A = np.random.randint(0, 100, (M, N)).astype(np.int32)
@@ -50,7 +50,7 @@ def _test_matrix_matrix_add():
     @df.region()
     def top():
         @df.kernel(mapping=[P0])
-        def core(A: Ty[M, N] @ SpA, B: Ty[M, N] @ SpA, C: Ty[M, N] @ SpA):
+        def core(A: Ty[M, N] @ LyA, B: Ty[M, N] @ LyA, C: Ty[M, N] @ LyA):
             C[:, :] = allo.add(A, B)
 
     A = np.random.randint(0, 100, (M, N)).astype(np.int32)
@@ -78,7 +78,7 @@ def _test_gemm_1D():
     @df.region()
     def top():
         @df.kernel(mapping=[P0])
-        def gemm(A: Ty[M, K] @ SpA, B: Ty[K, N], C: Ty[M, N] @ SpA):
+        def gemm(A: Ty[M, K] @ LyA, B: Ty[K, N], C: Ty[M, N] @ LyA):
             C[:, :] = allo.matmul(A, B)
 
     mod = df.build(top, target="aie")
@@ -98,7 +98,7 @@ def _test_gemm_2D():
     @df.region()
     def top():
         @df.kernel(mapping=[P0, P1])
-        def gemm(A: TyI[M, K] @ SpA, B: TyI[K, N] @ SpB, C: TyO[M, N] @ SpC):
+        def gemm(A: TyI[M, K] @ LyA, B: TyI[K, N] @ LyB, C: TyO[M, N] @ LyC):
             C[:, :] = allo.matmul(A, B)
 
     mod = df.build(top, target="aie")

--- a/tests/dataflow/aie/test_pingpong_gemm.py
+++ b/tests/dataflow/aie/test_pingpong_gemm.py
@@ -8,8 +8,10 @@ import numpy as np
 from allo.memory import Layout
 
 Ty = int16
+# M, N, K = 16, 16, 32
+# Pm, Pn, Pk = 1, 1, 4
 M, N, K = 16, 16, 16
-Pm, Pn, Pk = 1, 1, 2
+Pm, Pn, Pk = 1, 2, 2
 Mt, Nt, Kt = M // Pm, N // Pn, K // Pk
 
 LyA = Layout("S1S2")

--- a/tests/dataflow/aie/test_pingpong_gemm.py
+++ b/tests/dataflow/aie/test_pingpong_gemm.py
@@ -12,9 +12,9 @@ M, N, K = 16, 16, 16
 Pm, Pn, Pk = 1, 1, 2
 Mt, Nt, Kt = M // Pm, N // Pn, K // Pk
 
-SpA = Layout("S1S2")
-SpB = Layout("S2S0")
-SpC = Layout("S1S0")
+LyA = Layout("S1S2")
+LyB = Layout("S2S0")
+LyC = Layout("S1S0")
 
 
 @df.region()
@@ -23,7 +23,7 @@ def top():
     # Stream(Ty[Mt, Nt], 2)[Pk - 1, Pm, Pn]
 
     @df.kernel(mapping=[Pk, Pm, Pn])
-    def gemm(A: Ty[M, K] @ SpA, B: Ty[K, N] @ SpB, C: Ty[M, N] @ SpC):
+    def gemm(A: Ty[M, K] @ LyA, B: Ty[K, N] @ LyB, C: Ty[M, N] @ LyC):
         pk, pm, pn = df.get_pid()
         with allo.meta_if(pk > 0):
             C_in: Ty[Mt, Nt] = pipe[pk - 1, pm, pn].get()

--- a/tests/dataflow/aie/test_vector.py
+++ b/tests/dataflow/aie/test_vector.py
@@ -1,5 +1,5 @@
 # Copyright Allo authors. All Rights Reserved.
-# LyDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 
 import os
 import allo

--- a/tests/dataflow/aie/test_vector.py
+++ b/tests/dataflow/aie/test_vector.py
@@ -1,5 +1,5 @@
 # Copyright Allo authors. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
+# LyDX-License-Identifier: Apache-2.0
 
 import os
 import allo
@@ -8,7 +8,7 @@ import allo.dataflow as df
 import numpy as np
 from allo.memory import Layout
 
-Sp = Layout("S0")
+Ly = Layout("S0")
 
 
 def _test_vector_scalar_add():
@@ -168,7 +168,7 @@ def _test_vector_scalar_add_p0():
     @df.region()
     def top():
         @df.kernel(mapping=[P0])
-        def core(A: Ty[M] @ Sp, B: Ty[M] @ Sp):
+        def core(A: Ty[M] @ Ly, B: Ty[M] @ Ly):
             B[:] = allo.add(A[:], 1)
 
     mod = df.build(top, target="aie")
@@ -191,7 +191,7 @@ def _test_vector_vector_add_p0():
     @df.region()
     def top():
         @df.kernel(mapping=[P0])
-        def core(A: Ty[M] @ Sp, B: Ty[M] @ Sp, C: Ty[M] @ Sp):
+        def core(A: Ty[M] @ Ly, B: Ty[M] @ Ly, C: Ty[M] @ Ly):
             C[:] = allo.add(A, B)
 
     mod = df.build(top, target="aie")


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR enables 3D mapping so ping-pong GEMM with two AIE herd for reduction can be achieved.
1. Fix 3D mapping layout calculation
2. Refactor inputs and outputs dtensor, which contains a global copy and copy of each function with ID
3. Remove `enable_tensor`
4. (TODO) M=N=K=2 case is still not available due to limited DMA ports, which requires better routing mechanism

### Examples ###
```python
Ty = int16
M, N, K = 16, 16, 16
Pm, Pn, Pk = 1, 2, 2
Mt, Nt, Kt = M // Pm, N // Pn, K // Pk

LyA = Layout("S1S2")
LyB = Layout("S2S0")
LyC = Layout("S1S0")


@df.region()
def top():
    pipe = df.array(df.pipe(dtype=Ty, shape=(Mt, Nt), depth=2), shape=(Pk - 1, Pm, Pn))
    # Stream(Ty[Mt, Nt], 2)[Pk - 1, Pm, Pn]

    @df.kernel(mapping=[Pk, Pm, Pn])
    def gemm(A: Ty[M, K] @ LyA, B: Ty[K, N] @ LyB, C: Ty[M, N] @ LyC):
        pk, pm, pn = df.get_pid()
        with allo.meta_if(pk > 0):
            C_in: Ty[Mt, Nt] = pipe[pk - 1, pm, pn].get()
        with allo.meta_else():
            C_in: Ty[Mt, Nt] = 0
        C_out: Ty[Mt, Nt] = allo.add(allo.matmul(A, B), C_in)
        with allo.meta_if(pk < Pk - 1):
            pipe[pk, pm, pn].put(C_out)
        with allo.meta_elif(pk == Pk - 1):
            C[:, :] = C_out
```


## Checklist ##

Please make sure to review and check all of these items:
- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] All changes have test coverage (It would be good to provide ~2 different test cases to test the robustness of your code)
- [x] Pass the [formatting check](https://cornell-zhang.github.io/allo/developer/index.html#id1) locally
- [x] Code is well-documented
