### PR TITLE
[Dataflow][AIE] Understand the communication pattern between AIE tiles and support 2x2x2 cooperative GEMM by using different compute tiles placement

### DIFF
--- a/allo/backend/aie.py
+++ b/allo/backend/aie.py
@@ -619,13 +619,13 @@ def map_kernels_to_device_mesh(kernel_shapes, device_shape):
         if len(kernel_shape) == 3:
             # Try both flattening options (e.g., 2x2x2 -> 4x2 or 2x4)
             option1 = [
-                kernel_shape[0] * kernel_shape[1],
-                kernel_shape[2],
-            ]  # (dim1*dim2) x dim3
-            option2 = [
                 kernel_shape[0],
                 kernel_shape[1] * kernel_shape[2],
             ]  # dim1 x (dim2*dim3)
+            option2 = [
+                kernel_shape[0] * kernel_shape[1],
+                kernel_shape[2],
+            ]  # (dim1*dim2) x dim3
 
             flattening_options = [option1, option2]
 

--- a/tests/dataflow/aie/test_pingpong_gemm.py
+++ b/tests/dataflow/aie/test_pingpong_gemm.py
@@ -11,7 +11,7 @@ Ty = int16
 # M, N, K = 16, 16, 32
 # Pm, Pn, Pk = 1, 1, 4
 M, N, K = 16, 16, 16
-Pm, Pn, Pk = 1, 2, 2
+Pm, Pn, Pk = 2, 2, 2
 Mt, Nt, Kt = M // Pm, N // Pn, K // Pk
 
 LyA = Layout("S1S2")


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR resolves the TODO from [#341](https://github.com/cornell-zhang/allo/pull/341).

In the original compute tile placement strategy for the 2×2×2 cooperative GEMM, four compute tiles require three DMA-in channels to receive data — two for input tensors A and B, and one for the `pipe` stream. However, each AIE tile supports only two DMA-in channels, which leads to a DMA resource conflict and compilation error.

Under the previous strategy, the `pipe` stream communication spanned two hops (e.g., from tile_0_2 to tile_2_2). According to AMD documentation ([link](https://docs.amd.com/r/en-US/am009-versal-ai-engine/AI-Engine-Tile-to-AI-Engine-Tile-Data-Communication-via-Memory-and-DMA)), communication between non-adjacent tiles must use DMA, further exacerbating the issue.

This PR introduces a new placement strategy that ensures the `pipe` stream operates between neighboring tiles. In this case, the communication can leverage shared memory instead of DMA, as described in the AMD documentation ([link](https://docs.amd.com/r/en-US/am009-versal-ai-engine/AI-Engine-to-AI-Engine-Data-Communication-via-Shared-Memory)). This change avoids exceeding the DMA-in limit and resolves the original issue.


### Examples ###
```python
Ty = int16
M, N, K = 16, 16, 16
Pm, Pn, Pk = 2, 2, 2
Mt, Nt, Kt = M // Pm, N // Pn, K // Pk

LyA = Layout("S1S2")
LyB = Layout("S2S0")
LyC = Layout("S1S0")


@df.region()
def top():
    pipe = df.array(df.pipe(dtype=Ty, shape=(Mt, Nt), depth=2), shape=(Pk - 1, Pm, Pn))
    # Stream(Ty[Mt, Nt], 2)[Pk - 1, Pm, Pn]

    @df.kernel(mapping=[Pk, Pm, Pn])
    def gemm(A: Ty[M, K] @ LyA, B: Ty[K, N] @ LyB, C: Ty[M, N] @ LyC):
        pk, pm, pn = df.get_pid()
        with allo.meta_if(pk > 0):
            C_in: Ty[Mt, Nt] = pipe[pk - 1, pm, pn].get()
        with allo.meta_else():
            C_in: Ty[Mt, Nt] = 0
        C_out: Ty[Mt, Nt] = allo.add(allo.matmul(A, B), C_in)
        with allo.meta_if(pk < Pk - 1):
            pipe[pk, pm, pn].put(C_out)
        with allo.meta_elif(pk == Pk - 1):
            C[:, :] = C_out
```
```mlir
module {
  aie.device(npu1_4col) {
    func.func private @matmul_scalar_i16_i16(memref<8x8xi16>, memref<8x8xi16>, memref<8x8xi16>)
    %tile_shim0 = aie.tile(0, 0)
    %tile_shim1 = aie.tile(1, 0)
    %tile_mem0 = aie.tile(0, 1)
    %tile_mem1 = aie.tile(1, 1)
    %tile_comp_gemm_0_0_0 = aie.tile(0, 2)
    %tile_comp_gemm_0_0_1 = aie.tile(0, 3)
    %tile_comp_gemm_0_1_0 = aie.tile(0, 4)
    %tile_comp_gemm_0_1_1 = aie.tile(0, 5)
    %tile_comp_gemm_1_0_0 = aie.tile(1, 2)
    %tile_comp_gemm_1_0_1 = aie.tile(1, 3)
    %tile_comp_gemm_1_1_0 = aie.tile(1, 4)
    %tile_comp_gemm_1_1_1 = aie.tile(1, 5)
    %tile_comp_gemm_0_0_0_buf0 = aie.buffer(%tile_comp_gemm_0_0_0) : memref<8x8xi16>
    %tile_comp_gemm_0_0_0_buf1 = aie.buffer(%tile_comp_gemm_0_0_0) : memref<8x8xi16>
    %tile_comp_gemm_0_0_0_buf2 = aie.buffer(%tile_comp_gemm_0_0_0) : memref<8x8xi16>
    %tile_comp_gemm_0_0_0_buf3 = aie.buffer(%tile_comp_gemm_0_0_0) : memref<8x8xi16>
    %tile_comp_gemm_0_0_1_buf0 = aie.buffer(%tile_comp_gemm_0_0_1) : memref<8x8xi16>
    %tile_comp_gemm_0_0_1_buf1 = aie.buffer(%tile_comp_gemm_0_0_1) : memref<8x8xi16>
    %tile_comp_gemm_0_0_1_buf2 = aie.buffer(%tile_comp_gemm_0_0_1) : memref<8x8xi16>
    %tile_comp_gemm_0_0_1_buf3 = aie.buffer(%tile_comp_gemm_0_0_1) : memref<8x8xi16>
    %tile_comp_gemm_0_1_0_buf0 = aie.buffer(%tile_comp_gemm_0_1_0) : memref<8x8xi16>
    %tile_comp_gemm_0_1_0_buf1 = aie.buffer(%tile_comp_gemm_0_1_0) : memref<8x8xi16>
    %tile_comp_gemm_0_1_0_buf2 = aie.buffer(%tile_comp_gemm_0_1_0) : memref<8x8xi16>
    %tile_comp_gemm_0_1_0_buf3 = aie.buffer(%tile_comp_gemm_0_1_0) : memref<8x8xi16>
    %tile_comp_gemm_0_1_1_buf0 = aie.buffer(%tile_comp_gemm_0_1_1) : memref<8x8xi16>
    %tile_comp_gemm_0_1_1_buf1 = aie.buffer(%tile_comp_gemm_0_1_1) : memref<8x8xi16>
    %tile_comp_gemm_0_1_1_buf2 = aie.buffer(%tile_comp_gemm_0_1_1) : memref<8x8xi16>
    %tile_comp_gemm_0_1_1_buf3 = aie.buffer(%tile_comp_gemm_0_1_1) : memref<8x8xi16>
    %tile_comp_gemm_1_0_0_buf0 = aie.buffer(%tile_comp_gemm_1_0_0) : memref<8x8xi16>
    %tile_comp_gemm_1_0_0_buf1 = aie.buffer(%tile_comp_gemm_1_0_0) : memref<8x8xi16>
    %tile_comp_gemm_1_0_0_buf2 = aie.buffer(%tile_comp_gemm_1_0_0) : memref<8x8xi16>
    %tile_comp_gemm_1_0_1_buf0 = aie.buffer(%tile_comp_gemm_1_0_1) : memref<8x8xi16>
    %tile_comp_gemm_1_0_1_buf1 = aie.buffer(%tile_comp_gemm_1_0_1) : memref<8x8xi16>
    %tile_comp_gemm_1_0_1_buf2 = aie.buffer(%tile_comp_gemm_1_0_1) : memref<8x8xi16>
    %tile_comp_gemm_1_1_0_buf0 = aie.buffer(%tile_comp_gemm_1_1_0) : memref<8x8xi16>
    %tile_comp_gemm_1_1_0_buf1 = aie.buffer(%tile_comp_gemm_1_1_0) : memref<8x8xi16>
    %tile_comp_gemm_1_1_0_buf2 = aie.buffer(%tile_comp_gemm_1_1_0) : memref<8x8xi16>
    %tile_comp_gemm_1_1_1_buf0 = aie.buffer(%tile_comp_gemm_1_1_1) : memref<8x8xi16>
    %tile_comp_gemm_1_1_1_buf1 = aie.buffer(%tile_comp_gemm_1_1_1) : memref<8x8xi16>
    %tile_comp_gemm_1_1_1_buf2 = aie.buffer(%tile_comp_gemm_1_1_1) : memref<8x8xi16>
    aie.objectfifo @in_shim_A(%tile_shim0, {%tile_mem0}, 2 : i32) : !aie.objectfifo<memref<16x16xi16>>
    aie.objectfifo @in_mem_A_00(%tile_mem0, {%tile_comp_gemm_0_0_0, %tile_comp_gemm_0_0_1}, 2 : i32) : !aie.objectfifo<memref<8x8xi16>>
    aie.objectfifo @in_mem_A_10(%tile_mem0, {%tile_comp_gemm_0_1_0, %tile_comp_gemm_0_1_1}, 2 : i32) : !aie.objectfifo<memref<8x8xi16>>
    aie.objectfifo @in_mem_A_01(%tile_mem0, {%tile_comp_gemm_1_0_0, %tile_comp_gemm_1_0_1}, 2 : i32) : !aie.objectfifo<memref<8x8xi16>>
    aie.objectfifo @in_mem_A_11(%tile_mem0, {%tile_comp_gemm_1_1_0, %tile_comp_gemm_1_1_1}, 2 : i32) : !aie.objectfifo<memref<8x8xi16>>
    aie.objectfifo.link [@in_shim_A] -> [@in_mem_A_00, @in_mem_A_01, @in_mem_A_10, @in_mem_A_11]([] [0, 64, 128, 192])
    aie.objectfifo @in_shim_B(%tile_shim1, {%tile_mem1}, 2 : i32) : !aie.objectfifo<memref<16x16xi16>>
    aie.objectfifo @in_mem_B_00(%tile_mem1, {%tile_comp_gemm_0_0_0, %tile_comp_gemm_0_1_0}, 2 : i32) : !aie.objectfifo<memref<8x8xi16>>
    aie.objectfifo @in_mem_B_01(%tile_mem1, {%tile_comp_gemm_0_0_1, %tile_comp_gemm_0_1_1}, 2 : i32) : !aie.objectfifo<memref<8x8xi16>>
    aie.objectfifo @in_mem_B_10(%tile_mem1, {%tile_comp_gemm_1_0_0, %tile_comp_gemm_1_1_0}, 2 : i32) : !aie.objectfifo<memref<8x8xi16>>
    aie.objectfifo @in_mem_B_11(%tile_mem1, {%tile_comp_gemm_1_0_1, %tile_comp_gemm_1_1_1}, 2 : i32) : !aie.objectfifo<memref<8x8xi16>>
    aie.objectfifo.link [@in_shim_B] -> [@in_mem_B_00, @in_mem_B_01, @in_mem_B_10, @in_mem_B_11]([] [0, 64, 128, 192])
    aie.objectfifo @out_shim_C(%tile_mem0, {%tile_shim0}, 2 : i32) : !aie.objectfifo<memref<16x16xi16>>
    aie.objectfifo @out_mem_C_00(%tile_comp_gemm_1_0_0, {%tile_mem0}, 2 : i32) : !aie.objectfifo<memref<8x8xi16>>
    aie.objectfifo @out_mem_C_01(%tile_comp_gemm_1_0_1, {%tile_mem0}, 2 : i32) : !aie.objectfifo<memref<8x8xi16>>
    aie.objectfifo @out_mem_C_10(%tile_comp_gemm_1_1_0, {%tile_mem0}, 2 : i32) : !aie.objectfifo<memref<8x8xi16>>
    aie.objectfifo @out_mem_C_11(%tile_comp_gemm_1_1_1, {%tile_mem0}, 2 : i32) : !aie.objectfifo<memref<8x8xi16>>
    aie.objectfifo.link [@out_mem_C_00, @out_mem_C_01, @out_mem_C_10, @out_mem_C_11] -> [@out_shim_C]([0, 64, 128, 192] [])
    aie.objectfifo @pipe_0_0_0(%tile_comp_gemm_0_0_0, {%tile_comp_gemm_1_0_0}, 2 : i32) : !aie.objectfifo<memref<8x8xi16>>
    aie.objectfifo @pipe_0_0_1(%tile_comp_gemm_0_0_1, {%tile_comp_gemm_1_0_1}, 2 : i32) : !aie.objectfifo<memref<8x8xi16>>
    aie.objectfifo @pipe_0_1_0(%tile_comp_gemm_0_1_0, {%tile_comp_gemm_1_1_0}, 2 : i32) : !aie.objectfifo<memref<8x8xi16>>
    aie.objectfifo @pipe_0_1_1(%tile_comp_gemm_0_1_1, {%tile_comp_gemm_1_1_1}, 2 : i32) : !aie.objectfifo<memref<8x8xi16>>
    %core_0_2_tile_comp_gemm_0_0_0 = aie.core(%tile_comp_gemm_0_0_0) {
      %global_c0 = arith.constant 0 : index
      %global_c1 = arith.constant 1 : index
      %c9223372036854775807 = arith.constant 9223372036854775807 : index
      scf.for %arg0 = %global_c0 to %c9223372036854775807 step %global_c1 {
        %fifo0 = aie.objectfifo.acquire @in_mem_A_00(Consume, 1) : !aie.objectfifosubview<memref<8x8xi16>>
        %local0 = aie.objectfifo.subview.access %fifo0[0] : !aie.objectfifosubview<memref<8x8xi16>> -> memref<8x8xi16>
        %fifo1 = aie.objectfifo.acquire @in_mem_B_00(Consume, 1) : !aie.objectfifosubview<memref<8x8xi16>>
        %local1 = aie.objectfifo.subview.access %fifo1[0] : !aie.objectfifosubview<memref<8x8xi16>> -> memref<8x8xi16>
        %c0_i16 = arith.constant 0 : i16
        %c0 = arith.constant 0 : index
        %c8 = arith.constant 8 : index
        %c1 = arith.constant 1 : index
        scf.for %arg4 = %c0 to %c8 step %c1 {
          %c0_12 = arith.constant 0 : index
          %c8_13 = arith.constant 8 : index
          %c1_14 = arith.constant 1 : index
          scf.for %arg5 = %c0_12 to %c8_13 step %c1_14 {
            memref.store %c0_i16, %tile_comp_gemm_0_0_0_buf0[%arg4, %arg5] : memref<8x8xi16>
          }
        }
        %c0_1 = arith.constant 0 : index
        %c8_2 = arith.constant 8 : index
        %c1_3 = arith.constant 1 : index
        scf.for %arg4 = %c0_1 to %c8_2 step %c1_3 {
          %c0_12 = arith.constant 0 : index
          %c8_13 = arith.constant 8 : index
          %c1_14 = arith.constant 1 : index
          scf.for %arg5 = %c0_12 to %c8_13 step %c1_14 {
            memref.store %c0_i16, %tile_comp_gemm_0_0_0_buf1[%arg4, %arg5] : memref<8x8xi16>
          }
        }
        func.call @matmul_scalar_i16_i16(%local0, %local1, %tile_comp_gemm_0_0_0_buf1) : (memref<8x8xi16>, memref<8x8xi16>, memref<8x8xi16>) -> ()
        %c0_5 = arith.constant 0 : index
        %c8_6 = arith.constant 8 : index
        %c1_7 = arith.constant 1 : index
        scf.for %arg4 = %c0_5 to %c8_6 step %c1_7 {
          %c0_12 = arith.constant 0 : index
          %c8_13 = arith.constant 8 : index
          %c1_14 = arith.constant 1 : index
          scf.for %arg5 = %c0_12 to %c8_13 step %c1_14 {
            %0 = memref.load %tile_comp_gemm_0_0_0_buf1[%arg4, %arg5] : memref<8x8xi16>
            %1 = memref.load %tile_comp_gemm_0_0_0_buf0[%arg4, %arg5] : memref<8x8xi16>
            %2 = arith.addi %0, %1 : i16
            memref.store %2, %tile_comp_gemm_0_0_0_buf2[%arg4, %arg5] : memref<8x8xi16>
          }
        }
        %c0_9 = arith.constant 0 : index
        %c8_10 = arith.constant 8 : index
        %c1_11 = arith.constant 1 : index
        scf.for %arg4 = %c0_9 to %c8_10 step %c1_11 {
          %c0_12 = arith.constant 0 : index
          %c8_13 = arith.constant 8 : index
          %c1_14 = arith.constant 1 : index
          scf.for %arg5 = %c0_12 to %c8_13 step %c1_14 {
            %0 = memref.load %tile_comp_gemm_0_0_0_buf2[%arg4, %arg5] : memref<8x8xi16>
            memref.store %0, %tile_comp_gemm_0_0_0_buf3[%arg4, %arg5] : memref<8x8xi16>
          }
        }
        %fifo_pipe_0_0_0 = aie.objectfifo.acquire @pipe_0_0_0(Produce, 1) : !aie.objectfifosubview<memref<8x8xi16>>
        %local_pipe_0_0_0 = aie.objectfifo.subview.access %fifo_pipe_0_0_0[0] : !aie.objectfifosubview<memref<8x8xi16>> -> memref<8x8xi16>
        memref.copy %tile_comp_gemm_0_0_0_buf3, %local_pipe_0_0_0 : memref<8x8xi16> to memref<8x8xi16>
        aie.objectfifo.release @pipe_0_0_0(Produce, 1)
        aie.objectfifo.release @in_mem_A_00(Consume, 1)
        aie.objectfifo.release @in_mem_B_00(Consume, 1)
      }
      aie.end
    } {link_with = "external.o"}
    %core_0_3_tile_comp_gemm_0_0_1 = aie.core(%tile_comp_gemm_0_0_1) {
      %global_c0 = arith.constant 0 : index
      %global_c1 = arith.constant 1 : index
      %c9223372036854775807 = arith.constant 9223372036854775807 : index
      scf.for %arg0 = %global_c0 to %c9223372036854775807 step %global_c1 {
        %fifo0 = aie.objectfifo.acquire @in_mem_A_00(Consume, 1) : !aie.objectfifosubview<memref<8x8xi16>>
        %local0 = aie.objectfifo.subview.access %fifo0[0] : !aie.objectfifosubview<memref<8x8xi16>> -> memref<8x8xi16>
        %fifo1 = aie.objectfifo.acquire @in_mem_B_01(Consume, 1) : !aie.objectfifosubview<memref<8x8xi16>>
        %local1 = aie.objectfifo.subview.access %fifo1[0] : !aie.objectfifosubview<memref<8x8xi16>> -> memref<8x8xi16>
        %c0_i16 = arith.constant 0 : i16
        %c0 = arith.constant 0 : index
        %c8 = arith.constant 8 : index
        %c1 = arith.constant 1 : index
        scf.for %arg4 = %c0 to %c8 step %c1 {
          %c0_12 = arith.constant 0 : index
          %c8_13 = arith.constant 8 : index
          %c1_14 = arith.constant 1 : index
          scf.for %arg5 = %c0_12 to %c8_13 step %c1_14 {
            memref.store %c0_i16, %tile_comp_gemm_0_0_1_buf0[%arg4, %arg5] : memref<8x8xi16>
          }
        }
        %c0_1 = arith.constant 0 : index
        %c8_2 = arith.constant 8 : index
        %c1_3 = arith.constant 1 : index
        scf.for %arg4 = %c0_1 to %c8_2 step %c1_3 {
          %c0_12 = arith.constant 0 : index
          %c8_13 = arith.constant 8 : index
          %c1_14 = arith.constant 1 : index
          scf.for %arg5 = %c0_12 to %c8_13 step %c1_14 {
            memref.store %c0_i16, %tile_comp_gemm_0_0_1_buf1[%arg4, %arg5] : memref<8x8xi16>
          }
        }
        func.call @matmul_scalar_i16_i16(%local0, %local1, %tile_comp_gemm_0_0_1_buf1) : (memref<8x8xi16>, memref<8x8xi16>, memref<8x8xi16>) -> ()
        %c0_5 = arith.constant 0 : index
        %c8_6 = arith.constant 8 : index
        %c1_7 = arith.constant 1 : index
        scf.for %arg4 = %c0_5 to %c8_6 step %c1_7 {
          %c0_12 = arith.constant 0 : index
          %c8_13 = arith.constant 8 : index
          %c1_14 = arith.constant 1 : index
          scf.for %arg5 = %c0_12 to %c8_13 step %c1_14 {
            %0 = memref.load %tile_comp_gemm_0_0_1_buf1[%arg4, %arg5] : memref<8x8xi16>
            %1 = memref.load %tile_comp_gemm_0_0_1_buf0[%arg4, %arg5] : memref<8x8xi16>
            %2 = arith.addi %0, %1 : i16
            memref.store %2, %tile_comp_gemm_0_0_1_buf2[%arg4, %arg5] : memref<8x8xi16>
          }
        }
        %c0_9 = arith.constant 0 : index
        %c8_10 = arith.constant 8 : index
        %c1_11 = arith.constant 1 : index
        scf.for %arg4 = %c0_9 to %c8_10 step %c1_11 {
          %c0_12 = arith.constant 0 : index
          %c8_13 = arith.constant 8 : index
          %c1_14 = arith.constant 1 : index
          scf.for %arg5 = %c0_12 to %c8_13 step %c1_14 {
            %0 = memref.load %tile_comp_gemm_0_0_1_buf2[%arg4, %arg5] : memref<8x8xi16>
            memref.store %0, %tile_comp_gemm_0_0_1_buf3[%arg4, %arg5] : memref<8x8xi16>
          }
        }
        %fifo_pipe_0_0_1 = aie.objectfifo.acquire @pipe_0_0_1(Produce, 1) : !aie.objectfifosubview<memref<8x8xi16>>
        %local_pipe_0_0_1 = aie.objectfifo.subview.access %fifo_pipe_0_0_1[0] : !aie.objectfifosubview<memref<8x8xi16>> -> memref<8x8xi16>
        memref.copy %tile_comp_gemm_0_0_1_buf3, %local_pipe_0_0_1 : memref<8x8xi16> to memref<8x8xi16>
        aie.objectfifo.release @pipe_0_0_1(Produce, 1)
        aie.objectfifo.release @in_mem_A_00(Consume, 1)
        aie.objectfifo.release @in_mem_B_01(Consume, 1)
      }
      aie.end
    } {link_with = "external.o"}
    %core_0_4_tile_comp_gemm_0_1_0 = aie.core(%tile_comp_gemm_0_1_0) {
      %global_c0 = arith.constant 0 : index
      %global_c1 = arith.constant 1 : index
      %c9223372036854775807 = arith.constant 9223372036854775807 : index
      scf.for %arg0 = %global_c0 to %c9223372036854775807 step %global_c1 {
        %fifo0 = aie.objectfifo.acquire @in_mem_A_10(Consume, 1) : !aie.objectfifosubview<memref<8x8xi16>>
        %local0 = aie.objectfifo.subview.access %fifo0[0] : !aie.objectfifosubview<memref<8x8xi16>> -> memref<8x8xi16>
        %fifo1 = aie.objectfifo.acquire @in_mem_B_00(Consume, 1) : !aie.objectfifosubview<memref<8x8xi16>>
        %local1 = aie.objectfifo.subview.access %fifo1[0] : !aie.objectfifosubview<memref<8x8xi16>> -> memref<8x8xi16>
        %c0_i16 = arith.constant 0 : i16
        %c0 = arith.constant 0 : index
        %c8 = arith.constant 8 : index
        %c1 = arith.constant 1 : index
        scf.for %arg4 = %c0 to %c8 step %c1 {
          %c0_12 = arith.constant 0 : index
          %c8_13 = arith.constant 8 : index
          %c1_14 = arith.constant 1 : index
          scf.for %arg5 = %c0_12 to %c8_13 step %c1_14 {
            memref.store %c0_i16, %tile_comp_gemm_0_1_0_buf0[%arg4, %arg5] : memref<8x8xi16>
          }
        }
        %c0_1 = arith.constant 0 : index
        %c8_2 = arith.constant 8 : index
        %c1_3 = arith.constant 1 : index
        scf.for %arg4 = %c0_1 to %c8_2 step %c1_3 {
          %c0_12 = arith.constant 0 : index
          %c8_13 = arith.constant 8 : index
          %c1_14 = arith.constant 1 : index
          scf.for %arg5 = %c0_12 to %c8_13 step %c1_14 {
            memref.store %c0_i16, %tile_comp_gemm_0_1_0_buf1[%arg4, %arg5] : memref<8x8xi16>
          }
        }
        func.call @matmul_scalar_i16_i16(%local0, %local1, %tile_comp_gemm_0_1_0_buf1) : (memref<8x8xi16>, memref<8x8xi16>, memref<8x8xi16>) -> ()
        %c0_5 = arith.constant 0 : index
        %c8_6 = arith.constant 8 : index
        %c1_7 = arith.constant 1 : index
        scf.for %arg4 = %c0_5 to %c8_6 step %c1_7 {
          %c0_12 = arith.constant 0 : index
          %c8_13 = arith.constant 8 : index
          %c1_14 = arith.constant 1 : index
          scf.for %arg5 = %c0_12 to %c8_13 step %c1_14 {
            %0 = memref.load %tile_comp_gemm_0_1_0_buf1[%arg4, %arg5] : memref<8x8xi16>
            %1 = memref.load %tile_comp_gemm_0_1_0_buf0[%arg4, %arg5] : memref<8x8xi16>
            %2 = arith.addi %0, %1 : i16
            memref.store %2, %tile_comp_gemm_0_1_0_buf2[%arg4, %arg5] : memref<8x8xi16>
          }
        }
        %c0_9 = arith.constant 0 : index
        %c8_10 = arith.constant 8 : index
        %c1_11 = arith.constant 1 : index
        scf.for %arg4 = %c0_9 to %c8_10 step %c1_11 {
          %c0_12 = arith.constant 0 : index
          %c8_13 = arith.constant 8 : index
          %c1_14 = arith.constant 1 : index
          scf.for %arg5 = %c0_12 to %c8_13 step %c1_14 {
            %0 = memref.load %tile_comp_gemm_0_1_0_buf2[%arg4, %arg5] : memref<8x8xi16>
            memref.store %0, %tile_comp_gemm_0_1_0_buf3[%arg4, %arg5] : memref<8x8xi16>
          }
        }
        %fifo_pipe_0_1_0 = aie.objectfifo.acquire @pipe_0_1_0(Produce, 1) : !aie.objectfifosubview<memref<8x8xi16>>
        %local_pipe_0_1_0 = aie.objectfifo.subview.access %fifo_pipe_0_1_0[0] : !aie.objectfifosubview<memref<8x8xi16>> -> memref<8x8xi16>
        memref.copy %tile_comp_gemm_0_1_0_buf3, %local_pipe_0_1_0 : memref<8x8xi16> to memref<8x8xi16>
        aie.objectfifo.release @pipe_0_1_0(Produce, 1)
        aie.objectfifo.release @in_mem_A_10(Consume, 1)
        aie.objectfifo.release @in_mem_B_00(Consume, 1)
      }
      aie.end
    } {link_with = "external.o"}
    %core_0_5_tile_comp_gemm_0_1_1 = aie.core(%tile_comp_gemm_0_1_1) {
      %global_c0 = arith.constant 0 : index
      %global_c1 = arith.constant 1 : index
      %c9223372036854775807 = arith.constant 9223372036854775807 : index
      scf.for %arg0 = %global_c0 to %c9223372036854775807 step %global_c1 {
        %fifo0 = aie.objectfifo.acquire @in_mem_A_10(Consume, 1) : !aie.objectfifosubview<memref<8x8xi16>>
        %local0 = aie.objectfifo.subview.access %fifo0[0] : !aie.objectfifosubview<memref<8x8xi16>> -> memref<8x8xi16>
        %fifo1 = aie.objectfifo.acquire @in_mem_B_01(Consume, 1) : !aie.objectfifosubview<memref<8x8xi16>>
        %local1 = aie.objectfifo.subview.access %fifo1[0] : !aie.objectfifosubview<memref<8x8xi16>> -> memref<8x8xi16>
        %c0_i16 = arith.constant 0 : i16
        %c0 = arith.constant 0 : index
        %c8 = arith.constant 8 : index
        %c1 = arith.constant 1 : index
        scf.for %arg4 = %c0 to %c8 step %c1 {
          %c0_12 = arith.constant 0 : index
          %c8_13 = arith.constant 8 : index
          %c1_14 = arith.constant 1 : index
          scf.for %arg5 = %c0_12 to %c8_13 step %c1_14 {
            memref.store %c0_i16, %tile_comp_gemm_0_1_1_buf0[%arg4, %arg5] : memref<8x8xi16>
          }
        }
        %c0_1 = arith.constant 0 : index
        %c8_2 = arith.constant 8 : index
        %c1_3 = arith.constant 1 : index
        scf.for %arg4 = %c0_1 to %c8_2 step %c1_3 {
          %c0_12 = arith.constant 0 : index
          %c8_13 = arith.constant 8 : index
          %c1_14 = arith.constant 1 : index
          scf.for %arg5 = %c0_12 to %c8_13 step %c1_14 {
            memref.store %c0_i16, %tile_comp_gemm_0_1_1_buf1[%arg4, %arg5] : memref<8x8xi16>
          }
        }
        func.call @matmul_scalar_i16_i16(%local0, %local1, %tile_comp_gemm_0_1_1_buf1) : (memref<8x8xi16>, memref<8x8xi16>, memref<8x8xi16>) -> ()
        %c0_5 = arith.constant 0 : index
        %c8_6 = arith.constant 8 : index
        %c1_7 = arith.constant 1 : index
        scf.for %arg4 = %c0_5 to %c8_6 step %c1_7 {
          %c0_12 = arith.constant 0 : index
          %c8_13 = arith.constant 8 : index
          %c1_14 = arith.constant 1 : index
          scf.for %arg5 = %c0_12 to %c8_13 step %c1_14 {
            %0 = memref.load %tile_comp_gemm_0_1_1_buf1[%arg4, %arg5] : memref<8x8xi16>
            %1 = memref.load %tile_comp_gemm_0_1_1_buf0[%arg4, %arg5] : memref<8x8xi16>
            %2 = arith.addi %0, %1 : i16
            memref.store %2, %tile_comp_gemm_0_1_1_buf2[%arg4, %arg5] : memref<8x8xi16>
          }
        }
        %c0_9 = arith.constant 0 : index
        %c8_10 = arith.constant 8 : index
        %c1_11 = arith.constant 1 : index
        scf.for %arg4 = %c0_9 to %c8_10 step %c1_11 {
          %c0_12 = arith.constant 0 : index
          %c8_13 = arith.constant 8 : index
          %c1_14 = arith.constant 1 : index
          scf.for %arg5 = %c0_12 to %c8_13 step %c1_14 {
            %0 = memref.load %tile_comp_gemm_0_1_1_buf2[%arg4, %arg5] : memref<8x8xi16>
            memref.store %0, %tile_comp_gemm_0_1_1_buf3[%arg4, %arg5] : memref<8x8xi16>
          }
        }
        %fifo_pipe_0_1_1 = aie.objectfifo.acquire @pipe_0_1_1(Produce, 1) : !aie.objectfifosubview<memref<8x8xi16>>
        %local_pipe_0_1_1 = aie.objectfifo.subview.access %fifo_pipe_0_1_1[0] : !aie.objectfifosubview<memref<8x8xi16>> -> memref<8x8xi16>
        memref.copy %tile_comp_gemm_0_1_1_buf3, %local_pipe_0_1_1 : memref<8x8xi16> to memref<8x8xi16>
        aie.objectfifo.release @pipe_0_1_1(Produce, 1)
        aie.objectfifo.release @in_mem_A_10(Consume, 1)
        aie.objectfifo.release @in_mem_B_01(Consume, 1)
      }
      aie.end
    } {link_with = "external.o"}
    %core_0_6_tile_comp_gemm_1_0_0 = aie.core(%tile_comp_gemm_1_0_0) {
      %global_c0 = arith.constant 0 : index
      %global_c1 = arith.constant 1 : index
      %c9223372036854775807 = arith.constant 9223372036854775807 : index
      scf.for %arg0 = %global_c0 to %c9223372036854775807 step %global_c1 {
        %fifo0 = aie.objectfifo.acquire @in_mem_A_01(Consume, 1) : !aie.objectfifosubview<memref<8x8xi16>>
        %local0 = aie.objectfifo.subview.access %fifo0[0] : !aie.objectfifosubview<memref<8x8xi16>> -> memref<8x8xi16>
        %fifo1 = aie.objectfifo.acquire @in_mem_B_10(Consume, 1) : !aie.objectfifosubview<memref<8x8xi16>>
        %local1 = aie.objectfifo.subview.access %fifo1[0] : !aie.objectfifosubview<memref<8x8xi16>> -> memref<8x8xi16>
        %fifo_out0 = aie.objectfifo.acquire @out_mem_C_00(Produce, 1) : !aie.objectfifosubview<memref<8x8xi16>>
        %local_out0 = aie.objectfifo.subview.access %fifo_out0[0] : !aie.objectfifosubview<memref<8x8xi16>> -> memref<8x8xi16>
        %c0_i16 = arith.constant 0 : i16
        %fifo_pipe_0_0_0 = aie.objectfifo.acquire @pipe_0_0_0(Consume, 1) : !aie.objectfifosubview<memref<8x8xi16>>
        %local_pipe_0_0_0 = aie.objectfifo.subview.access %fifo_pipe_0_0_0[0] : !aie.objectfifosubview<memref<8x8xi16>> -> memref<8x8xi16>
        aie.objectfifo.release @pipe_0_0_0(Consume, 1)
        %c0 = arith.constant 0 : index
        %c8 = arith.constant 8 : index
        %c1 = arith.constant 1 : index
        scf.for %arg4 = %c0 to %c8 step %c1 {
          %c0_8 = arith.constant 0 : index
          %c8_9 = arith.constant 8 : index
          %c1_10 = arith.constant 1 : index
          scf.for %arg5 = %c0_8 to %c8_9 step %c1_10 {
            memref.store %c0_i16, %tile_comp_gemm_1_0_0_buf0[%arg4, %arg5] : memref<8x8xi16>
          }
        }
        func.call @matmul_scalar_i16_i16(%local0, %local1, %tile_comp_gemm_1_0_0_buf0) : (memref<8x8xi16>, memref<8x8xi16>, memref<8x8xi16>) -> ()
        %c0_1 = arith.constant 0 : index
        %c8_2 = arith.constant 8 : index
        %c1_3 = arith.constant 1 : index
        scf.for %arg4 = %c0_1 to %c8_2 step %c1_3 {
          %c0_8 = arith.constant 0 : index
          %c8_9 = arith.constant 8 : index
          %c1_10 = arith.constant 1 : index
          scf.for %arg5 = %c0_8 to %c8_9 step %c1_10 {
            %1 = memref.load %tile_comp_gemm_1_0_0_buf0[%arg4, %arg5] : memref<8x8xi16>
            %2 = memref.load %local_pipe_0_0_0[%arg4, %arg5] : memref<8x8xi16>
            %3 = arith.addi %1, %2 : i16
            memref.store %3, %tile_comp_gemm_1_0_0_buf1[%arg4, %arg5] : memref<8x8xi16>
          }
        }
        %c0_5 = arith.constant 0 : index
        %c8_6 = arith.constant 8 : index
        %c1_7 = arith.constant 1 : index
        scf.for %arg4 = %c0_5 to %c8_6 step %c1_7 {
          %c0_8 = arith.constant 0 : index
          %c8_9 = arith.constant 8 : index
          %c1_10 = arith.constant 1 : index
          scf.for %arg5 = %c0_8 to %c8_9 step %c1_10 {
            %1 = memref.load %tile_comp_gemm_1_0_0_buf1[%arg4, %arg5] : memref<8x8xi16>
            memref.store %1, %tile_comp_gemm_1_0_0_buf2[%arg4, %arg5] : memref<8x8xi16>
          }
        }
        memref.copy %tile_comp_gemm_1_0_0_buf2, %local_out0 {to = "C"} : memref<8x8xi16> to memref<8x8xi16>
        aie.objectfifo.release @in_mem_A_01(Consume, 1)
        aie.objectfifo.release @in_mem_B_10(Consume, 1)
        aie.objectfifo.release @out_mem_C_00(Produce, 1)
      }
      aie.end
    } {link_with = "external.o"}
    %core_0_7_tile_comp_gemm_1_0_1 = aie.core(%tile_comp_gemm_1_0_1) {
      %global_c0 = arith.constant 0 : index
      %global_c1 = arith.constant 1 : index
      %c9223372036854775807 = arith.constant 9223372036854775807 : index
      scf.for %arg0 = %global_c0 to %c9223372036854775807 step %global_c1 {
        %fifo0 = aie.objectfifo.acquire @in_mem_A_01(Consume, 1) : !aie.objectfifosubview<memref<8x8xi16>>
        %local0 = aie.objectfifo.subview.access %fifo0[0] : !aie.objectfifosubview<memref<8x8xi16>> -> memref<8x8xi16>
        %fifo1 = aie.objectfifo.acquire @in_mem_B_11(Consume, 1) : !aie.objectfifosubview<memref<8x8xi16>>
        %local1 = aie.objectfifo.subview.access %fifo1[0] : !aie.objectfifosubview<memref<8x8xi16>> -> memref<8x8xi16>
        %fifo_out0 = aie.objectfifo.acquire @out_mem_C_01(Produce, 1) : !aie.objectfifosubview<memref<8x8xi16>>
        %local_out0 = aie.objectfifo.subview.access %fifo_out0[0] : !aie.objectfifosubview<memref<8x8xi16>> -> memref<8x8xi16>
        %c0_i16 = arith.constant 0 : i16
        %fifo_pipe_0_0_1 = aie.objectfifo.acquire @pipe_0_0_1(Consume, 1) : !aie.objectfifosubview<memref<8x8xi16>>
        %local_pipe_0_0_1 = aie.objectfifo.subview.access %fifo_pipe_0_0_1[0] : !aie.objectfifosubview<memref<8x8xi16>> -> memref<8x8xi16>
        aie.objectfifo.release @pipe_0_0_1(Consume, 1)
        %c0 = arith.constant 0 : index
        %c8 = arith.constant 8 : index
        %c1 = arith.constant 1 : index
        scf.for %arg4 = %c0 to %c8 step %c1 {
          %c0_8 = arith.constant 0 : index
          %c8_9 = arith.constant 8 : index
          %c1_10 = arith.constant 1 : index
          scf.for %arg5 = %c0_8 to %c8_9 step %c1_10 {
            memref.store %c0_i16, %tile_comp_gemm_1_0_1_buf0[%arg4, %arg5] : memref<8x8xi16>
          }
        }
        func.call @matmul_scalar_i16_i16(%local0, %local1, %tile_comp_gemm_1_0_1_buf0) : (memref<8x8xi16>, memref<8x8xi16>, memref<8x8xi16>) -> ()
        %c0_1 = arith.constant 0 : index
        %c8_2 = arith.constant 8 : index
        %c1_3 = arith.constant 1 : index
        scf.for %arg4 = %c0_1 to %c8_2 step %c1_3 {
          %c0_8 = arith.constant 0 : index
          %c8_9 = arith.constant 8 : index
          %c1_10 = arith.constant 1 : index
          scf.for %arg5 = %c0_8 to %c8_9 step %c1_10 {
            %1 = memref.load %tile_comp_gemm_1_0_1_buf0[%arg4, %arg5] : memref<8x8xi16>
            %2 = memref.load %local_pipe_0_0_1[%arg4, %arg5] : memref<8x8xi16>
            %3 = arith.addi %1, %2 : i16
            memref.store %3, %tile_comp_gemm_1_0_1_buf1[%arg4, %arg5] : memref<8x8xi16>
          }
        }
        %c0_5 = arith.constant 0 : index
        %c8_6 = arith.constant 8 : index
        %c1_7 = arith.constant 1 : index
        scf.for %arg4 = %c0_5 to %c8_6 step %c1_7 {
          %c0_8 = arith.constant 0 : index
          %c8_9 = arith.constant 8 : index
          %c1_10 = arith.constant 1 : index
          scf.for %arg5 = %c0_8 to %c8_9 step %c1_10 {
            %1 = memref.load %tile_comp_gemm_1_0_1_buf1[%arg4, %arg5] : memref<8x8xi16>
            memref.store %1, %tile_comp_gemm_1_0_1_buf2[%arg4, %arg5] : memref<8x8xi16>
          }
        }
        memref.copy %tile_comp_gemm_1_0_1_buf2, %local_out0 {to = "C"} : memref<8x8xi16> to memref<8x8xi16>
        aie.objectfifo.release @in_mem_A_01(Consume, 1)
        aie.objectfifo.release @in_mem_B_11(Consume, 1)
        aie.objectfifo.release @out_mem_C_01(Produce, 1)
      }
      aie.end
    } {link_with = "external.o"}
    %core_0_8_tile_comp_gemm_1_1_0 = aie.core(%tile_comp_gemm_1_1_0) {
      %global_c0 = arith.constant 0 : index
      %global_c1 = arith.constant 1 : index
      %c9223372036854775807 = arith.constant 9223372036854775807 : index
      scf.for %arg0 = %global_c0 to %c9223372036854775807 step %global_c1 {
        %fifo0 = aie.objectfifo.acquire @in_mem_A_11(Consume, 1) : !aie.objectfifosubview<memref<8x8xi16>>
        %local0 = aie.objectfifo.subview.access %fifo0[0] : !aie.objectfifosubview<memref<8x8xi16>> -> memref<8x8xi16>
        %fifo1 = aie.objectfifo.acquire @in_mem_B_10(Consume, 1) : !aie.objectfifosubview<memref<8x8xi16>>
        %local1 = aie.objectfifo.subview.access %fifo1[0] : !aie.objectfifosubview<memref<8x8xi16>> -> memref<8x8xi16>
        %fifo_out0 = aie.objectfifo.acquire @out_mem_C_10(Produce, 1) : !aie.objectfifosubview<memref<8x8xi16>>
        %local_out0 = aie.objectfifo.subview.access %fifo_out0[0] : !aie.objectfifosubview<memref<8x8xi16>> -> memref<8x8xi16>
        %c0_i16 = arith.constant 0 : i16
        %fifo_pipe_0_1_0 = aie.objectfifo.acquire @pipe_0_1_0(Consume, 1) : !aie.objectfifosubview<memref<8x8xi16>>
        %local_pipe_0_1_0 = aie.objectfifo.subview.access %fifo_pipe_0_1_0[0] : !aie.objectfifosubview<memref<8x8xi16>> -> memref<8x8xi16>
        aie.objectfifo.release @pipe_0_1_0(Consume, 1)
        %c0 = arith.constant 0 : index
        %c8 = arith.constant 8 : index
        %c1 = arith.constant 1 : index
        scf.for %arg4 = %c0 to %c8 step %c1 {
          %c0_8 = arith.constant 0 : index
          %c8_9 = arith.constant 8 : index
          %c1_10 = arith.constant 1 : index
          scf.for %arg5 = %c0_8 to %c8_9 step %c1_10 {
            memref.store %c0_i16, %tile_comp_gemm_1_1_0_buf0[%arg4, %arg5] : memref<8x8xi16>
          }
        }
        func.call @matmul_scalar_i16_i16(%local0, %local1, %tile_comp_gemm_1_1_0_buf0) : (memref<8x8xi16>, memref<8x8xi16>, memref<8x8xi16>) -> ()
        %c0_1 = arith.constant 0 : index
        %c8_2 = arith.constant 8 : index
        %c1_3 = arith.constant 1 : index
        scf.for %arg4 = %c0_1 to %c8_2 step %c1_3 {
          %c0_8 = arith.constant 0 : index
          %c8_9 = arith.constant 8 : index
          %c1_10 = arith.constant 1 : index
          scf.for %arg5 = %c0_8 to %c8_9 step %c1_10 {
            %1 = memref.load %tile_comp_gemm_1_1_0_buf0[%arg4, %arg5] : memref<8x8xi16>
            %2 = memref.load %local_pipe_0_1_0[%arg4, %arg5] : memref<8x8xi16>
            %3 = arith.addi %1, %2 : i16
            memref.store %3, %tile_comp_gemm_1_1_0_buf1[%arg4, %arg5] : memref<8x8xi16>
          }
        }
        %c0_5 = arith.constant 0 : index
        %c8_6 = arith.constant 8 : index
        %c1_7 = arith.constant 1 : index
        scf.for %arg4 = %c0_5 to %c8_6 step %c1_7 {
          %c0_8 = arith.constant 0 : index
          %c8_9 = arith.constant 8 : index
          %c1_10 = arith.constant 1 : index
          scf.for %arg5 = %c0_8 to %c8_9 step %c1_10 {
            %1 = memref.load %tile_comp_gemm_1_1_0_buf1[%arg4, %arg5] : memref<8x8xi16>
            memref.store %1, %tile_comp_gemm_1_1_0_buf2[%arg4, %arg5] : memref<8x8xi16>
          }
        }
        memref.copy %tile_comp_gemm_1_1_0_buf2, %local_out0 {to = "C"} : memref<8x8xi16> to memref<8x8xi16>
        aie.objectfifo.release @in_mem_A_11(Consume, 1)
        aie.objectfifo.release @in_mem_B_10(Consume, 1)
        aie.objectfifo.release @out_mem_C_10(Produce, 1)
      }
      aie.end
    } {link_with = "external.o"}
    %core_0_9_tile_comp_gemm_1_1_1 = aie.core(%tile_comp_gemm_1_1_1) {
      %global_c0 = arith.constant 0 : index
      %global_c1 = arith.constant 1 : index
      %c9223372036854775807 = arith.constant 9223372036854775807 : index
      scf.for %arg0 = %global_c0 to %c9223372036854775807 step %global_c1 {
        %fifo0 = aie.objectfifo.acquire @in_mem_A_11(Consume, 1) : !aie.objectfifosubview<memref<8x8xi16>>
        %local0 = aie.objectfifo.subview.access %fifo0[0] : !aie.objectfifosubview<memref<8x8xi16>> -> memref<8x8xi16>
        %fifo1 = aie.objectfifo.acquire @in_mem_B_11(Consume, 1) : !aie.objectfifosubview<memref<8x8xi16>>
        %local1 = aie.objectfifo.subview.access %fifo1[0] : !aie.objectfifosubview<memref<8x8xi16>> -> memref<8x8xi16>
        %fifo_out0 = aie.objectfifo.acquire @out_mem_C_11(Produce, 1) : !aie.objectfifosubview<memref<8x8xi16>>
        %local_out0 = aie.objectfifo.subview.access %fifo_out0[0] : !aie.objectfifosubview<memref<8x8xi16>> -> memref<8x8xi16>
        %c0_i16 = arith.constant 0 : i16
        %fifo_pipe_0_1_1 = aie.objectfifo.acquire @pipe_0_1_1(Consume, 1) : !aie.objectfifosubview<memref<8x8xi16>>
        %local_pipe_0_1_1 = aie.objectfifo.subview.access %fifo_pipe_0_1_1[0] : !aie.objectfifosubview<memref<8x8xi16>> -> memref<8x8xi16>
        aie.objectfifo.release @pipe_0_1_1(Consume, 1)
        %c0 = arith.constant 0 : index
        %c8 = arith.constant 8 : index
        %c1 = arith.constant 1 : index
        scf.for %arg4 = %c0 to %c8 step %c1 {
          %c0_8 = arith.constant 0 : index
          %c8_9 = arith.constant 8 : index
          %c1_10 = arith.constant 1 : index
          scf.for %arg5 = %c0_8 to %c8_9 step %c1_10 {
            memref.store %c0_i16, %tile_comp_gemm_1_1_1_buf0[%arg4, %arg5] : memref<8x8xi16>
          }
        }
        func.call @matmul_scalar_i16_i16(%local0, %local1, %tile_comp_gemm_1_1_1_buf0) : (memref<8x8xi16>, memref<8x8xi16>, memref<8x8xi16>) -> ()
        %c0_1 = arith.constant 0 : index
        %c8_2 = arith.constant 8 : index
        %c1_3 = arith.constant 1 : index
        scf.for %arg4 = %c0_1 to %c8_2 step %c1_3 {
          %c0_8 = arith.constant 0 : index
          %c8_9 = arith.constant 8 : index
          %c1_10 = arith.constant 1 : index
          scf.for %arg5 = %c0_8 to %c8_9 step %c1_10 {
            %1 = memref.load %tile_comp_gemm_1_1_1_buf0[%arg4, %arg5] : memref<8x8xi16>
            %2 = memref.load %local_pipe_0_1_1[%arg4, %arg5] : memref<8x8xi16>
            %3 = arith.addi %1, %2 : i16
            memref.store %3, %tile_comp_gemm_1_1_1_buf1[%arg4, %arg5] : memref<8x8xi16>
          }
        }
        %c0_5 = arith.constant 0 : index
        %c8_6 = arith.constant 8 : index
        %c1_7 = arith.constant 1 : index
        scf.for %arg4 = %c0_5 to %c8_6 step %c1_7 {
          %c0_8 = arith.constant 0 : index
          %c8_9 = arith.constant 8 : index
          %c1_10 = arith.constant 1 : index
          scf.for %arg5 = %c0_8 to %c8_9 step %c1_10 {
            %1 = memref.load %tile_comp_gemm_1_1_1_buf1[%arg4, %arg5] : memref<8x8xi16>
            memref.store %1, %tile_comp_gemm_1_1_1_buf2[%arg4, %arg5] : memref<8x8xi16>
          }
        }
        memref.copy %tile_comp_gemm_1_1_1_buf2, %local_out0 {to = "C"} : memref<8x8xi16> to memref<8x8xi16>
        aie.objectfifo.release @in_mem_A_11(Consume, 1)
        aie.objectfifo.release @in_mem_B_11(Consume, 1)
        aie.objectfifo.release @out_mem_C_11(Produce, 1)
      }
      aie.end
    } {link_with = "external.o"}
    aiex.runtime_sequence(%arg0: memref<16x16xi16>, %arg1: memref<16x16xi16>, %arg2: memref<16x16xi16>) {
      aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][2, 2, 8, 8][128, 8, 16, 1]) {id = 0 : i64, issue_token = true, metadata = @in_shim_A} : memref<16x16xi16>
      aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 0][2, 2, 8, 8][128, 8, 16, 1]) {id = 1 : i64, issue_token = true, metadata = @in_shim_B} : memref<16x16xi16>
      aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 0, 0][2, 2, 8, 8][128, 8, 16, 1]) {id = 2 : i64, metadata = @out_shim_C} : memref<16x16xi16>
      aiex.npu.dma_wait {symbol = @in_shim_A}
      aiex.npu.dma_wait {symbol = @in_shim_B}
      aiex.npu.dma_wait {symbol = @out_shim_C}
    }
  }
}
```

## Checklist ##

Please make sure to review and check all of these items:
- [ ] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [ ] All changes have test coverage (It would be good to provide ~2 different test cases to test the robustness of your code)
- [ ] Pass the [formatting check](https://cornell-zhang.github.io/allo/developer/index.html#id1) locally
- [ ] Code is well-documented
