### PR TITLE
[Dataflow] Support function calls in dataflow region

### DIFF
--- a/allo/ir/builder.py
+++ b/allo/ir/builder.py
@@ -1476,7 +1476,8 @@ class ASTTransformer(ASTBuilder):
                                     )
                                 concated_name = "_".join(map(str, dim))
                                 node.name = orig_name + f"_{concated_name}"
-                                ASTTransformer.build_FunctionDef(new_ctx, node)
+                                func_op = ASTTransformer.build_FunctionDef(new_ctx, node)
+                                func_op.attributes["df.kernel"] = UnitAttr.get()
                             return
         else:
             old_ctx = None

--- a/allo/ir/builder.py
+++ b/allo/ir/builder.py
@@ -1476,7 +1476,9 @@ class ASTTransformer(ASTBuilder):
                                     )
                                 concated_name = "_".join(map(str, dim))
                                 node.name = orig_name + f"_{concated_name}"
-                                func_op = ASTTransformer.build_FunctionDef(new_ctx, node)
+                                func_op = ASTTransformer.build_FunctionDef(
+                                    new_ctx, node
+                                )
                                 func_op.attributes["df.kernel"] = UnitAttr.get()
                             return
         else:

--- a/allo/ir/utils.py
+++ b/allo/ir/utils.py
@@ -106,13 +106,10 @@ def get_func_id_from_param_types(param_types):
     return None
 
 
-def get_all_funcs_except_top(s):
+def get_all_df_kernels(s):
     funcs = []
     for func in s.module.body.operations:
-        if (
-            isinstance(func, func_d.FuncOp)
-            and func.attributes["sym_name"].value != s.top_func_name
-        ):
+        if isinstance(func, func_d.FuncOp) and "df.kernel" in func.attributes:
             funcs.append(func)
     return funcs
 

--- a/tests/dataflow/test_df_unit.py
+++ b/tests/dataflow/test_df_unit.py
@@ -2,8 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import allo
-from allo.ir.types import UInt
+from allo.ir.types import UInt, float32, index
 import allo.dataflow as df
+import numpy as np
 
 
 def test_uint():
@@ -30,5 +31,38 @@ def test_uint():
     assert " int16_t" not in mod.hls_code
 
 
+def test_func_index():
+    Ty = float32
+    M, N = 4, 4
+
+    def index_calculation(x: index) -> index:
+        res: index = x - 1
+        return res
+
+    @df.region()
+    def top():
+        pipe = df.pipe(dtype=Ty, shape=(), depth=4)
+
+        @df.kernel(mapping=[1])
+        def producer(A: Ty[M, N]):
+            for i, j in allo.grid(M, N):
+                out: Ty = A[i, index_calculation(j) + 1]
+                pipe.put(out)
+
+        @df.kernel(mapping=[1])
+        def consumer(B: Ty[M, N]):
+            for i, j in allo.grid(M, N):
+                data = pipe.get()
+                B[i, j] = data + 1
+
+    A = np.random.rand(M, N).astype(np.float32)
+    B = np.zeros((M, N), dtype=np.float32)
+    sim_mod = df.build(top, target="simulator")
+    sim_mod(A, B)
+    np.testing.assert_allclose(A + 1, B)
+    print("Passed!")
+
+
 if __name__ == "__main__":
     test_uint()
+    test_func_index()


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR fixes #342. It supports nested functions in the dataflow region. The dataflow functions are labeled as `df.kernel` using attributes.

### Examples ###
```python
def test_func_index():
    Ty = float32
    M, N = 4, 4

    def index_calculation(x: index) -> index:
        res: index = x - 1
        return res

    @df.region()
    def top():
        pipe = df.pipe(dtype=Ty, shape=(), depth=4)

        @df.kernel(mapping=[1])
        def producer(A: Ty[M, N]):
            for i, j in allo.grid(M, N):
                out: Ty = A[i, index_calculation(j) + 1]
                pipe.put(out)

        @df.kernel(mapping=[1])
        def consumer(B: Ty[M, N]):
            for i, j in allo.grid(M, N):
                data = pipe.get()
                B[i, j] = data + 1

    A = np.random.rand(M, N).astype(np.float32)
    B = np.zeros((M, N), dtype=np.float32)
    sim_mod = df.build(top, target="simulator")
    sim_mod(A, B)
    np.testing.assert_allclose(A + 1, B)
    print("Passed!")
```


## Checklist ##

Please make sure to review and check all of these items:
- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] All changes have test coverage (It would be good to provide ~2 different test cases to test the robustness of your code)
- [x] Pass the [formatting check](https://cornell-zhang.github.io/allo/developer/index.html#id1) locally
- [x] Code is well-documented
