### PR TITLE
[Template] Add allo.meta_for for compile-time loop unrolling

### DIFF
--- a/allo/ir/builder.py
+++ b/allo/ir/builder.py
@@ -2557,6 +2557,16 @@ class ASTTransformer(ASTBuilder):
             ), "Unmatched allo.meta_else()"
             final_cond = not ctx.meta_if_stack[ctx.with_scope_level][-1]
             ctx.meta_if_stack[ctx.with_scope_level].pop()
+        elif node.items[0].context_expr.func.attr == "meta_for":
+            assert len(node.items[0].context_expr.args) == 2, "Only support two arguments (lower and upper bound) for `allo.meta_for()`"
+            lb = ASTResolver.resolve_constant(node.items[0].context_expr.args[0], ctx)
+            ub = ASTResolver.resolve_constant(node.items[0].context_expr.args[1], ctx)
+            var = node.items[0].optional_vars.id
+            for i in range(lb, ub):
+                ctx.global_vars[var] = i
+                build_stmts(ctx, node.body)
+                ctx.global_vars.pop(var)
+            return
         else:
             raise RuntimeError("Unsupported meta function")
         if final_cond:

--- a/allo/ir/builder.py
+++ b/allo/ir/builder.py
@@ -2558,11 +2558,26 @@ class ASTTransformer(ASTBuilder):
             final_cond = not ctx.meta_if_stack[ctx.with_scope_level][-1]
             ctx.meta_if_stack[ctx.with_scope_level].pop()
         elif node.items[0].context_expr.func.attr == "meta_for":
-            assert len(node.items[0].context_expr.args) == 2, "Only support two arguments (lower and upper bound) for `allo.meta_for()`"
-            lb = ASTResolver.resolve_constant(node.items[0].context_expr.args[0], ctx)
-            ub = ASTResolver.resolve_constant(node.items[0].context_expr.args[1], ctx)
+            assert (
+                len(node.items[0].context_expr.args) <= 3
+            ), "Only support three arguments (lower, upper bound, and step) for `allo.meta_for()`"
+            rargs = [
+                ASTResolver.resolve_constant(node.items[0].context_expr.args[0], ctx)
+            ]
+            if len(node.items[0].context_expr.args) > 1:
+                rargs.append(
+                    ASTResolver.resolve_constant(
+                        node.items[0].context_expr.args[1], ctx
+                    )
+                )
+            if len(node.items[0].context_expr.args) > 2:
+                rargs.append(
+                    ASTResolver.resolve_constant(
+                        node.items[0].context_expr.args[2], ctx
+                    )
+                )
             var = node.items[0].optional_vars.id
-            for i in range(lb, ub):
+            for i in range(*rargs):
                 ctx.global_vars[var] = i
                 build_stmts(ctx, node.body)
                 ctx.global_vars.pop(var)

--- a/allo/ir/infer.py
+++ b/allo/ir/infer.py
@@ -1069,9 +1069,6 @@ class TypeInferer(ASTVisitor):
         assert isinstance(
             node.items[0].context_expr.func, ast.Attribute
         ), "Only support `with allo.meta_if/elif/else()`"
-        assert (
-            len(node.items[0].context_expr.args) <= 1
-        ), "Only support one argument for `allo.meta_if/elif/else()`"
         # Compile-time comparison
         if node.items[0].context_expr.func.attr in {"meta_if", "meta_elif"}:
             cond = ASTResolver.resolve_constant(node.items[0].context_expr.args[0], ctx)
@@ -1101,6 +1098,17 @@ class TypeInferer(ASTVisitor):
             ), "Unmatched allo.meta_else()"
             final_cond = not ctx.meta_if_stack[ctx.with_scope_level][-1]
             ctx.meta_if_stack[ctx.with_scope_level].pop()
+        elif node.items[0].context_expr.func.attr == "meta_for":
+            assert len(node.items[0].context_expr.args) == 2, "Only support two arguments (lower and upper bound) for `allo.meta_for()`"
+            _ = ASTResolver.resolve_constant(node.items[0].context_expr.args[0], ctx)
+            ub = ASTResolver.resolve_constant(node.items[0].context_expr.args[1], ctx)
+            var = node.items[0].optional_vars.id
+            ctx.global_vars[var] = ub
+            visit_stmts(ctx, node.body)
+            ctx.global_vars.pop(var)
+            node.dtype = None
+            node.shape = None
+            return node
         else:
             raise RuntimeError("Unsupported meta function")
         if final_cond:

--- a/allo/ir/infer.py
+++ b/allo/ir/infer.py
@@ -1099,11 +1099,12 @@ class TypeInferer(ASTVisitor):
             final_cond = not ctx.meta_if_stack[ctx.with_scope_level][-1]
             ctx.meta_if_stack[ctx.with_scope_level].pop()
         elif node.items[0].context_expr.func.attr == "meta_for":
-            assert len(node.items[0].context_expr.args) == 2, "Only support two arguments (lower and upper bound) for `allo.meta_for()`"
-            _ = ASTResolver.resolve_constant(node.items[0].context_expr.args[0], ctx)
-            ub = ASTResolver.resolve_constant(node.items[0].context_expr.args[1], ctx)
+            assert (
+                len(node.items[0].context_expr.args) <= 3
+            ), "Only support three arguments (lower, upper bound, and step) for `allo.meta_for()`"
+            lb = ASTResolver.resolve_constant(node.items[0].context_expr.args[0], ctx)
             var = node.items[0].optional_vars.id
-            ctx.global_vars[var] = ub
+            ctx.global_vars[var] = lb
             visit_stmts(ctx, node.body)
             ctx.global_vars.pop(var)
             node.dtype = None

--- a/allo/template.py
+++ b/allo/template.py
@@ -18,3 +18,8 @@ def meta_elif(cond):
 @contextmanager
 def meta_else():
     pass
+
+
+@contextmanager
+def meta_for(lb, ub):
+    pass

--- a/allo/template.py
+++ b/allo/template.py
@@ -21,5 +21,5 @@ def meta_else():
 
 
 @contextmanager
-def meta_for(lb, ub):
+def meta_for(lb, ub, step=1):
     pass

--- a/tests/dataflow/aie/test_tp.py
+++ b/tests/dataflow/aie/test_tp.py
@@ -36,8 +36,10 @@ def _test_tensor_parallelism():
 
         @df.kernel(mapping=[1])
         def acc(Z: Ty[M, L]):
-            # TODO: Use dynamic index to scale
-            Z[:, :] = allo.add(part_Z[0].get(), part_Z[1].get())
+            Z_out: Ty[M, L] = 0
+            with allo.meta_for(P0) as i:
+                Z_out[:, :] += part_Z[i].get()
+            Z[:, :] = Z_out
 
     X = np.random.randint(0, 64, (M, K)).astype(np.int32)
     W1 = np.random.randint(0, 64, (K, N)).astype(np.int32)

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -7,9 +7,9 @@ import allo
 from allo.ir.types import int8, int32, float32
 
 
-def kernel[TyA, TyB, TyC, M: int32, K: int32, N: int32](
-    A: "TyA[M, K]", B: "TyB[K, N]"
-) -> "TyC[M, N]":
+def kernel[
+    TyA, TyB, TyC, M: int32, K: int32, N: int32
+](A: "TyA[M, K]", B: "TyB[K, N]") -> "TyC[M, N]":
     C: TyC[M, N]
     for i in range(M):
         for j in range(N):

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -7,9 +7,9 @@ import allo
 from allo.ir.types import int8, int32, float32
 
 
-def kernel[
-    TyA, TyB, TyC, M: int32, K: int32, N: int32
-](A: "TyA[M, K]", B: "TyB[K, N]") -> "TyC[M, N]":
+def kernel[TyA, TyB, TyC, M: int32, K: int32, N: int32](
+    A: "TyA[M, K]", B: "TyB[K, N]"
+) -> "TyC[M, N]":
     C: TyC[M, N]
     for i in range(M):
         for j in range(N):
@@ -150,6 +150,22 @@ def test_double_meta_if():
     mod = s.build()
     np_A = np.random.randn(M).astype(np.int32)
     np_golden = np_A.copy()
+    mod(np_A)
+    np.testing.assert_allclose(np_A, np_golden, rtol=1e-4, atol=1e-4)
+
+
+def test_meta_for():
+    N = 8
+
+    def top(A: int32[N]):
+        with allo.meta_for(0, N) as i:
+            A[i] = A[i] + 1
+
+    s = allo.customize(top)
+    print(s.module)
+    mod = s.build()
+    np_A = np.random.randn(N).astype(np.int32)
+    np_golden = np_A.copy() + 1
     mod(np_A)
     np.testing.assert_allclose(np_A, np_golden, rtol=1e-4, atol=1e-4)
 

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -160,12 +160,21 @@ def test_meta_for():
     def top(A: int32[N]):
         with allo.meta_for(0, N) as i:
             A[i] = A[i] + 1
+        with allo.meta_for(N) as i:
+            A[i] = A[i] - 1
+        with allo.meta_for(N - 1, N, 2) as i:
+            with allo.meta_if(i == N - 1):
+                A[i] = A[i] + 3
+        with allo.meta_for(N + 1, N, 1) as i:
+            # will not be executed
+            A[i] = A[i] * 2
 
     s = allo.customize(top)
     print(s.module)
     mod = s.build()
-    np_A = np.random.randn(N).astype(np.int32)
-    np_golden = np_A.copy() + 1
+    np_A = np.random.randint(0, 10, N).astype(np.int32)
+    np_golden = np_A.copy()
+    np_golden[-1] += 3
     mod(np_A)
     np.testing.assert_allclose(np_A, np_golden, rtol=1e-4, atol=1e-4)
 


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR introduces a new metaprogramming primitive `allo.meta_for` for compile-time loop unrolling, which is useful for some cases that require compile-time constant values (e.g., FIFO array indices). This PR fixes #325.

### Examples ###
```python
def test_meta_for():
    N = 8

    def top(A: int32[N]):
        with allo.meta_for(0, N) as i:
            A[i] = A[i] + 1
        with allo.meta_for(N) as i:
            A[i] = A[i] - 1
        with allo.meta_for(N - 1, N, 2) as i:
            with allo.meta_if(i == N - 1):
                A[i] = A[i] + 3
        with allo.meta_for(N + 1, N, 1) as i:
            # will not be executed
            A[i] = A[i] * 2

    s = allo.customize(top)
    print(s.module)
    mod = s.build()
    np_A = np.random.randint(0, 10, N).astype(np.int32)
    np_golden = np_A.copy()
    np_golden[-1] += 3
    mod(np_A)
    np.testing.assert_allclose(np_A, np_golden, rtol=1e-4, atol=1e-4)
```

We can see from the MLIR module that the loop body is unrolled.
```mlir
module {
  func.func @top(%arg0: memref<8xi32>) attributes {itypes = "s", otypes = ""} {
    %0 = affine.load %arg0[0] {from = "A"} : memref<8xi32>
    %1 = arith.extsi %0 : i32 to i33
    %c1_i32 = arith.constant 1 : i32
    %2 = arith.extsi %c1_i32 : i32 to i33
    %3 = arith.addi %1, %2 : i33
    %4 = arith.trunci %3 : i33 to i32
    affine.store %4, %arg0[0] {to = "A"} : memref<8xi32>
    %5 = affine.load %arg0[1] {from = "A"} : memref<8xi32>
    %6 = arith.extsi %5 : i32 to i33
    %c1_i32_0 = arith.constant 1 : i32
    %7 = arith.extsi %c1_i32_0 : i32 to i33
    %8 = arith.addi %6, %7 : i33
    %9 = arith.trunci %8 : i33 to i32
    affine.store %9, %arg0[1] {to = "A"} : memref<8xi32>
    %10 = affine.load %arg0[2] {from = "A"} : memref<8xi32>
    %11 = arith.extsi %10 : i32 to i33
    %c1_i32_1 = arith.constant 1 : i32
    %12 = arith.extsi %c1_i32_1 : i32 to i33
    %13 = arith.addi %11, %12 : i33
    %14 = arith.trunci %13 : i33 to i32
    affine.store %14, %arg0[2] {to = "A"} : memref<8xi32>
    %15 = affine.load %arg0[3] {from = "A"} : memref<8xi32>
    %16 = arith.extsi %15 : i32 to i33
    %c1_i32_2 = arith.constant 1 : i32
    %17 = arith.extsi %c1_i32_2 : i32 to i33
    %18 = arith.addi %16, %17 : i33
    %19 = arith.trunci %18 : i33 to i32
    affine.store %19, %arg0[3] {to = "A"} : memref<8xi32>
    ...
    return
  }
}
```

## Checklist ##

Please make sure to review and check all of these items:
- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] All changes have test coverage (It would be good to provide ~2 different test cases to test the robustness of your code)
- [x] Pass the [formatting check](https://cornell-zhang.github.io/allo/developer/index.html#id1) locally
- [x] Code is well-documented
