### PR TITLE
[Primitive] Fix nested compose

### DIFF
--- a/allo/customize.py
+++ b/allo/customize.py
@@ -966,15 +966,8 @@ class Schedule:
                         args[0] = get_name(args[0])
                 with self.module.context, Location.unknown():
                     primitive_func = getattr(self, primitive[0])
-                    # Access the original function that was decorated
-                    original_func = (
-                        primitive_func.__wrapped__
-                        if hasattr(primitive_func, "__wrapped__")
-                        else primitive_func
-                    )
-                    # Apply the original function directly
-                    original_func(self, *args, **kwargs)
-                    self.primitive_sequences.append((primitive[0], args, kwargs))
+                    # directly apply primitives to new functions
+                    primitive_func(*args, **kwargs)
 
     def get_equivalent_variables(self, name):
         use_def = analyze_use_def(self.module)

--- a/tests/test_schedule_compose.py
+++ b/tests/test_schedule_compose.py
@@ -473,10 +473,15 @@ def test_nested_compose():
     s_const_5 = schedule_const(add_const, 5)
     s_const_7 = schedule_const(add_const, 7)
     s = allo.customize(top)
-    s.compose(s_const_5, id="const5")
-    s.compose(s_const_7, id="const7")
-    mod = s.build(target="vitis_hls")
-    print(mod)
+    # only apply to one of the add_const
+    s.compose(s_const_5, id="const7")
+    mod = s.build(target="vitis_hls").hls_code
+    assert "add_const5" in mod and "add_const_const5" in mod
+    assert "add_const7" in mod and "add_const_const7" in mod
+    # Count number of pipeline pragmas in the module
+    # including the load/store rewind
+    pipeline_count = str(mod).count("#pragma HLS pipeline II=1")
+    assert pipeline_count == 2
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR fixes #352 by avoiding adding duplicated primitives to `primitive_sequences` when applying `s.compose`.

### Examples ###
See #352.


## Checklist ##

Please make sure to review and check all of these items:
- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] All changes have test coverage (It would be good to provide ~2 different test cases to test the robustness of your code)
- [x] Pass the [formatting check](https://cornell-zhang.github.io/allo/developer/index.html#id1) locally
- [x] Code is well-documented
