### PR TITLE
[Backend][AIE] Remove redundant local buffer through buffer relaying in builder and support zero external kernel

### DIFF
--- a/allo/ir/builder.py
+++ b/allo/ir/builder.py
@@ -799,43 +799,77 @@ class ASTTransformer(ASTBuilder):
 
     @staticmethod
     def build_Assign(ctx, node):
-        # Compute RHS
-        rhs = build_stmt(ctx, node.value)
+        # Remove redundant array building
         if (
-            isinstance(node.value, ast.Call) or len(node.value.shape) > 0
-        ) and not isinstance(node.targets[0], ast.Subscript):
-            targets = []
-            if isinstance(node.targets[0], ast.Tuple):
-                targets = node.targets[0].elts
-            else:
-                targets = [node.targets[0]]
-            for idx, target in enumerate(targets):
-                if isinstance(target, ast.Name):
-                    if isinstance(rhs, list):
-                        # array of FIFOs
-                        for ele in rhs:
-                            new_name = target.id + "_" + ele.attributes["id"].value
-                            ele.attributes["name"] = StringAttr.get(new_name)
-                            ctx.buffers[new_name] = ele
-                        return rhs
-                    if hasattr(rhs, "attributes"):
-                        rhs.attributes["name"] = StringAttr.get(target.id)
-                    if target.id in ctx.buffers:
-                        raise RuntimeError(
-                            f"Variable `{target.id}` has already been defined, please use a different name"
-                        )
-                    ctx.buffers[target.id] = rhs[idx] if isinstance(rhs, tuple) else rhs
-                    if (
-                        isinstance(node.value, ast.Call)
-                        and isinstance(node.value.func, ast.Attribute)
-                        and node.value.func.attr == "get_pid"
-                    ):
-                        ctx.global_vars[ast.unparse(target)] = ctx.global_vars[
-                            f"df.p{idx}"
-                        ]
-                else:
-                    store_op = build_stmt(ctx, target, val=rhs, idx=idx)
+            isinstance(node.value, ast.Call)
+            and isinstance(node.value.func, ast.Attribute)
+            and isinstance(node.targets[0], ast.Subscript)
+            and isinstance(node.targets[0].value, ast.Name)
+            and node.targets[0].value.id in ctx.buffers
+            and node.value.func.attr in {
+                "matmul",
+                "bmm",
+                "softmax",
+                "exp",
+                "abs",
+                "log",
+                "add",
+                "sub",
+                "mul",
+                "div",
+                "relu",
+                "conv2d",
+                "maxpool",
+                "sumpool",
+                "copy",
+                "transpose",
+                "linear",
+                "view",
+                "concat",
+            }
+        ):
+            lhs_name = node.targets[0].value.id
+            out_buffer = ctx.buffers[lhs_name]
+            rhs = ASTTransformer.build_Call(ctx, node.value, out_buffer)
             return rhs
+        # Compute RHS
+        else:
+            rhs = build_stmt(ctx, node.value)
+            if (
+                isinstance(node.value, ast.Call) or len(node.value.shape) > 0
+            ) and not isinstance(node.targets[0], ast.Subscript):
+                targets = []
+                if isinstance(node.targets[0], ast.Tuple):
+                    targets = node.targets[0].elts
+                else:
+                    targets = [node.targets[0]]
+                for idx, target in enumerate(targets):
+                    if isinstance(target, ast.Name):
+                        if isinstance(rhs, list):
+                            # array of FIFOs
+                            for ele in rhs:
+                                new_name = target.id + "_" + ele.attributes["id"].value
+                                ele.attributes["name"] = StringAttr.get(new_name)
+                                ctx.buffers[new_name] = ele
+                            return rhs
+                        if hasattr(rhs, "attributes"):
+                            rhs.attributes["name"] = StringAttr.get(target.id)
+                        if target.id in ctx.buffers:
+                            raise RuntimeError(
+                                f"Variable `{target.id}` has already been defined, please use a different name"
+                            )
+                        ctx.buffers[target.id] = rhs[idx] if isinstance(rhs, tuple) else rhs
+                        if (
+                            isinstance(node.value, ast.Call)
+                            and isinstance(node.value.func, ast.Attribute)
+                            and node.value.func.attr == "get_pid"
+                        ):
+                            ctx.global_vars[ast.unparse(target)] = ctx.global_vars[
+                                f"df.p{idx}"
+                            ]
+                    else:
+                        store_op = build_stmt(ctx, target, val=rhs, idx=idx)
+                return rhs
         # Store LHS
         rhs = ASTTransformer.build_cast_op(
             ctx, rhs, node.value.dtype, node.dtype, node.value.shape
@@ -1786,7 +1820,7 @@ class ASTTransformer(ASTBuilder):
 
     # pylint: disable=too-many-return-statements
     @staticmethod
-    def build_Call(ctx, node):
+    def build_Call(ctx, node, out_buffer=None):
         original_func_id = ctx.func_id
         if isinstance(node.func, ast.Name):
             obj = ASTResolver.resolve(node.func, ctx.global_vars)
@@ -2107,7 +2141,7 @@ class ASTTransformer(ASTBuilder):
                         node.dims[1],
                     )
                 return ASTTransformer.build_library_op(
-                    ctx, node=node, attr=fn_name, new_args=new_args
+                    ctx, node=node, attr=fn_name, new_args=new_args, out_buffer=out_buffer
                 )
             if fn_name in {"layernorm", "gelu", "tril"}:
                 arg_results = [arg.result for arg in new_args]
@@ -2168,13 +2202,14 @@ class ASTTransformer(ASTBuilder):
         return call_op
 
     @staticmethod
-    def build_library_op(ctx, node, attr, new_args, dtype=None, shape=None):
+    def build_library_op(ctx, node, attr, new_args, dtype=None, shape=None, out_buffer=None):
         assert attr is not None and attr != ""
         ip = ctx.get_ip()
         dtype = dtype if dtype is not None else node.dtype
         shape = shape if shape is not None else node.shape
+        reuse = out_buffer is not None
+        buf_op = out_buffer if reuse else ASTTransformer.build_array(ctx, dtype, shape)
         with ip:
-            alloc_op = ASTTransformer.build_array(ctx, dtype, shape)
             if attr == "concat":
                 axis = node.keywords[0].value.value
                 strides = [1] * len(shape)
@@ -2184,7 +2219,7 @@ class ASTTransformer(ASTBuilder):
                 if ctx.enable_tensor:
                     insert_op = tensor_d.InsertSliceOp(
                         source=new_args[0].result,
-                        dest=alloc_op.result,
+                        dest=buf_op.result,
                         static_offsets=offsets,
                         static_sizes=list(node.args[0].shape),
                         static_strides=strides,
@@ -2227,7 +2262,7 @@ class ASTTransformer(ASTBuilder):
                     ),
                 ]
                 op_ = memref_d.SubViewOp(
-                    source=alloc_op,
+                    source=buf_op,
                     result=result[0],
                     static_offsets=offsets,
                     static_sizes=list(node.args[0].shape),
@@ -2243,7 +2278,7 @@ class ASTTransformer(ASTBuilder):
                     ip=ctx.get_ip(),
                 )
                 view_op = memref_d.SubViewOp(
-                    source=alloc_op,
+                    source=buf_op,
                     result=result[1],
                     static_offsets=new_offsets,
                     static_sizes=list(node.args[1].shape),
@@ -2258,7 +2293,7 @@ class ASTTransformer(ASTBuilder):
                     view_op,
                     ip=ctx.get_ip(),
                 )
-                return alloc_op
+                return buf_op
             if attr in {
                 "matmul",
                 "bmm",
@@ -2270,8 +2305,8 @@ class ASTTransformer(ASTBuilder):
                 # init zero
                 zero = MockConstant(0, ctx)
                 zero = ASTTransformer.build_cast_op(ctx, zero, Int(32), node.dtype)
-                linalg_fill = linalg_d.fill(zero.result, outs=[alloc_op.result])
-                result_tensor = linalg_fill if ctx.enable_tensor else alloc_op
+                linalg_fill = linalg_d.fill(zero.result, outs=[buf_op.result])
+                result_tensor = linalg_fill if ctx.enable_tensor else buf_op
                 ASTTransformer.attach_op_name(
                     ctx,
                     node,
@@ -2280,7 +2315,7 @@ class ASTTransformer(ASTBuilder):
                     postfix="init_zero",
                 )
             else:
-                result_tensor = alloc_op
+                result_tensor = buf_op
             # build linalg op
             if attr in {
                 "matmul",
@@ -2336,7 +2371,7 @@ class ASTTransformer(ASTBuilder):
                     "maxpool": linalg_d.pooling_nchw_max,
                     "sumpool": linalg_d.pooling_nchw_sum,
                 }.get(attr)(
-                    new_args[0].result, new_args[1].result, outs=[result_tensor]
+                    new_args[0].result, new_args[1].result, outs=[result_tensor.result if hasattr(result_tensor, "result") else result_tensor]
                 )
                 op = op.owner
             elif attr in {"exp", "log", "abs", "copy"}:
@@ -2345,7 +2380,7 @@ class ASTTransformer(ASTBuilder):
                     "log": linalg_d.log,
                     "abs": linalg_d.abs,
                     "copy": linalg_d.copy,
-                }.get(attr)(new_args[0].result, outs=[result_tensor])
+                }.get(attr)(new_args[0].result, outs=[result_tensor.result if hasattr(result_tensor, "result") else result_tensor])
                 op = op.owner
             elif attr == "softmax":
                 # TODO: Failed to lower to LLVM, see https://reviews.llvm.org/D153422
@@ -2452,7 +2487,7 @@ class ASTTransformer(ASTBuilder):
             else:
                 raise RuntimeError("Unsupported operation")
             ASTTransformer.attach_op_name(ctx, node, op, attr)
-        return op if ctx.enable_tensor else result_tensor
+        return op if (ctx.enable_tensor or reuse) else result_tensor
 
     @staticmethod
     def build_flattened_shapes(node, new_args):

--- a/allo/ir/builder.py
+++ b/allo/ir/builder.py
@@ -807,6 +807,20 @@ class ASTTransformer(ASTBuilder):
             and isinstance(node.targets[0], ast.Subscript)
             and isinstance(node.targets[0].value, ast.Name)
             and node.targets[0].value.id in ctx.buffers
+            and (
+                (
+                    isinstance(node.targets[0].slice, ast.Tuple)
+                    and all(
+                        isinstance(x, ast.Slice) and x.lower is None and x.upper is None
+                        for x in node.targets[0].slice.elts
+                    )
+                )
+                or (
+                    isinstance(node.targets[0].slice, ast.Slice)
+                    and node.targets[0].slice.lower is None
+                    and node.targets[0].slice.upper is None
+                )
+            )
             and node.value.func.attr
             in {
                 "matmul",

--- a/allo/passes.py
+++ b/allo/passes.py
@@ -889,7 +889,9 @@ def analyze_read_write_patterns(mlir_func):
                         if not explicit_ins_outs:
                             # First num_ins operands are inputs
                             for i in range(min(num_ins, total_operands)):
-                                operand_arg_index = resolve_to_func_arg_index(op.operands[i])
+                                operand_arg_index = resolve_to_func_arg_index(
+                                    op.operands[i]
+                                )
                                 if operand_arg_index == arg_index:
                                     is_input = True
 
@@ -897,7 +899,9 @@ def analyze_read_write_patterns(mlir_func):
                             for i in range(
                                 max(0, total_operands - num_outs), total_operands
                             ):
-                                operand_arg_index = resolve_to_func_arg_index(op.operands[i])
+                                operand_arg_index = resolve_to_func_arg_index(
+                                    op.operands[i]
+                                )
                                 if operand_arg_index == arg_index:
                                     is_output = True
 

--- a/tests/dataflow/aie/test_matrix.py
+++ b/tests/dataflow/aie/test_matrix.py
@@ -92,7 +92,7 @@ def _test_gemm_1D():
 
 def _test_gemm_2D():
     TyI, TyO = int16, int32
-    M, N, K = 16, 16, 16
+    M, N, K = 32, 32, 32
     P0, P1 = 4, 4
 
     @df.region()
@@ -106,7 +106,8 @@ def _test_gemm_2D():
     B = np.random.randint(0, 64, (K, N)).astype(np.int16)
     C = np.zeros((M, N)).astype(np.int32)
     mod(A, B, C)
-    np.testing.assert_allclose(C, A @ B, atol=1e-5)
+    np_C = A.astype(np.int32) @ B.astype(np.int32)
+    np.testing.assert_allclose(C, np_C, atol=1e-5)
     print("PASSED!")
 
 


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR eliminates redundant local buffers by enabling buffer relaying in the builder. Specifically, if the left-hand side of an assignment is an already defined tensor, the result of the right-hand side computation is written directly into it, avoiding the creation of a new buffer and the subsequent `memref.copy`. The corresponding case will be the assignment for `A[:]` or `A[:, :]`. To ensure correctness, the target tensor is zero-initialized beforehand. This PR also adds support for external vectorized zero-initialization kernels in MLIR-AIE. Additionally, it fixes the recursive lookup strategy in the `analyze_read_write_pattern` function.


### Examples ###
For this GEMM design,
```python
TyI, TyO = int16, int32
M, N, K = 128, 128, 128
P0, P1 = 4, 4

@df.region()
def top():
    @df.kernel(mapping=[P0, P1])
    def gemm(A: TyI[M, K] @ LyA, B: TyI[K, N] @ LyB, C: TyO[M, N] @ LyC):
        C[:, :] = allo.matmul(A, B)
```
the original generated mlir in each core is like this:
```mlir
%core_0_2_tile_comp_gemm_0_0 = aie.core(%tile_comp_gemm_0_0) {
  %global_c0 = arith.constant 0 : index
  %global_c1 = arith.constant 1 : index
  %c9223372036854775807 = arith.constant 9223372036854775807 : index
  scf.for %arg0 = %global_c0 to %c9223372036854775807 step %global_c1 {
    %fifo0 = aie.objectfifo.acquire @in_mem_A_0R(Consume, 1) : !aie.objectfifosubview<memref<32x128xi16>>
    %local0 = aie.objectfifo.subview.access %fifo0[0] : !aie.objectfifosubview<memref<32x128xi16>> -> memref<32x128xi16>
    %fifo1 = aie.objectfifo.acquire @in_mem_B_R0(Consume, 1) : !aie.objectfifosubview<memref<128x32xi16>>
    %local1 = aie.objectfifo.subview.access %fifo1[0] : !aie.objectfifosubview<memref<128x32xi16>> -> memref<128x32xi16>
    %fifo_out0 = aie.objectfifo.acquire @out_mem_C_00(Produce, 1) : !aie.objectfifosubview<memref<32x32xi32>>
    %local_out0 = aie.objectfifo.subview.access %fifo_out0[0] : !aie.objectfifosubview<memref<32x32xi32>> -> memref<32x32xi32>
    %c0_i16 = arith.constant 0 : i16
    %c0 = arith.constant 0 : index
    %c32 = arith.constant 32 : index
    %c1 = arith.constant 1 : index
    scf.for %arg3 = %c0 to %c32 step %c1 {
      %c0_4 = arith.constant 0 : index
      %c32_5 = arith.constant 32 : index
      %c1_6 = arith.constant 1 : index
      scf.for %arg4 = %c0_4 to %c32_5 step %c1_6 {
        memref.store %c0_i16, %tile_comp_gemm_0_0_buf0[%arg3, %arg4] : memref<32x32xi16>
      }
    }
    func.call @matmul_scalar_i16_i16(%local0, %local1, %tile_comp_gemm_0_0_buf0) : (memref<32x128xi16>, memref<128x32xi16>, memref<32x32xi16>) -> ()
    %c0_1 = arith.constant 0 : index
    %c32_2 = arith.constant 32 : index
    %c1_3 = arith.constant 1 : index
    scf.for %arg3 = %c0_1 to %c32_2 step %c1_3 {
      %c0_4 = arith.constant 0 : index
      %c32_5 = arith.constant 32 : index
      %c1_6 = arith.constant 1 : index
      scf.for %arg4 = %c0_4 to %c32_5 step %c1_6 {
        %0 = memref.load %tile_comp_gemm_0_0_buf0[%arg3, %arg4] : memref<32x32xi16>
        %1 = arith.extsi %0 : i16 to i32
        memref.store %1, %tile_comp_gemm_0_0_buf1[%arg3, %arg4] : memref<32x32xi32>
      }
    }
    memref.copy %tile_comp_gemm_0_0_buf1, %local_out0 {to = "C"} : memref<32x32xi32> to memref<32x32xi32>
    aie.objectfifo.release @in_mem_A_0R(Consume, 1)
    aie.objectfifo.release @in_mem_B_R0(Consume, 1)
    aie.objectfifo.release @out_mem_C_00(Produce, 1)
  }
  aie.end
}
```
now, it's like this:
```mlir
%core_0_2_tile_comp_gemm_0_0 = aie.core(%tile_comp_gemm_0_0) {
  %global_c0 = arith.constant 0 : index
  %global_c1 = arith.constant 1 : index
  %c9223372036854775807 = arith.constant 9223372036854775807 : index
  scf.for %arg0 = %global_c0 to %c9223372036854775807 step %global_c1 {
    %fifo0 = aie.objectfifo.acquire @in_mem_A_0R(Consume, 1) : !aie.objectfifosubview<memref<8x32xi16>>
    %local0 = aie.objectfifo.subview.access %fifo0[0] : !aie.objectfifosubview<memref<8x32xi16>> -> memref<8x32xi16>
    %fifo1 = aie.objectfifo.acquire @in_mem_B_R0(Consume, 1) : !aie.objectfifosubview<memref<32x8xi16>>
    %local1 = aie.objectfifo.subview.access %fifo1[0] : !aie.objectfifosubview<memref<32x8xi16>> -> memref<32x8xi16>
    %fifo_out0 = aie.objectfifo.acquire @out_mem_C_00(Produce, 1) : !aie.objectfifosubview<memref<8x8xi32>>
    %local_out0 = aie.objectfifo.subview.access %fifo_out0[0] : !aie.objectfifosubview<memref<8x8xi32>> -> memref<8x8xi32>
    func.call @zero_i32_vector(%local_out0) : (memref<8x8xi32>) -> ()
    func.call @matmul_scalar_i16_i32(%local0, %local1, %local_out0) : (memref<8x32xi16>, memref<32x8xi16>, memref<8x8xi32>) -> ()
    aie.objectfifo.release @in_mem_A_0R(Consume, 1)
    aie.objectfifo.release @in_mem_B_R0(Consume, 1)
    aie.objectfifo.release @out_mem_C_00(Produce, 1)
  }
  aie.end
}
```
## Checklist ##

Please make sure to review and check all of these items:
- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] All changes have test coverage (It would be good to provide ~2 different test cases to test the robustness of your code)
- [x] Pass the [formatting check](https://cornell-zhang.github.io/allo/developer/index.html#id1) locally
- [x] Code is well-documented
