### PR TITLE
[Builder] Fix consecutive AND conditions

### DIFF
--- a/allo/ir/builder.py
+++ b/allo/ir/builder.py
@@ -1689,7 +1689,10 @@ class ASTTransformer(ASTBuilder):
             ast.And: arith_d.AndIOp,
             ast.Or: arith_d.OrIOp,
         }.get(type(node.op))
-        return opcls(stmts[0].result, stmts[1].result, ip=ctx.get_ip())
+        result = opcls(stmts[0].result, stmts[1].result, ip=ctx.get_ip())
+        for i in range(2, len(stmts)):
+            result = opcls(result.result, stmts[i].result, ip=ctx.get_ip())
+        return result
 
     @staticmethod
     def build_IfExp(ctx, node):

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -220,6 +220,23 @@ def test_logic_and_or():
     assert mod(np_A, 2) == kernel(np_A, 2)
 
 
+def test_multiple_conditions():
+    def multiple_conditions(A: int32[3], b: int32, c: int32) -> int32:
+        r: int32 = 0
+        if A[0] > 0 and A[1] > 0 and A[2] > 0 and b > 0 and c > 0:
+            r = 1
+        return r
+
+    s = allo.customize(multiple_conditions)
+    print(s.module)
+    np_A = np.array([1, 1, -1], dtype=np.int32)
+    mod = s.build()
+    assert mod(np_A, 1, 1) == multiple_conditions(np_A, 1, 1)
+    assert mod(np_A, 1, -1) == multiple_conditions(np_A, 1, -1)
+    assert mod(np_A, -1, 1) == multiple_conditions(np_A, -1, 1)
+    assert mod(np_A, -1, -1) == multiple_conditions(np_A, -1, -1)
+
+
 def test_assign_logic():
     def kernel(A: int32) -> int32:
         B: int32 = 0


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR fixes #355. The builder supposes Python AST `BoolOp` has only two arguments, which is right for multiple `and` and `or` statements used in an interleaved way. However, Python AST will wrap consecutive `and` statements to one `BoolOp` node, leading to the error. Basically we need to cascade the condition generation.

### Examples ###
```python
def test_multiple_conditions():
    def multiple_conditions(A: int32[3], b: int32, c: int32) -> int32:
        r: int32 = 0
        if A[0] > 0 and A[1] > 0 and A[2] > 0 and b > 0 and c > 0:
            r = 1
        return r

    s = allo.customize(multiple_conditions)
    print(s.module)
    np_A = np.array([1, 1, -1], dtype=np.int32)
    mod = s.build()
    assert mod(np_A, 1, 1) == multiple_conditions(np_A, 1, 1)
```


## Checklist ##

Please make sure to review and check all of these items:
- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] All changes have test coverage (It would be good to provide ~2 different test cases to test the robustness of your code)
- [x] Pass the [formatting check](https://cornell-zhang.github.io/allo/developer/index.html#id1) locally
- [x] Code is well-documented
