### PR TITLE
[Frontend][PyTorch]  Conv2d and MaxPool2d

### DIFF
--- a/allo/frontend/pytorch.py
+++ b/allo/frontend/pytorch.py
@@ -447,8 +447,8 @@ class TorchBuilder:
     def build_conv2d(self, node):
         target_name = node.target.replace(".", "_")
         inp = get_var_name(node.args[0])
-        filter = get_var_name(target_name + "_weight")
-        return f"{node.name} = dsl.conv2d({inp}, {filter})"
+        weight = get_var_name(target_name + "_weight")
+        return f"{node.name} = dsl.conv2d({inp}, {weight})"
 
     def build_maxpool(self, node):
         inp = get_var_name(node.args[0])

--- a/allo/ir/infer.py
+++ b/allo/ir/infer.py
@@ -953,7 +953,8 @@ class TypeInferer(ASTVisitor):
                     argAshape[2] - argBshape[2] + 1,
                     argAshape[3] - argBshape[3] + 1,
                 )
-            elif op_name in {"maxpool", "sumpool"}:
+            elif op_name in {"maxpool"}:
+                argBshape = ASTResolver.resolve_constant(new_args[1], ctx)
                 node.shape = (
                     argAshape[0],
                     argAshape[1],

--- a/allo/ir/infer.py
+++ b/allo/ir/infer.py
@@ -953,8 +953,9 @@ class TypeInferer(ASTVisitor):
                     argAshape[2] - argBshape[2] + 1,
                     argAshape[3] - argBshape[3] + 1,
                 )
-            elif op_name in {"maxpool"}:
-                argBshape = ASTResolver.resolve_constant(new_args[1], ctx)
+            elif op_name in {"maxpool", "sumpool"}:
+                if op_name == "maxpool":
+                    argBshape = ASTResolver.resolve_constant(new_args[1], ctx)
                 node.shape = (
                     argAshape[0],
                     argAshape[1],

--- a/examples/torch/conv2d.py
+++ b/examples/torch/conv2d.py
@@ -1,0 +1,62 @@
+# Copyright Allo authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+import allo
+from allo import maxpool
+
+torch.set_printoptions(precision=4)
+
+in_channels = 3
+out_channels = 5
+kernel_size = 3
+
+pool_size = (2, 3)
+
+out_features = 2
+
+N = 2  # batch size
+C = 3  # num of channels
+H = 4  # image height
+W = 5  # image width
+
+
+class ImageClassify(nn.Module):
+    def __init__(self):
+        super(ImageClassify, self).__init__()
+        self.conv = nn.Conv2d(in_channels, out_channels, kernel_size)
+        self.pool = nn.MaxPool2d((2, 3), stride=(1, 1))
+        self.linear = nn.Linear(
+            out_channels
+            * ((H - kernel_size + 1) // pool_size[0])
+            * ((W - kernel_size + 1) // pool_size[1]),
+            out_features,
+        )
+        self.relu = F.relu
+
+    def forward(self, x):
+        x = self.conv(x)
+        x = self.relu(x)
+        x = self.pool(x)
+        x = x.view(x.size(0), -1)
+        x = self.linear(x)
+        return x
+
+
+model = ImageClassify()
+model.eval()
+example_inputs = [torch.empty(N, C, H, W).uniform_(-10, 10)]
+llvm_mod = allo.frontend.from_pytorch(
+    model,
+    example_inputs=example_inputs,
+    verbose=True,
+)
+print(llvm_mod)
+golden = model(*example_inputs)
+np_inputs = [x.detach().numpy() for x in example_inputs]
+res = llvm_mod(*np_inputs)
+torch.testing.assert_close(res, golden.detach().numpy(), atol=1e-1, rtol=1e-2)
+print("SUCCESS!")

--- a/examples/torch/conv2d.py
+++ b/examples/torch/conv2d.py
@@ -15,6 +15,7 @@ out_channels = 5
 kernel_size = 3
 
 pool_size = (2, 3)
+stride_size = (1, 1)
 
 out_features = 2
 
@@ -28,11 +29,11 @@ class ImageClassify(nn.Module):
     def __init__(self):
         super(ImageClassify, self).__init__()
         self.conv = nn.Conv2d(in_channels, out_channels, kernel_size)
-        self.pool = nn.MaxPool2d((2, 3), stride=(1, 1))
+        self.pool = nn.MaxPool2d(pool_size, stride=stride_size)
         self.linear = nn.Linear(
             out_channels
-            * ((H - kernel_size + 1) // pool_size[0])
-            * ((W - kernel_size + 1) // pool_size[1]),
+            * ((H - kernel_size + 1 - pool_size[0]) // stride_size[0] + 1)
+            * ((W - kernel_size + 1 - pool_size[1]) // stride_size[1] + 1),
             out_features,
         )
         self.relu = F.relu

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -415,16 +415,15 @@ def test_linalg_maxpool_nchw():
     OH = H - FH + 1
     OW = W - FW + 1
     np_0 = np.random.randint(0, 1000, size=(N, C, H, W), dtype="int32")
-    np_1 = np.random.randint(0, 10, size=(FH, FW), dtype="int32")
 
-    def kernel(A: int32[N, C, H, W], B: int32[FH, FW]) -> int32[N, C, OH, OW]:
-        C = allo.maxpool(A, B)
+    def kernel(A: int32[N, C, H, W]) -> int32[N, C, OH, OW]:
+        C = allo.maxpool(A, (FH, FW))
         return C
 
     s = allo.customize(kernel)
     f = s.build()
-    np_outs = kernel(np_0, np_1)
-    outs = f(np_0, np_1)
+    np_outs = kernel(np_0)
+    outs = f(np_0)
     print(np_outs)
     print(outs)
     np.testing.assert_allclose(outs, np_outs, atol=1e-3)


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR adds support for PyToch [Conv2d](https://pytorch.org/docs/stable/generated/torch.nn.Conv2d.html) and [MaxPool2d](https://pytorch.org/docs/stable/generated/torch.nn.MaxPool2d.html).


### Examples ###
I provided a new example in `examples/torch/conv2d.py`. I combined `Conv2d` with `MaxPool2d` in the same example because they are usually used together.


## Checklist ##

- [x] PR’s title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage (It would be better to provide ~2 different test cases to test the robustness of your code)
- [x] Code is well-documented