### PR TITLE
[Backend][AIE][Profiling] Enable profiling AIE module and fix bugs

### DIFF
--- a/allo/backend/experimental/README.md
+++ b/allo/backend/experimental/README.md
@@ -306,18 +306,24 @@ print("PASSED!")
 #### Profiling
 A new profiling feature has been added to help measure the performance of the module during execution. 
 
-To enable profiling, use the `do_profile` flag in the `__call__` method in the [`AIE_MLIRModule` class](__init__.py):
+To enable profiling, use the `do_profile` flag in the `build` method in [`dataflow.py`](../../dataflow.py):
 ```python
-def __call__(
-    self,
-    *args,
-    do_profile: bool = False,
-    warmup_iterations: int = 20,
-    test_iterations: int = 100,
+def build(
+    func,
+    target="vitis_hls",
+    mode="csim",
+    project="top.prj",
+    configs=None,
+    wrap_io=True,
+    opt_default=True,
+    enable_tensor=False,
+    do_profile=False,
+    warmup_iterations=20,
+    test_iterations=100,
 ):
 ```
 
-**Parameters:**
+**New Parameters:**
 
 - `do_profile` (`bool`): Set to `True` to enable profiling. When enabled, the module performs extra warm-up and test iterations.
 - `warmup_iterations` (`int`): Number of initial iterations to warm up the system. These iterations are **excluded** from the timing measurements. Default is `20`.
@@ -346,12 +352,18 @@ def top1():
     def gemm(A: Ty[M, K] @ LyA, B: Ty[K, N] @ LyB, C: int32[M, N] @ LyC):
         C[:, :] = allo.matmul(A, B)
 
-mod = df.build(top1, target="aie-mlir")
+mod = df.build(
+    top1,
+    target="aie-mlir",
+    do_profile=True,
+    warmup_iterations=200,
+    test_iterations=1000,
+)
 A = np.random.randint(0, 32, (M, K)).astype(np.int16)
 B = np.random.randint(0, 32, (K, N)).astype(np.int16)
 C = np.zeros((M, N)).astype(np.int32)
 tmp_C = np.zeros((M, N)).astype(np.int32)
-mod(A, B, C, do_profile=True)
+mod(A, B, C)
 ```
 
 ### ⚠️ Note

--- a/allo/backend/experimental/README.md
+++ b/allo/backend/experimental/README.md
@@ -317,9 +317,9 @@ def build(
     wrap_io=True,
     opt_default=True,
     enable_tensor=False,
-    do_profile=False,
-    warmup_iterations=20,
-    test_iterations=100,
+    profile=False,
+    warmup=20,
+    num_iters=100,
 ):
 ```
 
@@ -355,9 +355,9 @@ def top1():
 mod = df.build(
     top1,
     target="aie-mlir",
-    do_profile=True,
-    warmup_iterations=200,
-    test_iterations=1000,
+    profile=True,
+    warmup=200,
+    num_iters=1000,
 )
 A = np.random.randint(0, 32, (M, K)).astype(np.int16)
 B = np.random.randint(0, 32, (K, N)).astype(np.int16)

--- a/allo/backend/experimental/README.md
+++ b/allo/backend/experimental/README.md
@@ -325,9 +325,9 @@ def build(
 
 **New Parameters:**
 
-- `do_profile` (`bool`): Set to `True` to enable profiling. When enabled, the module performs extra warm-up and test iterations.
-- `warmup_iterations` (`int`): Number of initial iterations to warm up the system. These iterations are **excluded** from the timing measurements. Default is `20`.
-- `test_iterations` (`int`): Number of timed iterations used to compute execution time. Default is `100`.
+- `profile` (`bool`): Set to `True` to enable profiling. When enabled, the module performs extra warm-up and test iterations.
+- `warmup` (`int`): Number of initial iterations to warm up the system. These iterations are **excluded** from the timing measurements. Default is `20`.
+- `num_iters` (`int`): Number of timed iterations used to compute execution time. Default is `100`.
 
 ##### Example
 ```python

--- a/allo/backend/experimental/README.md
+++ b/allo/backend/experimental/README.md
@@ -251,6 +251,57 @@ def test_producer_consumer():
         print("MLIR_AIE_INSTALL_DIR unset. Skipping AIE backend test.")
 
 ```
+
+large scale GEMM
+```python
+import allo
+from allo.ir.types import int16, int32
+import allo.dataflow as df
+import numpy as np
+from allo.memory import Layout
+
+LyA = Layout("S0R")
+LyB = Layout("RS1")
+LyC = Layout("S0S1")
+
+
+TyI, TyO = int16, int32
+total_M, total_N, total_K = 128, 128, 512
+M, N, K = 128, 128, 32
+
+
+@df.region()
+def top1():
+    @df.kernel(mapping=[4, 4])
+    def gemm(A: TyI[M, K] @ LyA, B: TyI[K, N] @ LyB, C: TyO[M, N] @ LyC):
+        C[:, :] = allo.matmul(A, B)
+
+
+@df.region()
+def top2():
+    @df.kernel(mapping=[2, 4])
+    def core(A: TyO[M, N] @ LyC, B: TyO[M, N] @ LyC, C: TyO[M, N] @ LyC):
+        C[:, :] = allo.add(A, B)
+
+
+mod1 = df.build(top1, target="aie-mlir", project="top1.prj")
+mod2 = df.build(top2, target="aie-mlir", project="top2.prj")
+
+A = np.random.randint(0, 8, (total_M, total_K)).astype(np.int16)
+B = np.random.randint(0, 8, (total_K, total_N)).astype(np.int16)
+C_tmp = np.zeros((M, N)).astype(np.int32)
+C = np.zeros((M, N)).astype(np.int32)
+
+for i in range(total_K // K):
+    tile_A = A[:, i * K : (i + 1) * K]
+    tile_B = B[i * K : (i + 1) * K, :]
+    mod1(tile_A, tile_B, C_tmp)
+    mod2(C, C_tmp, C)
+
+np.testing.assert_allclose(C, A @ B, atol=1e-5)
+print("PASSED!")
+```
+
 ### New Feature
 #### Profiling
 A new profiling feature has been added to help measure the performance of the module during execution. 

--- a/allo/backend/experimental/__init__.py
+++ b/allo/backend/experimental/__init__.py
@@ -81,7 +81,7 @@ class AIE_MLIRModule:
         )  # core func name -> a list of (dtensors, is_in)
 
         self.aie_module: aie_ir.Module = None
-        self.do_profile: bool = False
+        self.profile: bool = False
 
     def collect_io(
         self,
@@ -164,13 +164,13 @@ class AIE_MLIRModule:
     def build(
         self,
         device_type="npu1_4col",
-        do_profile: bool = False,
-        warmup_iterations: int = 20,
-        test_iterations: int = 100,
+        profile: bool = False,
+        warmup: int = 20,
+        num_iters: int = 100,
     ):
-        self.do_profile = do_profile
-        self.warmup_iterations = warmup_iterations
-        self.test_iterations = test_iterations
+        self.profile = profile
+        self.warmup = warmup
+        self.num_iters = num_iters
         build_dir = os.path.join(self.project_dir, "build")
         if os.path.exists(build_dir):
             shutil.rmtree(build_dir)
@@ -256,7 +256,7 @@ class AIE_MLIRModule:
                 os.path.join(self.project_dir, f"input{i}.data"), "w", encoding="utf-8"
             ) as f:
                 f.write("\n".join([str(i) for i in args[i].flatten()]))
-        cmd = f"cd {self.project_dir} && ./build/top -x build/final.xclbin -i insts.txt -k MLIR_AIE {f'-p true --warmup {self.warmup_iterations} --test_iter {self.test_iterations}' if self.do_profile else ''}"
+        cmd = f"cd {self.project_dir} && ./build/top -x build/final.xclbin -i insts.txt -k MLIR_AIE {f'-p true --warmup {self.warmup} --test_iter {self.num_iters}' if self.profile else ''}"
         with subprocess.Popen(cmd, shell=True) as process:
             process.wait()
         if process.returncode != 0:

--- a/allo/backend/experimental/mlir_codegen.py
+++ b/allo/backend/experimental/mlir_codegen.py
@@ -243,7 +243,11 @@ def map_global_io(inputs, outputs) -> tuple[dict[str, list[DMATensorTile]], int,
         dma_tensor_tiles: list[DMATensorTile] = []
         # fixme: incomplete
         #   Currently, we may allow tensor tiles on a sharding dimension to be sent using different memory tiles
+        assert len(device_dims) == 1 or len(device_dims) == 2 
         lose_factor = 1 if len(device_dims) <= 1 else size[device_dims[0]]
+        inc_factor = (
+            size[device_dims[0]] if len(device_dims) <= 1 else size[device_dims[1]]
+        )
         remaining = tensor_tiles[:]
         start_idx = 0
         while remaining:
@@ -261,8 +265,8 @@ def map_global_io(inputs, outputs) -> tuple[dict[str, list[DMATensorTile]], int,
                     "Failed to allocate (shim, memory) tile: per-tile FIFO limit "
                     "exceeded or no more available tiles."
                 )
-            offset[device_dims[0]] = start_idx // lose_factor
-            size[device_dims[0]] = len(chunk) // lose_factor
+            offset[device_dims[0]] = start_idx // inc_factor
+            size[device_dims[0]] = len(chunk) // inc_factor
             dma_tensor_tiles.append(
                 DMATensorTile(
                     len(dma_tensor_tiles),

--- a/allo/backend/experimental/mlir_codegen.py
+++ b/allo/backend/experimental/mlir_codegen.py
@@ -243,7 +243,7 @@ def map_global_io(inputs, outputs) -> tuple[dict[str, list[DMATensorTile]], int,
         dma_tensor_tiles: list[DMATensorTile] = []
         # fixme: incomplete
         #   Currently, we may allow tensor tiles on a sharding dimension to be sent using different memory tiles
-        assert len(device_dims) == 1 or len(device_dims) == 2 
+        assert len(device_dims) == 1 or len(device_dims) == 2
         lose_factor = 1 if len(device_dims) <= 1 else size[device_dims[0]]
         inc_factor = (
             size[device_dims[0]] if len(device_dims) <= 1 else size[device_dims[1]]

--- a/allo/dataflow.py
+++ b/allo/dataflow.py
@@ -1,6 +1,6 @@
 # Copyright Allo authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=no-name-in-module, unexpected-keyword-arg, no-value-for-parameter, global-variable-not-assigned, global-statement, broad-exception-caught
+# pylint: disable=no-name-in-module, unexpected-keyword-arg, no-value-for-parameter, global-variable-not-assigned, global-statement, broad-exception-caught, too-many-arguments
 
 import functools
 import os
@@ -301,7 +301,13 @@ def build(
     wrap_io=True,
     opt_default=True,
     enable_tensor=False,
+    do_profile=False,
+    warmup_iterations=20,
+    test_iterations=100,
 ):
+    assert (
+        not do_profile or target == "aie-mlir"
+    ), "Profiling is only supported for AIE target"
     if target == "aie":
         global_vars = get_global_vars(func)
         s = _customize(func, global_vars=global_vars, enable_tensor=False)
@@ -329,7 +335,11 @@ def build(
             project,
             stream_info,
         )
-        aie_mod.build()
+        aie_mod.build(
+            do_profile=do_profile,
+            warmup_iterations=warmup_iterations,
+            test_iterations=test_iterations,
+        )
         return aie_mod
 
     if target == "simulator":

--- a/allo/dataflow.py
+++ b/allo/dataflow.py
@@ -301,12 +301,12 @@ def build(
     wrap_io=True,
     opt_default=True,
     enable_tensor=False,
-    do_profile=False,
-    warmup_iterations=20,
-    test_iterations=100,
+    profile=False,
+    warmup=20,
+    num_iters=100,
 ):
     assert (
-        not do_profile or target == "aie-mlir"
+        not profile or target == "aie-mlir"
     ), "Profiling is only supported for AIE target"
     if target == "aie":
         global_vars = get_global_vars(func)
@@ -336,9 +336,9 @@ def build(
             stream_info,
         )
         aie_mod.build(
-            do_profile=do_profile,
-            warmup_iterations=warmup_iterations,
-            test_iterations=test_iterations,
+            profile=profile,
+            warmup=warmup,
+            num_iters=num_iters,
         )
         return aie_mod
 


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR introduces a new feature to the `AIE_MLIRModule` class. The goal is to enable users to easily profile the performance of their module executions by measuring runtime over multiple iterations. 

### Problems ###
Previously, there was no built-in way to evaluate the performance of modules.
Previously, the `top_func_name` when building aie module was hardcoded as `top`.

### Proposed Solutions ###
- Extend host code construction to include profiling option.
- Added `profile`, `warmup`, and `num_iters` parameters to the `build` method.
  - When `profile=True`, the module performs:
    - A configurable number of warm-up runs (default: 20) to stabilize performance.
    - A configurable number of timed runs (default: 100) to gather average execution time.
    - Print average execution time to the console.

- Fix bug to enable different `top_func_name`.
### Examples ###
```python
import allo
from allo.ir.types import int16, int32, float32
import allo.dataflow as df
import numpy as np
from allo.memory import Layout

Ty = int16
M, N, K = 128, 128, 32
Pm, Pn, Pk = 4, 4, 1
Mt, Nt, Kt = M // Pm, N // Pn, K // Pk

LyA = Layout("S1S2")
LyB = Layout("S2S0")
LyC = Layout("S1S0")

@df.region()
def top1():
    @df.kernel(mapping=[Pk, Pm, Pn])
    def gemm(A: Ty[M, K] @ LyA, B: Ty[K, N] @ LyB, C: int32[M, N] @ LyC):
        C[:, :] = allo.matmul(A, B)

mod = df.build(
    top1,
    target="aie-mlir",
    profile=True,
    warmup=200,
    num_iters=1000,
)
A = np.random.randint(0, 32, (M, K)).astype(np.int16)
B = np.random.randint(0, 32, (K, N)).astype(np.int16)
C = np.zeros((M, N)).astype(np.int32)
tmp_C = np.zeros((M, N)).astype(np.int32)
mod(A, B, C)
```
Sample output:
```txt
Avg NPU execution time: 406.05us
```

## Checklist ##

Please make sure to review and check all of these items:
- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] All changes have test coverage (It would be good to provide ~2 different test cases to test the robustness of your code)
- [x] Pass the [formatting check](https://cornell-zhang.github.io/allo/developer/index.html#id1) locally
- [x] Code is well-documented
