### PR TITLE
[AIE][Environment] Make aie package optional due to compatibility issues

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -33,7 +33,6 @@ jobs:
         source activate allo
         export LLVM_BUILD_DIR=/root/llvm-project/build
         python3 -m pip install -v -e .
-        HOST_MLIR_PYTHON_PACKAGE_PREFIX=aie python3 -m pip install -r requirements_extra.txt
     - name: Formatting Check
       shell: bash
       run: |
@@ -43,7 +42,6 @@ jobs:
       shell: bash
       run: |
         source activate allo
-        export PYTHONPATH=/root/miniconda/envs/allo/lib/python3.12/site-packages/mlir_aie/python:$PYTHONPATH
         export PATH=/root/llvm-project/build/bin:${PATH}
         export LLVM_BUILD_DIR=/root/llvm-project/build
         python3 -m pytest --ignore=tests/dataflow tests -v
@@ -51,14 +49,12 @@ jobs:
       shell: bash
       run: |
         source activate allo
-        export PYTHONPATH=/root/miniconda/envs/allo/lib/python3.12/site-packages/mlir_aie/python:$PYTHONPATH
         export LLVM_BUILD_DIR=/root/llvm-project/build
         python3 -m pytest tutorials -v
     - name: Benchmark
       shell: bash
       run: |
         source activate allo
-        export PYTHONPATH=/root/miniconda/envs/allo/lib/python3.12/site-packages/mlir_aie/python:$PYTHONPATH
         export LLVM_BUILD_DIR=/root/llvm-project/build
         python3 -m pytest examples/polybench -v
     # no left space!

--- a/.github/workflows/sphinx_build.yml
+++ b/.github/workflows/sphinx_build.yml
@@ -43,12 +43,10 @@ jobs:
         source activate allo
         export LLVM_BUILD_DIR=/root/llvm-project/build
         python3 -m pip install -v -e .
-        HOST_MLIR_PYTHON_PACKAGE_PREFIX=aie python3 -m pip install -r requirements_extra.txt
     - name: Build docs
       shell: bash
       run: |
         source activate allo
-        export PYTHONPATH=/root/miniconda/envs/allo/lib/python3.12/site-packages/mlir_aie/python:$PYTHONPATH
         export PATH=/root/llvm-project/build/bin:${PATH}
         cd docs
         export LLVM_BUILD_DIR=/root/llvm-project/build

--- a/allo/backend/__init__.py
+++ b/allo/backend/__init__.py
@@ -1,4 +1,10 @@
 # Copyright Allo authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 import os
-from . import ai_engine, llvm, hls, ip, experimental
+from . import ai_engine, llvm, hls, ip
+
+try:
+    from . import experimental
+    from .experimental import AIE_MLIRModule
+except ImportError:
+    AIE_MLIRModule = None

--- a/allo/backend/experimental/README.md
+++ b/allo/backend/experimental/README.md
@@ -5,19 +5,22 @@
 ## Environment Setup
 Please follow the [Getting Started](https://github.com/Xilinx/mlir-aie/tree/main?tab=readme-ov-file#getting-started-for-amd-ryzen-ai-on-linux) guide to install MLIR-AIE.
 
-Install Allo:
+In **Step 3: Install IRON library, mlir-aie, and llvm-aie compilers from wheels**, under the section [Install IRON for AMD Ryzen™ AI AIE Application Development](https://github.com/Xilinx/mlir-aie/tree/main?tab=readme-ov-file#install-iron-for-amd-ryzen-ai-aie-application-development), please install version `v1.0` using the following commands:
+```bash
+# Install IRON library and mlir-aie from a wheel
+python3 -m pip install mlir_aie -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/v1.0
+
+# Install Peano from a llvm-aie wheel
+python3 -m pip install https://github.com/Xilinx/llvm-aie/releases/download/nightly/llvm_aie-19.0.0.2025041501+b2a279c1-py3-none-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+```
+> ⚠️ **Note:** The mlir_aie wheel require `manylinux_2_35`, and some systems (e.g., those with glibc 2.34, can be confirmed by `ldd --version`) do not meet this requirement. This results in an installation failure like:
+> `ERROR: mlir_aie-0.0.1.2025042204+24208c0-cp312-cp312-manylinux_2_35_x86_64.whl is not a supported wheel on this platform.`
+
+Then, install Allo as usual:
 ```bash
 git clone https://github.com/cornell-zhang/allo.git && cd allo
 python3 -m pip install -v -e .
 ```
-This will install the IRON library, and the mlir-aie and llvm-aie compiler release v1.0 from whls.
-
-Install MLIR Python Extras:
-```bash
-HOST_MLIR_PYTHON_PACKAGE_PREFIX=aie python3 -m pip install -r requirements_extra.txt
-```
-
-
 
 ### Commands Used
 
@@ -29,13 +32,12 @@ Below are the exact commands to set up the environment:
    conda activate allo
    ```
 
-2. Clone the allo repository and install.
-   - You may want to set up environment variables to use a custom CMake and LLVM build. For example, `export PATH=/opt/cmake-3.31.5-linux-x86_64/bin:/opt/llvm-project-19.x/build/bin:$PATH` and `export LLVM_BUILD_DIR=/opt/llvm-project-19.x/build`.
+2. install release 1.0
    ```bash
-   git clone https://github.com/cornell-zhang/allo.git
-   cd allo
-   python3 -m pip install -v -e .
-   HOST_MLIR_PYTHON_PACKAGE_PREFIX=aie python3 -m pip install -r requirements_extra.txt
+   # Install IRON library and mlir-aie from a wheel
+   python3 -m pip install mlir_aie -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/v1.0
+   # Install Peano from a llvm-aie wheel
+   python3 -m pip install https://github.com/Xilinx/llvm-aie/releases/download/nightly/llvm_aie-19.0.0.2025041501+b2a279c1-py3-none-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
    ```
 
 3. Clone the mlir-aie repository and checkout to the commit corresponding to release 1.0
@@ -50,6 +52,8 @@ Below are the exact commands to set up the environment:
    python3 -m pip install -r python/requirements.txt
    # Install the pre-commit hooks defined in .pre-commit-config.yaml
    pre-commit install
+   # Install MLIR Python Extras 
+   HOST_MLIR_PYTHON_PACKAGE_PREFIX=aie python3 -m pip install -r python/requirements_extras.txt
    # Install Torch for ML examples
    python3 -m pip install -r python/requirements_ml.txt
    ```
@@ -57,6 +61,14 @@ Below are the exact commands to set up the environment:
 5. Setup environment and add tools to PATHs
    ```bash
    source utils/env_setup.sh
+   ```
+
+6. Clone the allo repository and install.
+   - You may want to set up environment variables to use a custom CMake and LLVM build. For example, `export PATH=/opt/cmake-3.31.5-linux-x86_64/bin:/opt/llvm-project-19.x/build/bin:$PATH` and `export LLVM_BUILD_DIR=/opt/llvm-project-19.x/build`.
+   ```bash
+   git clone https://github.com/cornell-zhang/allo.git
+   cd allo
+   python3 -m pip install -v -e .
    ```
 
 Do not forget to setup Vitis and XRT.
@@ -119,13 +131,7 @@ def downgrade_ir_for_peano(llvmir):
 
 ## Usage
 
-To enable the experimental MLIR-AIE codegen, set the following environment variable:
-
-```bash
-export USE_AIE_MLIR_BUILDER=1
-```
-
-Then, specify `"aie-mlir"` as the target in the `dataflow.build` function.
+To enable the experimental MLIR-AIE codegen, specify `"aie-mlir"` as the target in the `dataflow.build` function.
 
 ### Example
 vector addition
@@ -356,8 +362,7 @@ tmp_C = np.zeros((M, N)).astype(np.int32)
 mod(A, B, C)
 ```
 
-## New Feature
-### Support for user-defined external kernels
+#### Support for user-defined external kernels
 
 Originally, complex computations on AIE cores were implemented using a limited set of [external kernels provided in the `mlir-aie` repository](https://github.com/Xilinx/mlir-aie/tree/v1.0/aie_kernels). However, this external kernel library supports only a narrow range of operations and leaves room for performance improvement. To address these limitations, we add support for user-defined external kernels.
 

--- a/allo/backend/experimental/__init__.py
+++ b/allo/backend/experimental/__init__.py
@@ -6,7 +6,10 @@ import os
 import subprocess
 import shutil
 
-import aie.ir as aie_ir
+try:
+    import aie.ir as aie_ir
+except ImportError:
+    pass
 
 import allo._mlir._mlir_libs._mlir as allo_ir
 from ..._mlir.dialects import func as allo_func_d

--- a/allo/backend/experimental/external_kernel.py
+++ b/allo/backend/experimental/external_kernel.py
@@ -13,6 +13,11 @@ def extract_extern_C_blocks(code: str) -> list[str]:
        extern "C" { ... }
     (properly handling nested braces) and return them as raw strings.
     """
+    # Remove all // comments
+    code = re.sub(r"//.*?$", "", code, flags=re.MULTILINE)
+    # Remove all /* ... */ comments (including multiline)
+    code = re.sub(r"/\*.*?\*/", "", code, flags=re.DOTALL)
+
     extern_kw = Keyword("extern")
     c_literal = Literal('"C"')
     brace_group = nestedExpr("{", "}")

--- a/allo/dataflow.py
+++ b/allo/dataflow.py
@@ -21,7 +21,7 @@ from .backend.ai_engine import AIEModule
 from .backend.simulator import LLVMOMPModule
 from .ir.types import Stream
 from .passes import df_pipeline
-from .backend.experimental import AIE_MLIRModule
+from .backend import AIE_MLIRModule
 
 
 def get_pid():

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,4 @@ rich
 ml_dtypes
 gurobipy
 pyparsing
-mlir_aie @ https://github.com/Xilinx/mlir-aie/releases/download/v1.0/mlir_aie-0.0.1.2025042204+24208c0-cp312-cp312-manylinux_2_35_x86_64.whl
-llvm_aie @ https://github.com/Xilinx/llvm-aie/releases/download/nightly/llvm_aie-19.0.0.2025041501+b2a279c1-py3-none-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
 past @ https://github.com/cornell-zhang/past-python-bindings/releases/download/65f989b/past-0.7.2-cp312-cp312-linux_x86_64.whl

--- a/requirements_extra.txt
+++ b/requirements_extra.txt
@@ -1,6 +1,0 @@
-# This file is copied from the mlir-aie-AIE (https://github.com/Xilinx/mlir-aie/blob/07320d6831b17e4a4c436d48c3301a17c1e9f1cd/python/requirements_extras.txt).
-
-# This can't go in the normal requirements file because the way the wheels build parses requirements.txt
-# does not support github packages
-git+https://github.com/makslevental/mlir-python-extras@f08db06
--f https://github.com/llvm/eudsl/releases/expanded_assets/latest


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
Make the aie package optional and revert to the original installation method without prebuilt wheels to improve compatibility, 

### Problems ###
In previous PR #368 , we configured the MLIR-AIE environment via prebuilt wheels by updating `requirements.txt`:

```
mlir_aie @ https://github.com/Xilinx/mlir-aie/releases/download/v1.0/mlir_aie-0.0.1.2025042204+24208c0-cp312-cp312-manylinux_2_35_x86_64.whl
llvm_aie @ https://github.com/Xilinx/llvm-aie/releases/download/nightly/llvm_aie-19.0.0.2025041501+b2a279c1-py3-none-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
```

However, the mlir_aie wheel require `manylinux_2_35`, and some systems (e.g., those with glibc 2.34, as confirmed by `ldd --version`) do not meet this requirement. This results in an installation failure like:

```
ERROR: mlir_aie-0.0.1.2025042204+24208c0-cp312-cp312-manylinux_2_35_x86_64.whl is not a supported wheel on this platform.
```

### Proposed Solutions ###
To improve compatibility, this PR:

- Restored the previous install setup and makes the `aie` package optional
- Refactors `aie` imports


### Examples ###
(Please provide an example of the input program and the expected behavior, e.g., the generated IR.)


## Checklist ##

Please make sure to review and check all of these items:
- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [ ] All changes have test coverage (It would be good to provide ~2 different test cases to test the robustness of your code)
- [ ] Pass the [formatting check](https://cornell-zhang.github.io/allo/developer/index.html#id1) locally
- [x] Code is well-documented
