### PR TITLE
[build] Declare setup-time dependency on pybind11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ if __name__ == "__main__":
         author="Allo Community",
         long_description=long_description,
         long_description_content_type="text/markdown",
-        setup_requires=[],
+        setup_requires=["pybind11>=2.8.0"],
         install_requires=parse_requirements("requirements.txt"),
         packages=find_packages(),
         ext_modules=[CMakeExtension("mlir", sourcedir="mlir")],


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##

The CMake build for the MLIR components for Allo depends on pybind11. pybind11 is already a run-time requirement (i.e., listed in `requirements.txt`), but it also needs to be required at build time to make isolated builds possible.

### Problems ###

In a [PEP 517](https://peps.python.org/pep-0517/)-style isolated build, no system-installed Python modules are available during the execution of `setup.py` and therefore of CMake. To make this work, we need to explicitly declare all the build-time dependencies—here, just pybind11.

### Proposed Solutions ###

Add a pybind11 requirement to `setup_requires` in `setup.py`.

### Examples ###

Try using [uv][] to build and install Allo into a virtualenv:

```
LLVM_BUILD_DIR=`pwd`/externals/llvm-project/build uv pip install -e .
```

Without this declared dependency, we'll get an error like this:

```
      CMake Error at
      /scratch/adrian/allo/externals/llvm-project/build/lib/cmake/mlir/MLIRDetect
PythonEnv.cmake:28
      (find_package):
        Could not find a package configuration file provided by "pybind11"
        (requested version 2.9) with any of the following names:

          pybind11Config.cmake
          pybind11-config.cmake

        Add the installation prefix of "pybind11" to CMAKE_PREFIX_PATH or set
        "pybind11_DIR" to a directory containing one of the above files.  If
        "pybind11" provides a separate development package or SDK, be sure
      it has
        been installed.
```

[uv]: https://docs.astral.sh/uv/

## Checklist ##

Please make sure to review and check all of these items:
- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [ ] All changes have test coverage (It would be good to provide ~2 different test cases to test the robustness of your code)
- [ ] Pass the [formatting check](https://cornell-zhang.github.io/allo/developer/index.html#id1) locally
- [ ] Code is well-documented

[Code-related items are not applicable.]