### PR TITLE
[Frontend] Support specifying data types for PyTorch models

### DIFF
--- a/allo/frontend/pytorch.py
+++ b/allo/frontend/pytorch.py
@@ -1,6 +1,6 @@
 # Copyright Allo authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=too-many-public-methods, too-many-instance-attributes
+# pylint: disable=too-many-public-methods, too-many-instance-attributes, broad-exception-caught
 
 import operator
 import inspect
@@ -104,12 +104,11 @@ def from_pytorch(
             if len(args) == len(example_inputs):
                 # User only passed inputs, automatically add weights
                 return mod(*args, *weight_data)
-            else:
-                # User passed both inputs and weights
-                num_inputs = len(example_inputs)
-                inputs = args[:num_inputs]
-                weights = args[num_inputs:]
-                return mod(*inputs, *weights)
+            # User passed both inputs and weights
+            num_inputs = len(example_inputs)
+            inputs = args[:num_inputs]
+            weights = args[num_inputs:]
+            return mod(*inputs, *weights)
 
         # Attach weight data to the wrapper for convenience
         wrapped_forward.weight_data = weight_data
@@ -163,9 +162,9 @@ class TorchBuilder:
     def _literal_for_allotype(self, t: AlloType) -> str:
         cls = t.__class__.__name__
         # Handle known constructors by their signatures
-        if cls in ("Fixed", "UFixed"):
+        if cls in {"Fixed", "UFixed"}:
             return f"{cls}({t.bits}, {t.fracs})"
-        if cls in ("Int", "UInt"):
+        if cls in {"Int", "UInt"}:
             return f"{cls}({t.bits})"
         if cls == "Float":
             if t.bits == 16:
@@ -177,11 +176,8 @@ class TorchBuilder:
             raise NotImplementedError(f"Unsupported float bits: {t.bits}")
         if cls == "Index":
             return "Index()"
-        # Fallback to class(bits, fracs)
-        try:
-            return f"{cls}({t.bits}, {t.fracs})"
-        except Exception:
-            return repr(t)
+        # Fallback
+        return f"{cls}({t.bits}, {t.fracs})"
 
     def _resolve_value_to_name_obj(self, value, kind_hint):
         # Accept string or AlloType; return (name, obj)

--- a/allo/ir/symbol_resolver.py
+++ b/allo/ir/symbol_resolver.py
@@ -157,6 +157,7 @@ class ASTResolver:
             # Construct the type instance using the resolved function object
             try:
                 return func_obj(*args)
+            # pylint: disable=broad-exception-caught
             except Exception:
                 return None
         else:

--- a/allo/ir/symbol_resolver.py
+++ b/allo/ir/symbol_resolver.py
@@ -106,7 +106,59 @@ class ASTResolver:
     @staticmethod
     def resolve_param_types(node, global_vars):
         if isinstance(node, ast.Tuple):
-            return list(ASTResolver.resolve(n, global_vars) for n in node.elts)
+            return list(
+                ASTResolver.resolve_param_type(n, global_vars) for n in node.elts
+            )
         if isinstance(node, ast.Name):
-            return [ASTResolver.resolve(node, global_vars)]
+            return [ASTResolver.resolve_param_type(node, global_vars)]
         raise RuntimeError(f"Unsupported node type: {type(node)}")
+
+    @staticmethod
+    def resolve_param_type(node, global_vars):
+        """Resolve a single parameter type, handling both symbols and constructor calls."""
+        if isinstance(node, ast.Call):
+            # Handle type constructor calls like Fixed(16, 10)
+            func_obj = ASTResolver.resolve(node.func, global_vars)
+            if func_obj is None:
+                # Try to resolve the function name as a string
+                if isinstance(node.func, ast.Name):
+                    func_name = node.func.id
+                    func_obj = global_vars.get(func_name)
+                elif isinstance(node.func, ast.Attribute):
+                    # Handle cases like types.Fixed
+                    if (
+                        isinstance(node.func.value, ast.Name)
+                        and node.func.value.id == "types"
+                    ):
+                        func_name = node.func.attr
+                        func_obj = global_vars.get(func_name)
+                    else:
+                        return None
+                else:
+                    return None
+
+            if func_obj is None:
+                return None
+
+            # Get the arguments
+            args = []
+            for arg in node.args:
+                if isinstance(arg, ast.Constant):
+                    args.append(arg.value)
+                else:
+                    # Try to resolve the argument
+                    resolved_arg = ASTResolver.resolve_constant(
+                        arg, type("Context", (), {"global_vars": global_vars})()
+                    )
+                    if resolved_arg is None:
+                        return None
+                    args.append(resolved_arg)
+
+            # Construct the type instance using the resolved function object
+            try:
+                return func_obj(*args)
+            except Exception:
+                return None
+        else:
+            # Handle simple symbol resolution
+            return ASTResolver.resolve(node, global_vars)

--- a/allo/library/nn.py
+++ b/allo/library/nn.py
@@ -6,9 +6,9 @@ from .. import dsl
 from .systolic import systolic
 
 
-def linear2d[TyX, TyW, TyO, M, N, K](
-    X: "TyX[M, K]", W: "TyW[N, K]", b: "TyO[N]"
-) -> "TyO[M, N]":
+def linear2d[
+    TyX, TyW, TyO, M, N, K
+](X: "TyX[M, K]", W: "TyW[N, K]", b: "TyO[N]") -> "TyO[M, N]":
     # https://pytorch.org/docs/stable/generated/torch.nn.Linear.html
     Z: TyO[M, N]
     buf: TyO[N]
@@ -32,9 +32,9 @@ def schedule_linear2d(s):
     return s
 
 
-def linear3d[TyX, TyW, TyO, B, L, D, M](
-    X: "TyX[B, L, D]", W: "TyW[M, D]", bias: "TyO[M]"
-) -> "TyO[B, L, M]":
+def linear3d[
+    TyX, TyW, TyO, B, L, D, M
+](X: "TyX[B, L, D]", W: "TyW[M, D]", bias: "TyO[M]") -> "TyO[B, L, M]":
     # https://pytorch.org/docs/stable/generated/torch.nn.Linear.html
     Z: TyO[B, L, M]
     buf: TyO[M]
@@ -170,9 +170,9 @@ def residual_add[Ty, L, D](X1: "Ty[L, D]", X2: "Ty[L, D]") -> "Ty[L, D]":
     return Z
 
 
-def scaled_dot_product_attention[Ty, H, L, D, M0, M1](
-    Q: "Ty[L, D]", K: "Ty[L, D]", V: "Ty[L, D]"
-) -> "Ty[L, D]":
+def scaled_dot_product_attention[
+    Ty, H, L, D, M0, M1
+](Q: "Ty[L, D]", K: "Ty[L, D]", V: "Ty[L, D]") -> "Ty[L, D]":
     # softmax(QK^T/sqrt(D // H))
     Z: Ty[L, D]
 
@@ -203,7 +203,9 @@ def scaled_dot_product_attention[Ty, H, L, D, M0, M1](
     return Z
 
 
-def conv2d[Ty, B, Cin, Cout, H, W, Kh, Kw, Oh, Ow, Sh, Sw, Pd0, Pd1](
+def conv2d[
+    Ty, B, Cin, Cout, H, W, Kh, Kw, Oh, Ow, Sh, Sw, Pd0, Pd1
+](
     inp: "Ty[B, Cin, H, W]", kernel: "Ty[Cout, Cin, Kh, Kw]", bias: "Ty[Cout]"
 ) -> "Ty[B, Cout, Oh, Ow]":
     # https://pytorch.org/docs/stable/generated/torch.nn.Conv2d.html
@@ -229,9 +231,9 @@ def schedule_conv2d(s):
     return s
 
 
-def maxpool2d[Ty, B, C, H, W, K, Oh, Ow, S, Pd](
-    inp: "Ty[B, C, H, W]",
-) -> "Ty[B, C, Oh, Ow]":
+def maxpool2d[
+    Ty, B, C, H, W, K, Oh, Ow, S, Pd
+](inp: "Ty[B, C, H, W]",) -> "Ty[B, C, Oh, Ow]":
     # https://pytorch.org/docs/stable/generated/torch.nn.MaxPool2d.html
     Z: Ty[B, C, Oh, Ow]
     for batch, c, oh, ow in dsl.grid(B, C, Oh, Ow):
@@ -252,9 +254,9 @@ def schedule_maxpool2d(s):
     return s
 
 
-def avgpool2d[Ty, B, C, H, W, K, Oh, Ow, S, Pd](
-    inp: "Ty[B, C, H, W]",
-) -> "Ty[B, C, Oh, Ow]":
+def avgpool2d[
+    Ty, B, C, H, W, K, Oh, Ow, S, Pd
+](inp: "Ty[B, C, H, W]",) -> "Ty[B, C, Oh, Ow]":
     # https://pytorch.org/docs/stable/generated/torch.nn.AvgPool2d.html
     Z: Ty[B, C, Oh, Ow]
     for batch, c, oh, ow in dsl.grid(B, C, Oh, Ow):
@@ -274,7 +276,9 @@ def schedule_avgpool2d(s):
     return s
 
 
-def batchnorm2d[Ty, B, C, H, W](
+def batchnorm2d[
+    Ty, B, C, H, W
+](
     X: "Ty[B, C, H, W]",
     gamma: "Ty[C]",
     beta: "Ty[C]",

--- a/allo/library/nn.py
+++ b/allo/library/nn.py
@@ -6,7 +6,9 @@ from .. import dsl
 from .systolic import systolic
 
 
-def linear2d[TyX, TyW, TyO, M, N, K](X: "TyX[M, K]", W: "TyW[N, K]", b: "TyO[N]") -> "TyO[M, N]":
+def linear2d[TyX, TyW, TyO, M, N, K](
+    X: "TyX[M, K]", W: "TyW[N, K]", b: "TyO[N]"
+) -> "TyO[M, N]":
     # https://pytorch.org/docs/stable/generated/torch.nn.Linear.html
     Z: TyO[M, N]
     buf: TyO[N]
@@ -30,9 +32,9 @@ def schedule_linear2d(s):
     return s
 
 
-def linear3d[
-    TyX, TyW, TyO, B, L, D, M
-](X: "TyX[B, L, D]", W: "TyW[M, D]", bias: "TyO[M]") -> "TyO[B, L, M]":
+def linear3d[TyX, TyW, TyO, B, L, D, M](
+    X: "TyX[B, L, D]", W: "TyW[M, D]", bias: "TyO[M]"
+) -> "TyO[B, L, M]":
     # https://pytorch.org/docs/stable/generated/torch.nn.Linear.html
     Z: TyO[B, L, M]
     buf: TyO[M]
@@ -168,9 +170,9 @@ def residual_add[Ty, L, D](X1: "Ty[L, D]", X2: "Ty[L, D]") -> "Ty[L, D]":
     return Z
 
 
-def scaled_dot_product_attention[
-    Ty, H, L, D, M0, M1
-](Q: "Ty[L, D]", K: "Ty[L, D]", V: "Ty[L, D]") -> "Ty[L, D]":
+def scaled_dot_product_attention[Ty, H, L, D, M0, M1](
+    Q: "Ty[L, D]", K: "Ty[L, D]", V: "Ty[L, D]"
+) -> "Ty[L, D]":
     # softmax(QK^T/sqrt(D // H))
     Z: Ty[L, D]
 
@@ -201,9 +203,7 @@ def scaled_dot_product_attention[
     return Z
 
 
-def conv2d[
-    Ty, B, Cin, Cout, H, W, Kh, Kw, Oh, Ow, Sh, Sw, Pd0, Pd1
-](
+def conv2d[Ty, B, Cin, Cout, H, W, Kh, Kw, Oh, Ow, Sh, Sw, Pd0, Pd1](
     inp: "Ty[B, Cin, H, W]", kernel: "Ty[Cout, Cin, Kh, Kw]", bias: "Ty[Cout]"
 ) -> "Ty[B, Cout, Oh, Ow]":
     # https://pytorch.org/docs/stable/generated/torch.nn.Conv2d.html
@@ -229,9 +229,9 @@ def schedule_conv2d(s):
     return s
 
 
-def maxpool2d[
-    Ty, B, C, H, W, K, Oh, Ow, S, Pd
-](inp: "Ty[B, C, H, W]") -> "Ty[B, C, Oh, Ow]":
+def maxpool2d[Ty, B, C, H, W, K, Oh, Ow, S, Pd](
+    inp: "Ty[B, C, H, W]",
+) -> "Ty[B, C, Oh, Ow]":
     # https://pytorch.org/docs/stable/generated/torch.nn.MaxPool2d.html
     Z: Ty[B, C, Oh, Ow]
     for batch, c, oh, ow in dsl.grid(B, C, Oh, Ow):
@@ -252,9 +252,9 @@ def schedule_maxpool2d(s):
     return s
 
 
-def avgpool2d[
-    Ty, B, C, H, W, K, Oh, Ow, S, Pd
-](inp: "Ty[B, C, H, W]") -> "Ty[B, C, Oh, Ow]":
+def avgpool2d[Ty, B, C, H, W, K, Oh, Ow, S, Pd](
+    inp: "Ty[B, C, H, W]",
+) -> "Ty[B, C, Oh, Ow]":
     # https://pytorch.org/docs/stable/generated/torch.nn.AvgPool2d.html
     Z: Ty[B, C, Oh, Ow]
     for batch, c, oh, ow in dsl.grid(B, C, Oh, Ow):
@@ -274,9 +274,7 @@ def schedule_avgpool2d(s):
     return s
 
 
-def batchnorm2d[
-    Ty, B, C, H, W
-](
+def batchnorm2d[Ty, B, C, H, W](
     X: "Ty[B, C, H, W]",
     gamma: "Ty[C]",
     beta: "Ty[C]",

--- a/allo/library/nn.py
+++ b/allo/library/nn.py
@@ -6,16 +6,16 @@ from .. import dsl
 from .systolic import systolic
 
 
-def linear2d[Ty, M, N, K](X: "Ty[M, K]", W: "Ty[N, K]", b: "Ty[N]") -> "Ty[M, N]":
+def linear2d[TyX, TyW, TyO, M, N, K](X: "TyX[M, K]", W: "TyW[N, K]", b: "TyO[N]") -> "TyO[M, N]":
     # https://pytorch.org/docs/stable/generated/torch.nn.Linear.html
-    Z: Ty[M, N]
-    buf: Ty[N]
+    Z: TyO[M, N]
+    buf: TyO[N]
     for i in range(M):
         for j_init in range(N):
             buf[j_init] = 0
         for k in range(K):
             # reorder reduction loop outside, and pipeline
-            x: Ty = X[i, k]
+            x: TyX = X[i, k]
             for j in range(N):
                 buf[j] += x * W[j, k]
         for j_back in range(N):
@@ -31,18 +31,18 @@ def schedule_linear2d(s):
 
 
 def linear3d[
-    Ty, B, L, D, M
-](X: "Ty[B, L, D]", W: "Ty[M, D]", bias: "Ty[M]") -> "Ty[B, L, M]":
+    TyX, TyW, TyO, B, L, D, M
+](X: "TyX[B, L, D]", W: "TyW[M, D]", bias: "TyO[M]") -> "TyO[B, L, M]":
     # https://pytorch.org/docs/stable/generated/torch.nn.Linear.html
-    Z: Ty[B, L, M]
-    buf: Ty[M]
+    Z: TyO[B, L, M]
+    buf: TyO[M]
     for b in range(B):
         for i in range(L):
             for j_init in range(M):
                 buf[j_init] = 0
             for k in range(D):
                 # reorder reduction loop outside, and pipeline
-                x: Ty = X[b, i, k]
+                x: TyX = X[b, i, k]
                 for j in range(M):
                     buf[j] += x * W[j, k]
             for j_back in range(M):

--- a/examples/torch/mlp.py
+++ b/examples/torch/mlp.py
@@ -5,7 +5,7 @@ import torch
 import torch.nn.functional as F
 import torch.nn as nn
 import allo
-from allo.ir.types import int8
+from allo.ir.types import float32
 
 
 class MLP(nn.Module):
@@ -25,12 +25,16 @@ model = MLP()
 model.eval()
 example_inputs = [torch.rand(8, 16)]
 llvm_mod = allo.frontend.from_pytorch(
-    model, example_inputs=example_inputs, verbose=True, op_dtypes={
-        "default": int8,   # global fallback
-        "linear": int8,       # per-op override
-        "relu": int8,
-        "inputs": int8,    # optional input arg annotation
-        "outputs": int8,   # optional outputs annotation
+    model,
+    example_inputs=example_inputs,
+    verbose=True,
+    weights_as_args=True,
+    op_dtypes={
+        "inputs": float32,
+        "linear1": [float32, float32, float32],  # X, W, O for first linear
+        "linear2": [float32, float32, float32],  # X, W, O for second linear
+        "relu": float32,
+        "outputs": float32,  # optional outputs annotation
     },
 )
 golden = model(*example_inputs)

--- a/examples/torch/mlp.py
+++ b/examples/torch/mlp.py
@@ -5,7 +5,7 @@ import torch
 import torch.nn.functional as F
 import torch.nn as nn
 import allo
-from allo.ir.types import float32
+from allo.ir.types import float32, Fixed
 
 
 class MLP(nn.Module):
@@ -31,8 +31,8 @@ llvm_mod = allo.frontend.from_pytorch(
     weights_as_args=True,
     op_dtypes={
         "inputs": float32,
-        "linear1": [float32, float32, float32],  # X, W, O for first linear
-        "linear2": [float32, float32, float32],  # X, W, O for second linear
+        "linear1": [float32, Fixed(64, 30), float32],  # X, W, O for first linear
+        "linear2": [float32, Fixed(64, 30), float32],  # X, W, O for second linear
         "relu": float32,
         "outputs": float32,  # optional outputs annotation
     },

--- a/examples/torch/mlp.py
+++ b/examples/torch/mlp.py
@@ -5,6 +5,7 @@ import torch
 import torch.nn.functional as F
 import torch.nn as nn
 import allo
+from allo.ir.types import int8
 
 
 class MLP(nn.Module):
@@ -24,7 +25,13 @@ model = MLP()
 model.eval()
 example_inputs = [torch.rand(8, 16)]
 llvm_mod = allo.frontend.from_pytorch(
-    model, example_inputs=example_inputs, verbose=True
+    model, example_inputs=example_inputs, verbose=True, op_dtypes={
+        "default": int8,   # global fallback
+        "linear": int8,       # per-op override
+        "relu": int8,
+        "inputs": int8,    # optional input arg annotation
+        "outputs": int8,   # optional outputs annotation
+    },
 )
 golden = model(*example_inputs)
 np_inputs = [x.detach().numpy() for x in example_inputs]

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -36,7 +36,7 @@ def test_builtin_linear():
     b = np.random.randn(
         N,
     ).astype(np.float32)
-    s = allo.customize(nn.linear2d, instantiate=[float32, M, N, K])
+    s = allo.customize(nn.linear2d, instantiate=[float32, float32, float32, M, N, K])
     mod = s.build(target="llvm")
     Z = mod(X, W, b)
     np.testing.assert_allclose(Z, np.dot(X, W.T) + b, atol=1e-5)
@@ -63,13 +63,13 @@ def test_cascaded_linear():
         b0: float32[M1],
         b1: float32[M2],
     ) -> float32[BS, M2]:
-        Z0 = nn.linear2d[float32, BS, M1, M0](X, W0, b0)
-        Z1 = nn.linear2d[float32, BS, M2, M1](Z0, W1, b1)
+        Z0 = nn.linear2d[float32, float32, float32, BS, M1, M0](X, W0, b0)
+        Z1 = nn.linear2d[float32, float32, float32, BS, M2, M1](Z0, W1, b1)
         return Z1
 
     s = allo.customize(cascaded_linear)
-    s.compose(nn.linear2d, instantiate=[float32, BS, M1, M0])
-    s.compose(nn.linear2d, id="1", instantiate=[float32, BS, M2, M1])
+    s.compose(nn.linear2d, instantiate=[float32, float32, float32, BS, M1, M0])
+    s.compose(nn.linear2d, id="1", instantiate=[float32, float32, float32, BS, M2, M1])
     print(s.module)
     mod = s.build(target="llvm")
     Z = mod(X, W0, W1, b0, b1)


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR fixes #387 by providing an interface for specifying the data types for each operation in PyTorch. Currently users can pass in a dictionary (mapping from PyTorch module name to input/output data types) to `op_dtypes` in the `allo.frontend.from_pytorch` function. All the Allo [data types](https://cornell-zhang.github.io/allo/gallery/dive_01_data_types.html) are supported, but users need to guarantee the correct data types between operations. NO automatic type conversion is added in this PR.


### Examples ###
```python
llvm_mod = allo.frontend.from_pytorch(
    model,
    example_inputs=example_inputs,
    verbose=True,
    weights_as_args=True,
    op_dtypes={
        "inputs": float32,
        "linear1": [float32, Fixed(64, 30), float32],  # X, W, O for first linear
        "linear2": [float32, Fixed(64, 30), float32],  # X, W, O for second linear
        "relu": float32,
        "outputs": float32,  # optional outputs annotation
    },
)
```


## Checklist ##

Please make sure to review and check all of these items:
- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] All changes have test coverage (It would be good to provide ~2 different test cases to test the robustness of your code)
- [x] Pass the [formatting check](https://cornell-zhang.github.io/allo/developer/index.html#id1) locally
- [x] Code is well-documented
