### PR TITLE
[Frontend][PyTorch][Bugfix][Feature] Add support for common Pytorch operations (repeat, batchnorm1d, log_softmax)

### DIFF
--- a/allo/frontend/library.py
+++ b/allo/frontend/library.py
@@ -48,6 +48,29 @@ def CoreAttention_lib(s_0, s_1, s_2, s_3):
 
 
 def SliceClsToken_lib(s_0, s_1, s_2):
+    """
+    Extracts the [CLS] token embedding from a 3D input tensor.
+
+    This function is used in Transformer-based models where a
+    special classification token ([CLS]) is prepended to the sequence
+    dimension. It selects the first token (index 0 along s_1) from each sequence in
+    the batch.
+
+    Args:
+        s_0 (int): Batch size.
+        s_1 (int): Sequence length ([CLS] token at position 0).
+        s_2 (int): Feature dimension.
+
+    Returns:
+        Callable: A function that takes a tensor of shape (s_0, s_1, s_2)
+        and returns a tensor of shape (s_0, s_2) containing only the [CLS]
+        token embeddings.
+
+    Reference:
+        Original BERT implementation (Google) extracts the [CLS] token via:
+        https://github.com/google-research/bert/blob/master/modeling.py#L227
+    """
+
     def SliceClsToken(
         inp: float32[s_0, s_1, s_2],
     ) -> float32[s_0, s_2]:

--- a/allo/frontend/library.py
+++ b/allo/frontend/library.py
@@ -47,8 +47,8 @@ def CoreAttention_lib(s_0, s_1, s_2, s_3):
     return CoreAttention
 
 
-def SliceFirstDim_lib(s_0, s_1, s_2):
-    def SliceFirstDim(
+def SliceClsToken_lib(s_0, s_1, s_2):
+    def SliceClsToken(
         inp: float32[s_0, s_1, s_2],
     ) -> float32[s_0, s_2]:
         out: float32[s_0, s_2] = 0.0
@@ -56,4 +56,4 @@ def SliceFirstDim_lib(s_0, s_1, s_2):
             out[i, k] = inp[i, 0, k]
         return out
 
-    return SliceFirstDim
+    return SliceClsToken

--- a/allo/frontend/library.py
+++ b/allo/frontend/library.py
@@ -45,3 +45,15 @@ def CoreAttention_lib(s_0, s_1, s_2, s_3):
         return Attn
 
     return CoreAttention
+
+
+def SliceFirstDim_lib(s_0, s_1, s_2):
+    def SliceFirstDim(
+        inp: float32[s_0, s_1, s_2],
+    ) -> float32[s_0, s_2]:
+        out: float32[s_0, s_2] = 0.0
+        for i, k in dsl.grid(s_0, s_2):
+            out[i, k] = inp[i, 0, k]
+        return out
+
+    return SliceFirstDim

--- a/allo/frontend/pytorch.py
+++ b/allo/frontend/pytorch.py
@@ -548,9 +548,7 @@ class TorchBuilder:
             n, d = shape
             self.composition.append(("log_softmax", name_id, [dtype_obj, n, d]))
             return f'{node.name} = nn.log_softmax[{dtype_name}, {n}, {d}, "{name_id}"]({inp})'
-        else:
-            raise NotImplementedError(f"Unsupported shape for log_softmax: {shape}")
-        # return f"{node.name} = dsl.log_softmax({inp})"
+        raise NotImplementedError(f"Unsupported shape for log_softmax: {shape}")
 
     def build_relu(self, node):
         inp = get_var_name(node.args[0])

--- a/allo/frontend/pytorch.py
+++ b/allo/frontend/pytorch.py
@@ -344,7 +344,6 @@ class TorchBuilder:
 
     def __call__(self, node):
         method = getattr(self, "build_" + node.op)
-
         ret = method(node)
         if ret:
             self.code.append(ret)

--- a/allo/library/__init__.py
+++ b/allo/library/__init__.py
@@ -38,6 +38,18 @@ from .nn import (
     schedule_avgpool2d,
     batchnorm2d,
     schedule_batchnorm2d,
+    relu3d,
+    schedule_relu3d,
+    repeat_batch3d,
+    schedule_repeat_batch3d,
+    batchnorm1d_2d,
+    schedule_batchnorm1d_2d,
+    batchnorm1d_3d,
+    schedule_batchnorm1d_3d,
+    log_softmax,
+    schedule_log_softmax,
+    concat,
+    schedule_concat,
 )
 
 KERNEL2SCHEDULE = {}
@@ -65,5 +77,11 @@ KERNEL2SCHEDULE.update(
         maxpool2d: schedule_maxpool2d,
         avgpool2d: schedule_avgpool2d,
         batchnorm2d: schedule_batchnorm2d,
+        relu3d: schedule_relu3d,
+        repeat_batch3d: schedule_repeat_batch3d,
+        batchnorm1d_2d: schedule_batchnorm1d_2d,
+        batchnorm1d_3d: schedule_batchnorm1d_3d,
+        log_softmax: schedule_log_softmax,
+        concat: schedule_concat,
     }
 )

--- a/allo/library/nn.py
+++ b/allo/library/nn.py
@@ -343,6 +343,7 @@ def schedule_batchnorm2d(s):
 def batchnorm1d_2d[Ty, B, C](
     X: "Ty[B, C]", gamma: "Ty[C]", beta: "Ty[C]", eps: "Ty", mean: "Ty[C]", var: "Ty[C]"
 ) -> "Ty[B, C]":
+    # https://docs.pytorch.org/docs/stable/generated/torch.nn.BatchNorm1d.html
     Z: Ty[B, C]
     for b, c in dsl.grid(B, C):
         Z[b, c] = gamma[c] * (X[b, c] - mean[c]) / dsl.sqrt(var[c] + eps) + beta[c]
@@ -362,6 +363,7 @@ def batchnorm1d_3d[Ty, B, C, L](
     mean: "Ty[C]",
     var: "Ty[C]",
 ) -> "Ty[B, C, L]":
+    # https://docs.pytorch.org/docs/stable/generated/torch.nn.BatchNorm1d.html
     Z: Ty[B, C, L]
     for b, c, l in dsl.grid(B, C, L):
         Z[b, c, l] = (

--- a/allo/library/nn.py
+++ b/allo/library/nn.py
@@ -6,9 +6,9 @@ from .. import dsl
 from .systolic import systolic
 
 
-def linear2d[TyX, TyW, TyO, M, N, K](
-    X: "TyX[M, K]", W: "TyW[N, K]", b: "TyO[N]"
-) -> "TyO[M, N]":
+def linear2d[
+    TyX, TyW, TyO, M, N, K
+](X: "TyX[M, K]", W: "TyW[N, K]", b: "TyO[N]") -> "TyO[M, N]":
     # https://pytorch.org/docs/stable/generated/torch.nn.Linear.html
     Z: TyO[M, N]
     buf: TyO[N]
@@ -32,9 +32,9 @@ def schedule_linear2d(s):
     return s
 
 
-def linear3d[TyX, TyW, TyO, B, L, D, M](
-    X: "TyX[B, L, D]", W: "TyW[M, D]", bias: "TyO[M]"
-) -> "TyO[B, L, M]":
+def linear3d[
+    TyX, TyW, TyO, B, L, D, M
+](X: "TyX[B, L, D]", W: "TyW[M, D]", bias: "TyO[M]") -> "TyO[B, L, M]":
     # https://pytorch.org/docs/stable/generated/torch.nn.Linear.html
     Z: TyO[B, L, M]
     buf: TyO[M]
@@ -213,9 +213,9 @@ def residual_add[Ty, L, D](X1: "Ty[L, D]", X2: "Ty[L, D]") -> "Ty[L, D]":
     return Z
 
 
-def scaled_dot_product_attention[Ty, H, L, D, M0, M1](
-    Q: "Ty[L, D]", K: "Ty[L, D]", V: "Ty[L, D]"
-) -> "Ty[L, D]":
+def scaled_dot_product_attention[
+    Ty, H, L, D, M0, M1
+](Q: "Ty[L, D]", K: "Ty[L, D]", V: "Ty[L, D]") -> "Ty[L, D]":
     # softmax(QK^T/sqrt(D // H))
     Z: Ty[L, D]
 
@@ -246,7 +246,9 @@ def scaled_dot_product_attention[Ty, H, L, D, M0, M1](
     return Z
 
 
-def conv2d[Ty, B, Cin, Cout, H, W, Kh, Kw, Oh, Ow, Sh, Sw, Pd0, Pd1](
+def conv2d[
+    Ty, B, Cin, Cout, H, W, Kh, Kw, Oh, Ow, Sh, Sw, Pd0, Pd1
+](
     inp: "Ty[B, Cin, H, W]", kernel: "Ty[Cout, Cin, Kh, Kw]", bias: "Ty[Cout]"
 ) -> "Ty[B, Cout, Oh, Ow]":
     # https://pytorch.org/docs/stable/generated/torch.nn.Conv2d.html
@@ -272,9 +274,9 @@ def schedule_conv2d(s):
     return s
 
 
-def maxpool2d[Ty, B, C, H, W, K, Oh, Ow, S, Pd](
-    inp: "Ty[B, C, H, W]",
-) -> "Ty[B, C, Oh, Ow]":
+def maxpool2d[
+    Ty, B, C, H, W, K, Oh, Ow, S, Pd
+](inp: "Ty[B, C, H, W]",) -> "Ty[B, C, Oh, Ow]":
     # https://pytorch.org/docs/stable/generated/torch.nn.MaxPool2d.html
     Z: Ty[B, C, Oh, Ow]
     for batch, c, oh, ow in dsl.grid(B, C, Oh, Ow):
@@ -295,9 +297,9 @@ def schedule_maxpool2d(s):
     return s
 
 
-def avgpool2d[Ty, B, C, H, W, K, Oh, Ow, S, Pd](
-    inp: "Ty[B, C, H, W]",
-) -> "Ty[B, C, Oh, Ow]":
+def avgpool2d[
+    Ty, B, C, H, W, K, Oh, Ow, S, Pd
+](inp: "Ty[B, C, H, W]",) -> "Ty[B, C, Oh, Ow]":
     # https://pytorch.org/docs/stable/generated/torch.nn.AvgPool2d.html
     Z: Ty[B, C, Oh, Ow]
     for batch, c, oh, ow in dsl.grid(B, C, Oh, Ow):
@@ -317,7 +319,9 @@ def schedule_avgpool2d(s):
     return s
 
 
-def batchnorm2d[Ty, B, C, H, W](
+def batchnorm2d[
+    Ty, B, C, H, W
+](
     X: "Ty[B, C, H, W]",
     gamma: "Ty[C]",
     beta: "Ty[C]",
@@ -340,7 +344,9 @@ def schedule_batchnorm2d(s):
     return s
 
 
-def batchnorm1d_2d[Ty, B, C](
+def batchnorm1d_2d[
+    Ty, B, C
+](
     X: "Ty[B, C]", gamma: "Ty[C]", beta: "Ty[C]", eps: "Ty", mean: "Ty[C]", var: "Ty[C]"
 ) -> "Ty[B, C]":
     # https://docs.pytorch.org/docs/stable/generated/torch.nn.BatchNorm1d.html
@@ -355,7 +361,9 @@ def schedule_batchnorm1d_2d(s):
     return s
 
 
-def batchnorm1d_3d[Ty, B, C, L](
+def batchnorm1d_3d[
+    Ty, B, C, L
+](
     X: "Ty[B, C, L]",
     gamma: "Ty[C]",
     beta: "Ty[C]",
@@ -397,9 +405,9 @@ def schedule_repeat_batch3d(s):
     return s
 
 
-def concat[Ty, B, N1, N2, C](
-    X1: "Ty[B, N1, C]", X2: "Ty[B, N2, C]"
-) -> "Ty[B, N1+N2, C]":
+def concat[
+    Ty, B, N1, N2, C
+](X1: "Ty[B, N1, C]", X2: "Ty[B, N2, C]") -> "Ty[B, N1+N2, C]":
     Y: Ty[B, N1 + N2, C]
     for b, n, c in dsl.grid(B, N1, C):
         Y[b, n, c] = X1[b, n, c]

--- a/allo/library/nn.py
+++ b/allo/library/nn.py
@@ -6,9 +6,9 @@ from .. import dsl
 from .systolic import systolic
 
 
-def linear2d[
-    TyX, TyW, TyO, M, N, K
-](X: "TyX[M, K]", W: "TyW[N, K]", b: "TyO[N]") -> "TyO[M, N]":
+def linear2d[TyX, TyW, TyO, M, N, K](
+    X: "TyX[M, K]", W: "TyW[N, K]", b: "TyO[N]"
+) -> "TyO[M, N]":
     # https://pytorch.org/docs/stable/generated/torch.nn.Linear.html
     Z: TyO[M, N]
     buf: TyO[N]
@@ -32,9 +32,9 @@ def schedule_linear2d(s):
     return s
 
 
-def linear3d[
-    TyX, TyW, TyO, B, L, D, M
-](X: "TyX[B, L, D]", W: "TyW[M, D]", bias: "TyO[M]") -> "TyO[B, L, M]":
+def linear3d[TyX, TyW, TyO, B, L, D, M](
+    X: "TyX[B, L, D]", W: "TyW[M, D]", bias: "TyO[M]"
+) -> "TyO[B, L, M]":
     # https://pytorch.org/docs/stable/generated/torch.nn.Linear.html
     Z: TyO[B, L, M]
     buf: TyO[M]
@@ -83,6 +83,18 @@ def schedule_relu4d(s):
     return s
 
 
+def relu3d[Ty, N, L, C](X: "Ty[N, L, C]") -> "Ty[N, L, C]":
+    Z: Ty[N, L, C]
+    for n, l, c in dsl.grid(N, L, C):
+        Z[n, l, c] = max(0.0, X[n, l, c])
+    return Z
+
+
+def schedule_relu3d(s):
+    s.pipeline("relu3d:c")
+    return s
+
+
 def softmax[Ty, L](X: "Ty[L, L]") -> "Ty[L, L]":
     Z: Ty[L, L]
     E: Ty[L, L]
@@ -105,6 +117,37 @@ def softmax[Ty, L](X: "Ty[L, L]") -> "Ty[L, L]":
 
 
 def schedule_softmax(s):
+    lj = s.get_loops(s.top_func_name)["exp_sum"]["j"]
+    s.pipeline(lj)
+    lj = s.get_loops(s.top_func_name)["update"]["j"]
+    s.pipeline(lj)
+    return s
+
+
+def log_softmax[Ty, B, C](X: "Ty[B, C]") -> "Ty[B, C]":
+    Z: Ty[B, C]
+    E: Ty[B, C]
+    M: Ty[B] = -1000000000000.0
+    S: Ty[B] = 0.0
+
+    # Row-wise max
+    for i, j in dsl.grid(B, C, name="row_max"):
+        if X[i, j] > M[i]:
+            M[i] = X[i, j]
+
+    # Compute exp and sum
+    for i, j in dsl.grid(B, C, name="exp_sum"):
+        E[i, j] = dsl.exp(X[i, j] - M[i])
+        S[i] += E[i, j]
+
+    # Log softmax update
+    for i, j in dsl.grid(B, C, name="update"):
+        Z[i, j] = X[i, j] - M[i] - dsl.log(S[i])
+
+    return Z
+
+
+def schedule_log_softmax(s):
     lj = s.get_loops(s.top_func_name)["exp_sum"]["j"]
     s.pipeline(lj)
     lj = s.get_loops(s.top_func_name)["update"]["j"]
@@ -170,9 +213,9 @@ def residual_add[Ty, L, D](X1: "Ty[L, D]", X2: "Ty[L, D]") -> "Ty[L, D]":
     return Z
 
 
-def scaled_dot_product_attention[
-    Ty, H, L, D, M0, M1
-](Q: "Ty[L, D]", K: "Ty[L, D]", V: "Ty[L, D]") -> "Ty[L, D]":
+def scaled_dot_product_attention[Ty, H, L, D, M0, M1](
+    Q: "Ty[L, D]", K: "Ty[L, D]", V: "Ty[L, D]"
+) -> "Ty[L, D]":
     # softmax(QK^T/sqrt(D // H))
     Z: Ty[L, D]
 
@@ -203,9 +246,7 @@ def scaled_dot_product_attention[
     return Z
 
 
-def conv2d[
-    Ty, B, Cin, Cout, H, W, Kh, Kw, Oh, Ow, Sh, Sw, Pd0, Pd1
-](
+def conv2d[Ty, B, Cin, Cout, H, W, Kh, Kw, Oh, Ow, Sh, Sw, Pd0, Pd1](
     inp: "Ty[B, Cin, H, W]", kernel: "Ty[Cout, Cin, Kh, Kw]", bias: "Ty[Cout]"
 ) -> "Ty[B, Cout, Oh, Ow]":
     # https://pytorch.org/docs/stable/generated/torch.nn.Conv2d.html
@@ -231,9 +272,9 @@ def schedule_conv2d(s):
     return s
 
 
-def maxpool2d[
-    Ty, B, C, H, W, K, Oh, Ow, S, Pd
-](inp: "Ty[B, C, H, W]",) -> "Ty[B, C, Oh, Ow]":
+def maxpool2d[Ty, B, C, H, W, K, Oh, Ow, S, Pd](
+    inp: "Ty[B, C, H, W]",
+) -> "Ty[B, C, Oh, Ow]":
     # https://pytorch.org/docs/stable/generated/torch.nn.MaxPool2d.html
     Z: Ty[B, C, Oh, Ow]
     for batch, c, oh, ow in dsl.grid(B, C, Oh, Ow):
@@ -254,9 +295,9 @@ def schedule_maxpool2d(s):
     return s
 
 
-def avgpool2d[
-    Ty, B, C, H, W, K, Oh, Ow, S, Pd
-](inp: "Ty[B, C, H, W]",) -> "Ty[B, C, Oh, Ow]":
+def avgpool2d[Ty, B, C, H, W, K, Oh, Ow, S, Pd](
+    inp: "Ty[B, C, H, W]",
+) -> "Ty[B, C, Oh, Ow]":
     # https://pytorch.org/docs/stable/generated/torch.nn.AvgPool2d.html
     Z: Ty[B, C, Oh, Ow]
     for batch, c, oh, ow in dsl.grid(B, C, Oh, Ow):
@@ -276,9 +317,7 @@ def schedule_avgpool2d(s):
     return s
 
 
-def batchnorm2d[
-    Ty, B, C, H, W
-](
+def batchnorm2d[Ty, B, C, H, W](
     X: "Ty[B, C, H, W]",
     gamma: "Ty[C]",
     beta: "Ty[C]",
@@ -298,4 +337,75 @@ def batchnorm2d[
 
 def schedule_batchnorm2d(s):
     s.pipeline("batchnorm2d:w")
+    return s
+
+
+def batchnorm1d_2d[Ty, B, C](
+    X: "Ty[B, C]", gamma: "Ty[C]", beta: "Ty[C]", eps: "Ty", mean: "Ty[C]", var: "Ty[C]"
+) -> "Ty[B, C]":
+    Z: Ty[B, C]
+    for b, c in dsl.grid(B, C):
+        Z[b, c] = gamma[c] * (X[b, c] - mean[c]) / dsl.sqrt(var[c] + eps) + beta[c]
+    return Z
+
+
+def schedule_batchnorm1d_2d(s):
+    s.pipeline("batchnorm1d_2d:c")
+    return s
+
+
+def batchnorm1d_3d[Ty, B, C, L](
+    X: "Ty[B, C, L]",
+    gamma: "Ty[C]",
+    beta: "Ty[C]",
+    eps: "Ty",
+    mean: "Ty[C]",
+    var: "Ty[C]",
+) -> "Ty[B, C, L]":
+    Z: Ty[B, C, L]
+    for b, c, l in dsl.grid(B, C, L):
+        Z[b, c, l] = (
+            gamma[c] * (X[b, c, l] - mean[c]) / dsl.sqrt(var[c] + eps) + beta[c]
+        )
+    return Z
+
+
+def schedule_batchnorm1d_3d(s):
+    s.pipeline("batchnorm1d_3d:l")
+    return s
+
+
+def repeat_batch3d[Ty, B, L, C, N](X: "Ty[B, L, C]") -> "Ty[N*B, L, C]":
+    """
+    Repeat X along batch dimension N times for cls_token.
+    Args:
+        X: Input tensor of shape (B, L, C)
+        N: Repeat times (int)
+    Returns:
+        Y: Output tensor of shape (N*B, L, C)
+    """
+    Y: Ty[N * B, L, C]
+    for r, b, l, c in dsl.grid(N, B, L, C):
+        Y[r * B + b, l, c] = X[b, l, c]
+    return Y
+
+
+def schedule_repeat_batch3d(s):
+    s.pipeline("repeat_batch3d:c")
+    return s
+
+
+def concat[Ty, B, N1, N2, C](
+    X1: "Ty[B, N1, C]", X2: "Ty[B, N2, C]"
+) -> "Ty[B, N1+N2, C]":
+    Y: Ty[B, N1 + N2, C]
+    for b, n, c in dsl.grid(B, N1, C):
+        Y[b, n, c] = X1[b, n, c]
+    for b2, n2, c2 in dsl.grid(B, N2, C):
+        Y[b2, n2 + N1, c2] = X2[b2, n2, c2]
+    return Y
+
+
+def schedule_concat(s):
+    s.pipeline("concat:c")
     return s

--- a/allo/library/nn.py
+++ b/allo/library/nn.py
@@ -388,11 +388,6 @@ def schedule_batchnorm1d_3d(s):
 def repeat_batch3d[Ty, B, L, C, N](X: "Ty[B, L, C]") -> "Ty[N*B, L, C]":
     """
     Repeat X along batch dimension N times for cls_token.
-    Args:
-        X: Input tensor of shape (B, L, C)
-        N: Repeat times (int)
-    Returns:
-        Y: Output tensor of shape (N*B, L, C)
     """
     Y: Ty[N * B, L, C]
     for r, b, l, c in dsl.grid(N, B, L, C):

--- a/examples/torch/particle_transformer.py
+++ b/examples/torch/particle_transformer.py
@@ -1,0 +1,142 @@
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import allo
+
+
+class ConstituentNet(nn.Module):
+    def __init__(self, in_dim, embbed_dim, num_heads, num_classes, num_transformers):
+        super(ConstituentNet, self).__init__()
+        self.embedding = nn.Linear(in_dim, embbed_dim)
+        self.norm = nn.BatchNorm1d(embbed_dim)
+        self.linear = nn.Linear(embbed_dim, num_classes)
+        self.cls_token = nn.Parameter(torch.randn(1, 1, embbed_dim))
+
+        self.transformers = nn.ModuleList(
+            [
+                Transformer(
+                    embbed_dim,
+                    num_heads=num_heads,
+                )
+                for _ in range(num_transformers)
+            ]
+        )
+
+        self.slicer = SliceFirstDim()
+
+    def forward(self, x):
+        m_batch, _, _ = x.size()
+        out = self.embedding(x)
+        cls_tokens = self.cls_token.repeat(m_batch, 1, 1)
+        out = torch.cat((cls_tokens, out), dim=1)
+
+        for transformer in self.transformers:
+            out = transformer(out)
+
+        out = self.slicer(out)
+        out = self.norm(out)
+        out = self.linear(out)
+        return F.log_softmax(out, dim=-1)
+
+
+class Transformer(nn.Module):
+    def __init__(self, in_dim, num_heads):
+        super(Transformer, self).__init__()
+        self.latent_dim = in_dim
+
+        self.self_attention = SelfAttention(
+            in_dim=in_dim,
+            num_heads=num_heads,
+        )
+
+        self.norm_0 = nn.BatchNorm1d(in_dim)
+        self.activ_0 = nn.ReLU()
+
+        self.linear_0 = nn.Linear(in_dim, in_dim * 2, bias=False)
+        self.norm_1 = nn.BatchNorm1d(in_dim * 2)
+        self.activ_1 = nn.ReLU()
+
+        self.linear_1 = nn.Linear(in_dim * 2, in_dim, bias=False)
+
+    def forward(self, x):
+        x = self.self_attention(x)
+        out0 = self.norm_0(x.transpose(1, 2)).transpose(1, 2)
+        out1 = self.activ_0(out0)
+        out2 = self.linear_0(out1)
+        out3 = self.norm_1(out2.transpose(1, 2)).transpose(1, 2)
+        out4 = self.activ_1(out3)
+        out5 = self.linear_1(out4)
+        out = x + out5
+        return out
+
+
+class SelfAttention(nn.Module):
+    def __init__(self, in_dim, num_heads):
+        super(SelfAttention, self).__init__()
+        self.latent_dim = in_dim
+        self.heads = num_heads
+        self.head_dim = self.latent_dim // num_heads
+
+        self.norm = nn.BatchNorm1d(in_dim)
+        self.q = nn.Linear(in_dim, in_dim, bias=False)
+        self.k = nn.Linear(in_dim, in_dim, bias=False)
+        self.v = nn.Linear(in_dim, in_dim, bias=False)
+        self.out = nn.Linear(in_dim, in_dim)
+
+        assert (in_dim // num_heads) * num_heads == in_dim
+        assert self.head_dim * num_heads == self.latent_dim
+
+    def forward(self, x):
+        B, L, _ = x.size()
+        out = self.norm(x.transpose(1, 2)).transpose(1, 2)
+        q = self.q(out).view(B, L, self.heads, -1)
+        k = self.k(out).view(B, L, self.heads, -1)
+        v = self.v(out).view(B, L, self.heads, -1)
+
+        Q_ = q.permute(0, 2, 1, 3)
+        K_ = k.permute(0, 2, 3, 1)
+        energy = torch.matmul(Q_, K_)
+        attn = F.softmax(energy / (self.head_dim**0.5), dim=-1)
+
+        V_ = v.permute(0, 2, 1, 3)
+        ctx = torch.matmul(attn, V_)
+        out = ctx.permute(0, 2, 1, 3).reshape(B, L, -1)
+        out = self.out(out)
+        return out + x
+
+
+class SliceFirstDim(nn.Module):
+    def forward(self, inp):
+        # inp: (B, L, C), take CLS at position 0 -> (B, C)
+        return inp[:, 0, :]
+
+
+if __name__ == "__main__":
+    torch.manual_seed(0)
+
+    batch_size = 2
+    num_particles = 8
+    in_dim = 3
+    embbed_dim = 16
+    num_heads = 2
+    num_classes = 5
+    num_transformers = 1
+
+    model = ConstituentNet(
+        in_dim, embbed_dim, num_heads, num_classes, num_transformers
+    ).eval()
+    example_inputs = [torch.randn(batch_size, num_particles, in_dim)]
+    golden = model(*example_inputs).detach().numpy()
+    np_inp = example_inputs[0].detach().numpy()
+
+    mod = allo.frontend.from_pytorch(
+        model,
+        example_inputs=example_inputs,
+        leaf_modules=(SliceFirstDim,),
+        verbose=False,
+    )
+
+    out = mod(np_inp)
+    np.testing.assert_allclose(out, golden, atol=1e-5, rtol=1e-5)
+    print("Passed!")

--- a/examples/torch/particle_transformer.py
+++ b/examples/torch/particle_transformer.py
@@ -1,3 +1,6 @@
+# Copyright Allo authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import numpy as np
 import torch
 import torch.nn as nn

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -204,9 +204,7 @@ def test_bert():
     H, L, D, Dffn = 2, 8, 8, 16
     M0, M1 = 2, 2
 
-    def BertLayer[
-        Ty, H, L, D, Dffn, M0, M1
-    ](
+    def BertLayer[Ty, H, L, D, Dffn, M0, M1](
         X: "Ty[L, D]",
         Wq: "Ty[D, D]",
         Wk: "Ty[D, D]",
@@ -426,6 +424,164 @@ def test_batchnorm2d():
     ) * gamma.reshape(1, C, 1, 1) + beta.reshape(1, C, 1, 1)
 
     np.testing.assert_allclose(allo_out, np_out, rtol=1e-04)
+    print("Passed!")
+    print(s.build(target="vhls"))
+
+
+def np_log_softmax(x, axis=-1):
+    x_max = np.max(x, axis=axis, keepdims=True)
+    y = x - x_max
+    return y - np.log(np.sum(np.exp(y), axis=axis, keepdims=True))
+
+
+def test_log_softmax():
+    from allo.library.nn import log_softmax
+
+    # log_softmax[Ty, B, C]
+    s = allo.customize(log_softmax, instantiate=[float32, 8, 8])
+    mod = s.build()
+    inp = np.random.randn(8, 8).astype(np.float32)
+    inp = 1000 * inp
+    allo_out = mod(inp)
+    np_out = np_log_softmax(inp).astype(np.float32)
+    np.testing.assert_allclose(allo_out, np_out, atol=1e-5, rtol=1e-5)
+    print("Passed!")
+    print(s.build(target="vhls"))
+
+
+def test_batchnorm1d_2d():
+    from allo.library.nn import batchnorm1d_2d
+
+    B, C = 4, 8
+    inp = np.random.randn(B, C).astype(np.float32)
+    gamma = np.random.randn(C).astype(np.float32)
+    beta = np.random.randn(C).astype(np.float32)
+
+    # Simulating running mean and variance
+    running_mean = np.random.randn(C).astype(np.float32)
+    running_var = np.abs(np.random.randn(C)).astype(np.float32)
+
+    s = allo.customize(batchnorm1d_2d, instantiate=[float32, B, C])
+    mod = s.build()
+    allo_out = mod(inp, gamma, beta, 1e-5, running_mean, running_var)
+
+    np_out = (inp - running_mean.reshape(1, C)) / np.sqrt(
+        running_var.reshape(1, C) + 1e-5
+    ) * gamma.reshape(1, C) + beta.reshape(1, C)
+
+    np.testing.assert_allclose(allo_out, np_out, rtol=1e-5, atol=1e-5)
+    print("Passed!")
+    print(s.build(target="vhls"))
+
+
+def test_batchnorm1d_3d():
+    from allo.library.nn import batchnorm1d_3d
+
+    B, C, L = 2, 6, 5
+    inp = np.random.randn(B, C, L).astype(np.float32)
+    gamma = np.random.randn(C).astype(np.float32)
+    beta = np.random.randn(C).astype(np.float32)
+
+    running_mean = np.random.randn(C).astype(np.float32)
+    running_var = np.abs(np.random.randn(C)).astype(np.float32)
+
+    s = allo.customize(batchnorm1d_3d, instantiate=[float32, B, C, L])
+    mod = s.build()
+    allo_out = mod(inp, gamma, beta, 1e-5, running_mean, running_var)
+
+    np_out = (inp - running_mean.reshape(1, C, 1)) / np.sqrt(
+        running_var.reshape(1, C, 1) + 1e-5
+    ) * gamma.reshape(1, C, 1) + beta.reshape(1, C, 1)
+
+    np.testing.assert_allclose(allo_out, np_out, rtol=1e-5, atol=1e-5)
+    print("Passed!")
+    print(s.build(target="vhls"))
+
+
+def test_repeat_batch3d():
+    from allo.library.nn import repeat_batch3d
+
+    B, L, C, N = 3, 4, 5, 2  # Output (N*B, L, C)
+    inp = np.random.randn(B, L, C).astype(np.float32)
+
+    s = allo.customize(repeat_batch3d, instantiate=[float32, B, L, C, N])
+    mod = s.build()
+
+    allo_out = mod(inp)
+    # Copy inp N times along the batch dimension
+    np_out = np.tile(inp, (N, 1, 1)).astype(np.float32)
+
+    np.testing.assert_allclose(allo_out, np_out, rtol=1e-5, atol=1e-5)
+    print("Passed!")
+    print(s.build(target="vhls"))
+
+
+def test_concat():
+    from allo.library.nn import concat
+
+    B, N1, N2, C = 2, 3, 4, 5
+    x1 = np.random.randn(B, N1, C).astype(np.float32)
+    x2 = np.random.randn(B, N2, C).astype(np.float32)
+
+    s = allo.customize(concat, instantiate=[float32, B, N1, N2, C])
+    mod = s.build()
+
+    allo_out = mod(x1, x2)
+    # Concatenate along dim 1 (N1 + N2, C)
+    np_out = np.concatenate([x1, x2], axis=1).astype(np.float32)
+
+    np.testing.assert_allclose(allo_out, np_out, rtol=1e-5, atol=1e-5)
+    print("Passed!")
+    print(s.build(target="vhls"))
+
+
+def test_relu2d():
+    from allo.library.nn import relu2d
+
+    H, W = 8, 10
+    x = (np.random.randn(H, W)).astype(np.float32)
+
+    s = allo.customize(relu2d, instantiate=[float32, H, W])
+    mod = s.build()
+
+    allo_out = mod(x)
+    np_out = np.maximum(x, 0.0).astype(np.float32)
+
+    np.testing.assert_allclose(allo_out, np_out, rtol=1e-5, atol=1e-5)
+    print("Passed!")
+    print(s.build(target="vhls"))
+
+
+def test_relu3d():
+    from allo.library.nn import relu3d
+
+    N, L, C = 3, 5, 7
+    x = (np.random.randn(N, L, C)).astype(np.float32)
+
+    s = allo.customize(relu3d, instantiate=[float32, N, L, C])
+    mod = s.build()
+
+    allo_out = mod(x)
+    np_out = np.maximum(x, 0.0).astype(np.float32)
+
+    np.testing.assert_allclose(allo_out, np_out, rtol=1e-5, atol=1e-5)
+    print("Passed!")
+    print(s.build(target="vhls"))
+
+
+def test_relu4d():
+    from allo.library.nn import relu4d
+
+    N, C, H, W = 2, 4, 6, 8
+    x = (np.random.randn(N, C, H, W)).astype(np.float32)
+
+    s = allo.customize(relu4d, instantiate=[float32, N, C, H, W])
+    mod = s.build()
+
+    allo_out = mod(x)
+    np_out = np.maximum(x, 0.0).astype(np.float32)
+
+    np.testing.assert_allclose(allo_out, np_out, rtol=1e-5, atol=1e-5)
     print("Passed!")
     print(s.build(target="vhls"))
 

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -204,7 +204,9 @@ def test_bert():
     H, L, D, Dffn = 2, 8, 8, 16
     M0, M1 = 2, 2
 
-    def BertLayer[Ty, H, L, D, Dffn, M0, M1](
+    def BertLayer[
+        Ty, H, L, D, Dffn, M0, M1
+    ](
         X: "Ty[L, D]",
         Wq: "Ty[D, D]",
         Wk: "Ty[D, D]",


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR fixes cornell-zhang/allo#386 and enhances the PyTorch frontend in the allo library to support additional operations commonly used in Transformer models.

### Problems ###
The current PyTorch frontend lacks support for several commonly used Transformer components, leading to conversion failures when compiling models.
Unsupported features include:
- `build_get_attr` handling for cls_token to avoid attribute access errors
- `repeat` for CLS token expansion
- `log_softmax` operator
- `BatchNorm1d` supporting both 2D (B, C) and 3D (B, C, L) inputs
- `relu3d` (previously only relu2d and relu4d existed)
- `concat` for sequence concatenation, used to prepend CLS token
- Slice operation to extract CLS token (Allo currently does not support slicing)

### Proposed Solutions ###
- Fix bug: add build_get_attr support for cls_token parameters
- Add repeat_batch3d, concat, relu3d, log_softmax, batchnorm1d_2d, batchnorm1d_3d and schedules
- Add leaf module SliceClsToken_lib for extracting CLS token

### Examples ###
A minimal working Particle Transformer example is provided in `examples/torch/particle_transformer.py`.

## Checklist ##

Please make sure to review and check all of these items:
- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] All changes have test coverage (It would be good to provide ~2 different test cases to test the robustness of your code)
- [x] Pass the [formatting check](https://cornell-zhang.github.io/allo/developer/index.html#id1) locally
- [x] Code is well-documented
