### PR TITLE
[Library] Fix legacy systolic array performance issue

### DIFF
--- a/allo/customize.py
+++ b/allo/customize.py
@@ -262,8 +262,11 @@ class Schedule:
             axes.append(axis)
         arg_results = [arg.result for arg in loop_hdls]
         allo_d.FuseOp(arg_results, ip=ip)
-        name = "_".join(axes) + "_fused"
-        return LoopWrapper(f"{args[0].func}:{band_name}.{name}", None)
+        if isinstance(args[0], LoopWrapper):
+            name = "_".join(axes) + "_fused"
+            return LoopWrapper(f"{args[0].func}:{band_name}.{name}", None)
+        else:
+            return LoopWrapper(f"{func.name.value}:{band_name}", None)
 
     @wrapped_apply
     # pylint: disable=too-many-branches

--- a/allo/customize.py
+++ b/allo/customize.py
@@ -265,8 +265,7 @@ class Schedule:
         if isinstance(args[0], LoopWrapper):
             name = "_".join(axes) + "_fused"
             return LoopWrapper(f"{args[0].func}:{band_name}.{name}", None)
-        else:
-            return LoopWrapper(f"{func.name.value}:{band_name}", None)
+        return LoopWrapper(f"{func.name.value}:{band_name}", None)
 
     @wrapped_apply
     # pylint: disable=too-many-branches

--- a/allo/customize.py
+++ b/allo/customize.py
@@ -252,14 +252,18 @@ class Schedule:
         ip = InsertionPoint.at_block_terminator(func.entry_block)
         op_hdl = allo_d.CreateOpHandleOp(band_name, ip=ip)
         loop_hdls = []
+        axes = []
         for arg in args:
             func, axis = self._get_func_and_axis(args)
             band_name, axis = find_loop_in_bands(func, arg)
             loop_hdls.append(
                 allo_d.CreateLoopHandleOp(op_hdl.result, StringAttr.get(axis), ip=ip)
             )
+            axes.append(axis)
         arg_results = [arg.result for arg in loop_hdls]
         allo_d.FuseOp(arg_results, ip=ip)
+        name = "_".join(axes) + "_fused"
+        return LoopWrapper(f"{args[0].func}:{band_name}.{name}", None)
 
     @wrapped_apply
     # pylint: disable=too-many-branches

--- a/allo/library/systolic.py
+++ b/allo/library/systolic.py
@@ -40,7 +40,7 @@ def PE_kernel[
 ):
     # Be careful, need to use high precision for accumulation
     v: TyC = 0
-    for k in range(K):
+    for k in dsl.grid(K, name="reduction"):
         a: TyA = A_in[k]
         b: TyB = B_in[k]
         v += a * b
@@ -304,20 +304,18 @@ def schedule_systolic(s):
     s.partition(s.local_C, dim=0)  # required, otherwise it will fail dataflow checking
     s.partition(s.local_A, dim=1)
     s.partition(s.local_B, dim=2)
-    load_A_loop = s.get_loops(s.top_func_name)["outer_tile"]["ai"]
-    if str(load_A_loop.loop.attributes["upperBoundMap"]) == "affine_map<() -> (1)>":
-        load_A_loop = s.get_loops(s.top_func_name)["outer_tile"]["ak"]
+    load_A_loop = s.get_loops(s.top_func_name)["outer_tile"]["ak"]
     s.pipeline(load_A_loop)
-    load_B_loop = s.get_loops(s.top_func_name)["outer_tile"]["bj"]
-    if str(load_B_loop.loop.attributes["upperBoundMap"]) == "affine_map<() -> (1)>":
-        load_B_loop = s.get_loops(s.top_func_name)["outer_tile"]["bk"]
+    load_B_loop = s.get_loops(s.top_func_name)["outer_tile"]["bk"]
     s.pipeline(load_B_loop)
-    store_C_loop = s.get_loops(s.top_func_name)["outer_tile"]["si"]
-    if str(store_C_loop.loop.attributes["upperBoundMap"]) == "affine_map<() -> (1)>":
-        store_C_loop = s.get_loops(s.top_func_name)["outer_tile"]["sj"]
+    store_C_loop = s.get_loops(s.top_func_name)["outer_tile"]["sj"]
     s.pipeline(store_C_loop)
-    tile_loop = s.get_loops(s.top_func_name)["outer_tile"]["ni"]
+    inner_tile_loop = s.get_loops(s.top_func_name)["outer_tile"]["ni"]
+    outer_tile_loop = s.get_loops(s.top_func_name)["outer_tile"]["mi"]
+    tile_loop = s.fuse(outer_tile_loop, inner_tile_loop)
     s.dataflow(tile_loop)
+    kernel_loop = s.get_loops(f"PE_kernel")["reduction"]["k"]
+    s.pipeline(kernel_loop)
     pe = s.unfold(f"{tile_name}:PE", [0, 1])  # specify which are spatial loops
     s.to(MockBuffer(tile_name, "A_fifo"), pe, axis=1, depth=M0 + 1)
     s.to(MockBuffer(tile_name, "B_fifo"), pe, axis=0, depth=M1 + 1)

--- a/allo/library/systolic.py
+++ b/allo/library/systolic.py
@@ -294,7 +294,6 @@ def schedule_systolic(s):
         assert len(s.inst_list) == 9
         tile_name = "systolic_tile"
         M0, M1 = s.inst_list[-3], s.inst_list[-2]
-        kernel_loop = s.get_loops(f"PE_kernel_packed_int8xint8")["reduction"]["k"]
     elif s.top_func_name == "packed_int8xint8_systolic":
         assert len(s.inst_list) == 6
         tile_name = "systolic_tile"
@@ -317,7 +316,15 @@ def schedule_systolic(s):
     outer_tile_loop = s.get_loops(s.top_func_name)["outer_tile"]["mi"]
     tile_loop = s.fuse(outer_tile_loop, inner_tile_loop)
     s.dataflow(tile_loop)
-    s.pipeline(kernel_loop)
+    kernel_loop = None
+    for kernel_name in {"PE_kernel", "PE_kernel_packed_int8xint8"}:
+        try:
+            kernel_loop = s.get_loops(kernel_name)["reduction"]["k"]
+            break
+        except RuntimeError:
+            continue
+    if kernel_loop is not None:
+        s.pipeline(kernel_loop)
     pe = s.unfold(f"{tile_name}:PE", [0, 1])  # specify which are spatial loops
     s.to(MockBuffer(tile_name, "A_fifo"), pe, axis=1, depth=M0 + 1)
     s.to(MockBuffer(tile_name, "B_fifo"), pe, axis=0, depth=M1 + 1)

--- a/playground/int8_gemm.py
+++ b/playground/int8_gemm.py
@@ -9,6 +9,51 @@ from allo.utils import get_np_struct_type
 import allo.backend.hls as hls
 
 
+def test_single_systolic():
+    from allo.library.systolic import systolic
+
+    MODE = "csyn"
+    # L, D = 512, 768
+    # M0, M1 = 16, 16
+    L, D = 8, 8
+    M0, M1 = 2, 2
+    # L, D = 512, 512
+    # M0, M1 = 16, 16
+    # L, D = 1024, 1024
+    # M0, M1 = 16, 16
+    W_A = np.random.randint(-4, 4, size=(D, D)).astype(np.int8)
+    allo_C = np.zeros((L, D), dtype=np.int8)
+
+    def top(X: int8[L, D], W_A: int8[D, D]) -> int8[L, D]:
+        Z: int8[L, D]
+        systolic[int8, int8, int8, L, D, D, M0, M1](X, W_A, Z)
+        return Z
+
+    s = allo.customize(top)
+    # CPU testing
+    mod = s.build()
+    X = np.random.randint(-4, 4, size=(L, D)).astype(np.int8)
+    allo_C = mod(X, W_A)
+    np_C = X @ W_A
+    np.testing.assert_allclose(allo_C, np_C, atol=1e-3)
+    print("Passed!")
+    s.compose(systolic, instantiate=[int8, int8, int8, L, D, D, M0, M1])
+    s.dataflow("top")
+    hls_mod = s.build(
+        target="vitis_hls",
+        mode=MODE,
+        project=f"single_{L}x{D}_tile_{M0}x{M1}.prj",
+    )
+    if MODE == "csyn":
+        hls_mod()
+        print("Passed!")
+    else:
+        hls_mod(X, W_A, allo_C)
+        np_C = X @ W_A
+        np.testing.assert_allclose(allo_C, np_C, atol=1e-3)
+        print("Passed!")
+
+
 def test_cascaded_int8_gemm():
     from allo.library.systolic import systolic
 
@@ -213,6 +258,7 @@ def test_int8_gemm_dsp_packing():
 
 
 if __name__ == "__main__":
+    test_single_systolic()
     test_cascaded_int8_gemm()
     test_int8_gemm()
     test_int8_gemm_dsp_packing()


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR fixes a legacy SA issue where the original SA based on Allo's schedule cannot achieve the expected performance.
This is mainly due to the incorrect pipelined loops for data loading/storing.

### Problems ###
The old performance result (8x8 GEMM using 2x2 SA):
```
+ Latency: 
    * Summary: 
    +---------+---------+----------+----------+-----+-----+----------+
    |  Latency (cycles) |  Latency (absolute) |  Interval | Pipeline |
    |   min   |   max   |    min   |    max   | min | max |   Type   |
    +---------+---------+----------+----------+-----+-----+----------+
    |      725|      727|  2.416 us|  2.423 us|  454|  454|  dataflow|
    +---------+---------+----------+----------+-----+-----+----------+

    + Detail: 
        * Instance: 
        +-----------------+--------------+---------+---------+----------+----------+-----+-----+------------------------------------------+
        |                 |              |  Latency (cycles) |  Latency (absolute) |  Interval |                 Pipeline                 |
        |     Instance    |    Module    |   min   |   max   |    min   |    max   | min | max |                   Type                   |
        +-----------------+--------------+---------+---------+----------+----------+-----+-----+------------------------------------------+
        |entry_proc_U0    |entry_proc    |        0|        0|      0 ns|      0 ns|    0|    0|                                        no|
        |load_buf0_1_U0   |load_buf0_1   |      136|      137|  0.453 us|  0.457 us|   64|   64|  loop rewind stp(delay=0 clock cycles(s))|
        |load_buf1_1_U0   |load_buf1_1   |      136|      137|  0.453 us|  0.457 us|   64|   64|  loop rewind stp(delay=0 clock cycles(s))|
        |systolic_U0      |systolic      |      453|      453|  1.510 us|  1.510 us|  453|  453|                                        no|
        |store_res2_1_U0  |store_res2_1  |      134|      135|  0.447 us|  0.450 us|   64|   64|  loop rewind stp(delay=0 clock cycles(s))|
        +-----------------+--------------+---------+---------+----------+----------+-----+-----+------------------------------------------+

+ Latency: 
    * Summary: 
    +---------+---------+-----------+-----------+-----+-----+----------+
    |  Latency (cycles) |   Latency (absolute)  |  Interval | Pipeline |
    |   min   |   max   |    min    |    max    | min | max |   Type   |
    +---------+---------+-----------+-----------+-----+-----+----------+
    |       16|       16|  53.328 ns|  53.328 ns|   14|   14|  dataflow|
    +---------+---------+-----------+-----------+-----+-----+----------+

    + Detail: 
        * Instance: 
        +-----------------------------------------------+--------------------------------------------+---------+---------+-----------+-----------+-----+-----+---------+
        |                                               |                                            |  Latency (cycles) |   Latency (absolute)  |  Interval | Pipeline|
        |                    Instance                   |                   Module                   |   min   |   max   |    min    |    max    | min | max |   Type  |
        +-----------------------------------------------+--------------------------------------------+---------+---------+-----------+-----------+-----+-----+---------+
        |systolic_tile_Loop_l_data_load_k4_proc411_U0   |systolic_tile_Loop_l_data_load_k4_proc411   |       10|       10|  33.330 ns|  33.330 ns|   10|   10|       no|
        |PE_kernel_0_012_U0                             |PE_kernel_0_012                             |       13|       13|  43.329 ns|  43.329 ns|   13|   13|       no|
        |PE_kernel_1_013_U0                             |PE_kernel_1_013                             |       13|       13|  43.329 ns|  43.329 ns|   13|   13|       no|
        |PE_kernel_0_114_U0                             |PE_kernel_0_114                             |       13|       13|  43.329 ns|  43.329 ns|   13|   13|       no|
        |PE_kernel_1_115_U0                             |PE_kernel_1_115                             |       13|       13|  43.329 ns|  43.329 ns|   13|   13|       no|
        |systolic_tile_Loop_l_data_drain_k5_proc516_U0  |systolic_tile_Loop_l_data_drain_k5_proc516  |       10|       10|  33.330 ns|  33.330 ns|   10|   10|       no|
        +-----------------------------------------------+--------------------------------------------+---------+---------+-----------+-----------+-----+-----+---------+

```

The new performance result is shown below:
```
+ Latency: 
    * Summary: 
    +---------+---------+----------+----------+-----+-----+----------+
    |  Latency (cycles) |  Latency (absolute) |  Interval | Pipeline |
    |   min   |   max   |    min   |    max   | min | max |   Type   |
    +---------+---------+----------+----------+-----+-----+----------+
    |      397|      399|  1.322 us|  1.329 us|  252|  252|  dataflow|
    +---------+---------+----------+----------+-----+-----+----------+

    + Detail: 
        * Instance: 
        +-----------------+--------------+---------+---------+----------+----------+-----+-----+------------------------------------------+
        |                 |              |  Latency (cycles) |  Latency (absolute) |  Interval |                 Pipeline                 |
        |     Instance    |    Module    |   min   |   max   |    min   |    max   | min | max |                   Type                   |
        +-----------------+--------------+---------+---------+----------+----------+-----+-----+------------------------------------------+
        |entry_proc_U0    |entry_proc    |        0|        0|      0 ns|      0 ns|    0|    0|                                        no|
        |load_buf0_1_U0   |load_buf0_1   |       73|       74|  0.243 us|  0.246 us|   64|   64|  loop rewind stp(delay=0 clock cycles(s))|
        |load_buf1_1_U0   |load_buf1_1   |       73|       74|  0.243 us|  0.246 us|   64|   64|  loop rewind stp(delay=0 clock cycles(s))|
        |systolic_U0      |systolic      |      251|      251|  0.836 us|  0.836 us|  251|  251|                                        no|
        |store_res2_1_U0  |store_res2_1  |       71|       72|  0.236 us|  0.240 us|   64|   64|  loop rewind stp(delay=1 clock cycles(s))|
        +-----------------+--------------+---------+---------+----------+----------+-----+-----+------------------------------------------+

+ Latency: 
    * Summary: 
    +---------+---------+-----------+-----------+-----+-----+----------+
    |  Latency (cycles) |   Latency (absolute)  |  Interval | Pipeline |
    |   min   |   max   |    min    |    max    | min | max |   Type   |
    +---------+---------+-----------+-----------+-----+-----+----------+
    |       16|       16|  53.280 ns|  53.280 ns|   14|   14|  dataflow|
    +---------+---------+-----------+-----------+-----+-----+----------+

    + Detail: 
        * Instance: 
        +---------------------------------------------+------------------------------------------+---------+---------+-----------+-----------+-----+-----+---------+
        |                                             |                                          |  Latency (cycles) |   Latency (absolute)  |  Interval | Pipeline|
        |                   Instance                  |                  Module                  |   min   |   max   |    min    |    max    | min | max |   Type  |
        +---------------------------------------------+------------------------------------------+---------+---------+-----------+-----------+-----+-----+---------+
        |systolic_tile_Loop_l_data_load_k4_proc4_U0   |systolic_tile_Loop_l_data_load_k4_proc4   |       10|       10|  33.300 ns|  33.300 ns|   10|   10|       no|
        |PE_kernel_0_0_U0                             |PE_kernel_0_0                             |       13|       13|  43.290 ns|  43.290 ns|   13|   13|       no|
        |PE_kernel_1_0_U0                             |PE_kernel_1_0                             |       13|       13|  43.290 ns|  43.290 ns|   13|   13|       no|
        |PE_kernel_0_1_U0                             |PE_kernel_0_1                             |       13|       13|  43.290 ns|  43.290 ns|   13|   13|       no|
        |PE_kernel_1_1_U0                             |PE_kernel_1_1                             |       13|       13|  43.290 ns|  43.290 ns|   13|   13|       no|
        |systolic_tile_Loop_l_data_drain_k5_proc5_U0  |systolic_tile_Loop_l_data_drain_k5_proc5  |       10|       10|  33.300 ns|  33.300 ns|   10|   10|       no|
        +---------------------------------------------+------------------------------------------+---------+---------+-----------+-----------+-----+-----+---------+
```



## Checklist ##

Please make sure to review and check all of these items:
- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] All changes have test coverage (It would be good to provide ~2 different test cases to test the robustness of your code)
- [x] Pass the [formatting check](https://cornell-zhang.github.io/allo/developer/index.html#id1) locally
- [x] Code is well-documented
