### PR TITLE
[Backend][Bugfix] Fix naming conflicts in bit operations when targeting HLS

### DIFF
--- a/mlir/lib/Translation/EmitVivadoHLS.cpp
+++ b/mlir/lib/Translation/EmitVivadoHLS.cpp
@@ -1565,9 +1565,12 @@ void ModuleEmitter::emitGetBit(allo::GetIntBitOp op) {
   indent();
   Value result = op.getResult();
   fixUnsignedType(result, op->hasAttr("unsigned"));
+  emitValue(result);
+  os << ";\n";
+  indent();
   // generate ap_int types
   os << "ap_int<" << op.getNum().getType().getIntOrFloatBitWidth() << "> ";
-  emitValue(op.getNum());
+  os << getName(result);
   os << "_tmp = ";
   emitValue(op.getNum());
   os << ";\n";
@@ -1575,7 +1578,7 @@ void ModuleEmitter::emitGetBit(allo::GetIntBitOp op) {
   indent();
   emitValue(result);
   os << " = ";
-  emitValue(op.getNum());
+  os << getName(result);
   os << "_tmp[";
   emitValue(op.getIndex());
   os << "];";
@@ -1584,15 +1587,18 @@ void ModuleEmitter::emitGetBit(allo::GetIntBitOp op) {
 
 void ModuleEmitter::emitSetBit(allo::SetIntBitOp op) {
   indent();
+  emitValue(op.getResult());
+  os << ";\n";
   // generate ap_int types
+  indent();
   os << "ap_int<" << op.getNum().getType().getIntOrFloatBitWidth() << "> ";
-  emitValue(op.getNum());
+  os << getName(op.getResult());
   os << "_tmp = ";
   emitValue(op.getNum());
   os << ";\n";
   // generate bit indexing
   indent();
-  emitValue(op.getNum());
+  os << getName(op.getResult());
   os << "_tmp[";
   emitValue(op.getIndex());
   os << "] = ";
@@ -1602,7 +1608,7 @@ void ModuleEmitter::emitSetBit(allo::SetIntBitOp op) {
   indent();
   emitValue(op.getResult());
   os << " = ";
-  emitValue(op.getNum());
+  os << getName(op.getResult());
   os << "_tmp;";
   emitInfoAndNewLine(op);
 }
@@ -1610,10 +1616,13 @@ void ModuleEmitter::emitSetBit(allo::SetIntBitOp op) {
 void ModuleEmitter::emitGetSlice(allo::GetIntSliceOp op) {
   indent();
   Value result = op.getResult();
+  emitValue(result);
+  os << ";\n";
   fixUnsignedType(result, op->hasAttr("unsigned"));
   // generate ap_int types
+  indent();
   os << "ap_int<" << op.getNum().getType().getIntOrFloatBitWidth() << "> ";
-  emitValue(op.getNum());
+  os << getName(result);
   os << "_tmp = ";
   emitValue(op.getNum());
   os << ";\n";
@@ -1621,7 +1630,7 @@ void ModuleEmitter::emitGetSlice(allo::GetIntSliceOp op) {
   indent();
   emitValue(result);
   os << " = ";
-  emitValue(op.getNum());
+  os << getName(result);
   os << "_tmp(";
   emitValue(op.getHi());
   os << ", ";
@@ -1635,15 +1644,18 @@ void ModuleEmitter::emitSetSlice(allo::SetIntSliceOp op) {
   // T v;
   // v(a, b) = x;
   // c = v; // <- Need to redirect to the updated variable.
+  emitValue(op.getResult());
+  os << ";\n";
   // generate ap_int types
+  indent();
   os << "ap_int<" << op.getNum().getType().getIntOrFloatBitWidth() << "> ";
-  emitValue(op.getNum());
+  os << getName(op.getResult());
   os << "_tmp = ";
   emitValue(op.getNum());
   os << ";\n";
   // generate bit slicing
   indent();
-  emitValue(op.getNum());
+  os << getName(op.getResult());
   os << "_tmp(";
   emitValue(op.getHi());
   os << ", ";
@@ -1655,7 +1667,7 @@ void ModuleEmitter::emitSetSlice(allo::SetIntSliceOp op) {
   indent();
   emitValue(op.getResult());
   os << " = ";
-  emitValue(op.getNum());
+  os << getName(op.getResult());
   os << "_tmp;";
   emitInfoAndNewLine(op);
 }


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR fixes a naming conflict when using bit operations with `allo.meta_for` (explicit unrolling) for the HLS backend

### Problems ###
Old code:
```cpp
    ap_int<128> v65_tmp = v65;
    int8_t v66 = v66_tmp(7, 0);	// L108
    v48.write(v66);	// L109
    ap_int<128> v65_tmp = v65;  // naming conflict
    int8_t v67 = v65_tmp(15, 8);	// L110
    v49.write(v67);	// L111
```

New generated code:
```cpp
    int8_t v66;
    ap_int<128> v66_tmp = v65;
    v66 = v66_tmp(7, 0);	// L108
    v48.write(v66);	// L109
    int8_t v67;
    ap_int<128> v67_tmp = v65;
    v67 = v67_tmp(15, 8);	// L110
    v49.write(v67);	// L111
```



## Checklist ##

Please make sure to review and check all of these items:
- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [ ] All changes have test coverage (It would be good to provide ~2 different test cases to test the robustness of your code)
- [x] Pass the [formatting check](https://cornell-zhang.github.io/allo/developer/index.html#id1) locally
- [x] Code is well-documented
