### PR TITLE
[Bugfix] Fix softmax template causing Vitis HLS codegen error

### DIFF
--- a/allo/ir/template/softmax_impl.mlir
+++ b/allo/ir/template/softmax_impl.mlir
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // https://github.com/llvm/llvm-project/blob/main/mlir/test/Dialect/Linalg/transform-op-decompose.mlir
 
-func.func @softmax(%A: memref<2x16x32xf32>, %B: memref<2x16x32xf32>) -> memref<2x16x32xf32> {
+func.func @softmax(%A: memref<2x16x32xf32>) -> memref<2x16x32xf32> {
         %0 = memref.alloc() : memref<2x16xf32>
+        %B = memref.alloc() : memref<2x16x32xf32>
         %C0_f32 = arith.constant 0xFF800000 : f32
         linalg.fill ins(%C0_f32 : f32) outs(%0 : memref<2x16xf32>)
         linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel",
@@ -36,5 +37,5 @@ func.func @softmax(%A: memref<2x16x32xf32>, %B: memref<2x16x32xf32>) -> memref<2
             %7 = arith.divf %IN1, %IN2 : f32
             linalg.yield %7 : f32
           }
-          return %B : memref<2x16x32xf32>
+      return %B : memref<2x16x32xf32>
 }


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR fixes #457 

### Problems ###
The original issue was reported [here](https://github.com/cornell-zhang/allo/issues/457#issuecomment-3510770273).
The root cause is a mismatch between the argument table of the internally generated library kernel and the callee.
Further investigation revealed that the `vitis_hls` backend fix in #391 is not fully compatible with the old[ `softmax.mlir` template](https://github.com/cornell-zhang/allo/blob/84cc61e893ee27cde71b349a066fd30f23e4f3ea/allo/ir/template/softmax_impl.mlir).

### Proposed Solutions ###
Updated the `softmax.mlir` template and adjusted some corresponding logic.


## Checklist ##

Please make sure to review and check all of these items:
- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [ ] All changes have test coverage (It would be good to provide ~2 different test cases to test the robustness of your code)
- [x] Pass the [formatting check](https://cornell-zhang.github.io/allo/developer/index.html#id1) locally
- [ ] Code is well-documented
