### PR TITLE
[Setup][Fix] Fix nanobind registration issue by setting MLIR Python bindings NB_DOMAIN

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ class CMakeBuild(build_ext):
             f"-DMLIR_DIR={llvm_build_dir}/lib/cmake/mlir",
             f"-DPython3_EXECUTABLE={sys.executable}",
             f"-Dnanobind_DIR={nanobind_cmake_dir}",
-            "-DMLIR_BINDINGS_PYTHON_NB_DOMAIN=allo"
+            "-DMLIR_BINDINGS_PYTHON_NB_DOMAIN=allo",
         ]
 
         build_temp = os.path.join(ext.sourcedir, "build")


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR fixes a crash when importing `allo` together with other MLIR-based Python packages (e.g. `mlir-aie`) caused by **duplicate nanobind registrations of MLIR core enums**, such as `DiagnosticSeverity`.

### Problems ###
When multiple MLIR Python bindings are loaded in the same Python process, each may attempt to register MLIR core types and enums via nanobind. Without isolation, this leads to errors like:
```txt
<frozen importlib._bootstrap>:488: RuntimeWarning: nanobind: type '_Globals' was already registered! 
<frozen importlib._bootstrap>:488: RuntimeWarning: nanobind: type 'DiagnosticSeverity' was already registered!
Critical nanobind error: refusing to add duplicate key "ERROR" to enumeration "allo._mlir._mlir_libs._mlir.ir.DiagnosticSeverity"!
```

(This issue became visible after using newer `mlir-aie` wheels)

### Proposed Solutions ###
building Allo’s MLIR Python bindings with a dedicated nanobind domain:

```txt
-DMLIR_BINDINGS_PYTHON_NB_DOMAIN=allo
```

**Reference:**
- https://github.com/llvm/lighthouse/issues/14
- https://github.com/llvm/torch-mlir/pull/4385
## Checklist ##

Please make sure to review and check all of these items:
- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] All changes have test coverage (It would be good to provide ~2 different test cases to test the robustness of your code)
- [x] Pass the [formatting check](https://cornell-zhang.github.io/allo/developer/index.html#id1) locally
- [x] Code is well-documented
