### PR TITLE
[Builder] Support accessing a slice of a numpy array as a const tensor

### DIFF
--- a/allo/ir/builder.py
+++ b/allo/ir/builder.py
@@ -1117,7 +1117,12 @@ class ASTTransformer(ASTBuilder):
                     assert idx is None, "Not Supported"
                     ctx.buffers[target.id] = rhs
                     # FIXME (Shihan): GetGlobalOp has a "name" attribute, which may have assignment conflict
-                    if "name" in rhs.attributes:
+                    # For GetGlobalOp (constant tensors), the name is the global symbol reference,
+                    # not the target variable name. Skip the assertion check for GetGlobalOp.
+                    if isinstance(rhs, memref_d.GetGlobalOp):
+                        # GetGlobalOp's name is a symbol reference - don't try to set/check attributes
+                        pass
+                    elif "name" in rhs.attributes:
                         assert rhs.attributes["name"].value == target.id
                     else:
                         rhs.attributes["name"] = StringAttr.get(target.id)

--- a/allo/ir/infer.py
+++ b/allo/ir/infer.py
@@ -647,6 +647,32 @@ class TypeInferer(ASTVisitor):
                 ctx, value, ctx.global_vars[value.id], dtype=target_dtype
             )
             value.dtype = target_dtype
+        elif isinstance(value, ast.Subscript) and isinstance(value.value, ast.Name):
+            # Handle slicing of a constant numpy array, e.g., np_array[i]
+            array_name = value.value.id
+            if array_name in ctx.global_vars and isinstance(
+                ctx.global_vars[array_name], np.ndarray
+            ):
+                assert target_shape is not None and target_dtype is not None
+                np_array = ctx.global_vars[array_name]
+                # Evaluate the slice at compile time
+                slice_expr = compile(ast.Expression(value.slice), "", "eval")
+                # pylint: disable=eval-used
+                slice_val = eval(slice_expr, ctx.global_vars)
+                # Extract the slice
+                sliced_array = np_array[slice_val]
+                # Ensure it's still a numpy array (scalar case)
+                if not isinstance(sliced_array, np.ndarray):
+                    sliced_array = np.array([sliced_array], dtype=np_array.dtype)
+                assert (
+                    sliced_array.shape == target_shape
+                ), f"Slice shape mismatch, got {sliced_array.shape} and {target_shape}"
+                TypeInferer.visit_constant_tensor(
+                    ctx, value, sliced_array, dtype=target_dtype
+                )
+                value.dtype = target_dtype
+            else:
+                visit_stmt(ctx, value)
         else:
             visit_stmt(ctx, value)
         return value

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1410,5 +1410,35 @@ def test_constexpr_with_helper_functions():
     np.testing.assert_allclose(np_B, expected, rtol=1e-5)
 
 
+def test_constant_tensor_slice():
+    """Test loading a slice of a constant numpy array."""
+    np_A = np.array([[1, 2, 3, 4], [5, 6, 7, 8]], dtype=np.int32)
+
+    def kernel() -> int32[4]:
+        A: int32[4] = np_A[1]  # Load second row as constant
+        return A
+
+    s = allo.customize(kernel)
+    print(s.module)
+    mod = s.build()
+    result = mod()
+    np.testing.assert_array_equal(result, np_A[1])
+
+
+def test_constant_tensor_slice_2d():
+    """Test loading a 2D slice of a constant numpy 3D array."""
+    np_A = np.arange(24, dtype=np.float32).reshape(2, 3, 4)
+
+    def kernel() -> float32[3, 4]:
+        A: float32[3, 4] = np_A[1]  # Load second 2D slice
+        return A
+
+    s = allo.customize(kernel)
+    print(s.module)
+    mod = s.build()
+    result = mod()
+    np.testing.assert_allclose(result, np_A[1], rtol=1e-5)
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR adds support for accessing a slice of a numpy array as a const tensor.

### Examples ###
```python
def test_constant_tensor_slice_2d():
    """Test loading a 2D slice of a constant numpy 3D array."""
    np_A = np.arange(24, dtype=np.float32).reshape(2, 3, 4)

    def kernel() -> float32[3, 4]:
        A: float32[3, 4] = np_A[1]  # Load second 2D slice
        return A

    s = allo.customize(kernel)
    print(s.module)
    mod = s.build()
    result = mod()
    np.testing.assert_allclose(result, np_A[1], rtol=1e-5)
```
```mlir
module {
  memref.global "private" @A : memref<3x4xf32> = dense<[[1.200000e+01, 1.300000e+01, 1.400000e+01, 1.500000e+01], [1.600000e+01, 1.700000e+01, 1.800000e+01, 1.900000e+01], [2.000000e+01, 2.100000e+01, 2.200000e+01, 2.300000e+01]]>
  func.func @kernel() -> memref<3x4xf32> attributes {itypes = "", otypes = "_"} {
    %0 = memref.get_global @A : memref<3x4xf32>
    return %0 : memref<3x4xf32>
  }
}
```


## Checklist ##

Please make sure to review and check all of these items:
- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] All changes have test coverage (It would be good to provide ~2 different test cases to test the robustness of your code)
- [x] Pass the [formatting check](https://cornell-zhang.github.io/allo/developer/index.html#id1) locally
- [x] Code is well-documented
