### PR TITLE
[Dataflow] Update FEATHER interface and CI

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -48,6 +48,16 @@ jobs:
         export OMP_NUM_THREADS=128
         python3 -m pytest --ignore=tests/dataflow/aie tests/dataflow -v
         unset OMP_NUM_THREADS
+    - name: Accelerators
+      shell: bash
+      run: |
+        source activate allo
+        export PATH=/root/llvm-project/build/bin:${PATH}
+        export LLVM_BUILD_DIR=/root/llvm-project/build
+        export OMP_NUM_THREADS=128
+        python3 examples/feather/gemm.py
+        python3 examples/feather/convolution.py
+        unset OMP_NUM_THREADS
     - name: Tutorial
       shell: bash
       run: |


### PR DESCRIPTION
## Description ##
Update the FEATHER example to the latest dataflow interface and add CI coverage by running the FEATHER GEMM and convolution examples.

### Problems ###
FEATHER examples were using outdated dataflow kernel signatures and were not covered in CI, which led to runtime failures and regressions going unnoticed.

### Proposed Solutions ###
- Update FEATHER dataflow region/kernel argument wiring to match the current interface.
- Add a CI step to run `examples/feather/gemm.py` and `examples/feather/convolution.py` with the LLVM simulator.

### Examples ###
CI now runs:
- `python3 examples/feather/gemm.py`
- `python3 examples/feather/convolution.py`

## Checklist ##

Please make sure to review and check all of these items:
- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] All changes have test coverage (It would be good to provide ~2 different test cases to test the robustness of your code)
- [x] Pass the [formatting check](https://cornell-zhang.github.io/allo/developer/index.html#id1) locally
- [x] Code is well-documented
