### PR TITLE
[Testcase][Fix][AIE] Add data type guard for AIE GEMM test

### DIFF
--- a/tests/dataflow/aie/test_mapping_large_gemm.py
+++ b/tests/dataflow/aie/test_mapping_large_gemm.py
@@ -18,6 +18,10 @@ from allo.backend.aie import is_available
 )
 def test_pingpong_gemm(M, N, K, Pm, Pn, Pk, TyI, TyO):
     top, mapping_primitives = GEMM(M, N, K, Pm, Pn, Pk, TyI, TyO)
+    assert (TyI is int4 or TyI is int8) and TyO is int8, (
+        "This test only supports these data type combinations. "
+        "Please refer to examples/aie/gemm.py for gemm examples with other data types."
+    )
 
     if is_available():
         os.environ["ENABLE_AGGRESSIVE_PORT_UTILIZATION_PATCH"] = "1"


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
After moving GEMM to a library module, the large GEMM examples were migrated to `examples/aie/gemm.py`.
The test `tests/dataflow/aie/test_mapping_large_gemm.py` only supports a limited set of data types as a simple validity check. However, the test was not well written, which has caused confusion for some users. 

### Problems ###
if modify the data types to `i16`, it can lead to errors like:
```txt
Error: Invalid input file, byte number mismatch
```

### Proposed Solutions ###
Add a data type guard in the test and provide clear error message

## Checklist ##

Please make sure to review and check all of these items:
- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [ ] All changes have test coverage (It would be good to provide ~2 different test cases to test the robustness of your code)
- [x] Pass the [formatting check](https://cornell-zhang.github.io/allo/developer/index.html#id1) locally
- [ ] Code is well-documented
