### PR TITLE
[Backend][HLS] Explicitly specify frequency for Vitis HLS

### DIFF
--- a/allo/backend/vitis.py
+++ b/allo/backend/vitis.py
@@ -438,10 +438,11 @@ def generate_description_file(top, src_path, dst_path, frequency):
 
     # Generate HLS pre-tcl script to set clock
     # This bypasses v++ option parsing validation issues
+    assert frequency > 0, "Frequency must be positive"
     clock_period_ns = 1000.0 / frequency
     hls_tcl_path = dst_path.replace("description.json", "hls_pre.tcl")
     with open(hls_tcl_path, "w", encoding="utf-8") as tcl_file:
-        tcl_file.write(f"create_clock -period {clock_period_ns:.2f} -name default\n")
+        tcl_file.write(f"create_clock -period {clock_period_ns:.4f} -name default\n")
 
     # Generate HLS config file referencing the pre-tcl script
     hls_cfg_path = dst_path.replace("description.json", "hls.cfg")


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This is a follow-up of #277 that also changes the frequency in synthesis. Previously, we only attached frequency to the linking stage, which is the backend P&R. After this PR, users can see the HLS report also reports the right clock period.

### Examples ###
```python
s.build(target="vitis_hls", configs={"device": "u250", "frequency": 250})
```


## Checklist ##

Please make sure to review and check all of these items:
- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [ ] All changes have test coverage (It would be good to provide ~2 different test cases to test the robustness of your code)
- [x] Pass the [formatting check](https://cornell-zhang.github.io/allo/developer/index.html#id1) locally
- [ ] Code is well-documented
