### PR TITLE
[CI] Add weekly FPGA CI workflow for Feather GEMM test

### DIFF
--- a/.github/workflows/fpga_weekly.yml
+++ b/.github/workflows/fpga_weekly.yml
@@ -4,8 +4,8 @@
 name: "Allo FPGA Weekly Test"
 on:
   schedule:
-    # Saturday 8:00 PM ET = Sunday 1:00 AM UTC (during EST)
-    # Note: During EDT (daylight saving), this runs at Saturday 9:00 PM ET
+    # Run weekly at Sunday 1:00 AM UTC.
+    # This corresponds to Saturday 8:00 PM EST and Saturday 9:00 PM EDT.
     - cron: '0 1 * * 0'
   workflow_dispatch:  # Allow manual triggering from GitHub Actions UI
 
@@ -16,16 +16,19 @@ jobs:
       image: zzzdavid/allo-fpga:latest
       options: >-
         -v /opt/xilinx:/opt/xilinx
-        -v /opt/xilinx/platforms:/opt/xilinx/platforms
     env:
       XILINXD_LICENSE_FILE: 2100@en-license-05.coecis.cornell.edu
       VITIS: /opt/xilinx/Vitis/2023.2
       HLS_INCLUDE: /opt/xilinx/Vitis_HLS/2023.2/include
       XDEVICE: /opt/xilinx/platforms/xilinx_u280_gen3x16_xdma_1_202211_1/xilinx_u280_gen3x16_xdma_1_202211_1.xpfm
+      LANG: en_US.UTF-8
+      LC_ALL: en_US.UTF-8
     steps:
-    - name: Install git in container
+    - name: Install git and setup locale in container
       run: |
-        apt-get update && apt-get -y install git
+        apt-get update && apt-get -y install git locales
+        sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen
+        locale-gen en_US.UTF-8
         git config --global --add safe.directory "$GITHUB_WORKSPACE"
     - uses: actions/checkout@v4
       with:
@@ -44,4 +47,4 @@ jobs:
         source /opt/xilinx/xrt/setup.sh
         source $VITIS/settings64.sh
         cd examples/feather
-        python gemm.py
+        ALLO_FPGA_HW_MODE=1 python gemm.py

--- a/examples/feather/feather.py
+++ b/examples/feather/feather.py
@@ -148,7 +148,7 @@ def get_scheduled_feather(AW: int, AH: int, Ty: AlloType):
     # s.partition("top:weights", dim=2, factor=AW)
     # s.partition("top:weights", dim=3, factor=AH)
     # fully partition as a bypass for now
-    # we need to support paritioning same array multiple times
+    # we need to support partitioning same array multiple times
     s.partition("top:weights", dim=0)
     return s
 

--- a/examples/feather/gemm.py
+++ b/examples/feather/gemm.py
@@ -200,9 +200,12 @@ def test_FEATHER_GEMM():
     if hls.is_available("vitis_hls"):
         print("Running Vitis Synthesis and On-Board Execution...")
         s = get_scheduled_feather(AW, AH, Ty)
+        # Use "hw" mode for full hardware synthesis when ALLO_FPGA_HW_MODE is set,
+        # otherwise default to "hw_emu" (hardware emulation) for faster iteration.
+        hls_mode = "hw" if os.environ.get("ALLO_FPGA_HW_MODE") else "hw_emu"
         csyn_mod = s.build(
             target="vitis_hls",
-            mode="hw",
+            mode=hls_mode,
             project=f"feather_gemm_{M}_{N}_{K}_{AW}_{AH}_new.prj",
         )
         oActs_hls = np.zeros((N, 2 * M), dtype=np.int8)


### PR DESCRIPTION
## Summary
- Add a new GitHub Actions workflow (`fpga_weekly.yml`) that runs weekly on Saturdays at 8pm ET
- Runs on the `brg-zhang-xcel` self-hosted runner using the `zzzdavid/allo-fpga:latest` container
- Mounts Vitis 2023.2 toolchain from host and executes the Feather GEMM example (`examples/feather/gemm.py`)

## Test plan
- [ ] Verify the workflow file syntax is correct
- [ ] Confirm the cron schedule triggers at the expected time
- [ ] Validate the container can access mounted Vitis tools
- [ ] Ensure `python gemm.py` runs successfully on the FPGA

🤖 Generated with [Claude Code](https://claude.com/claude-code)