### PR TITLE
[builder] Fix const numpy array slicing

### DIFF
--- a/allo/ir/infer.py
+++ b/allo/ir/infer.py
@@ -648,29 +648,28 @@ class TypeInferer(ASTVisitor):
             )
             value.dtype = target_dtype
         elif isinstance(value, ast.Subscript) and isinstance(value.value, ast.Name):
-            # Handle slicing of a constant numpy array, e.g., np_array[i]
+            # Handle slicing of a constant numpy array, e.g., np_array[pid]
             array_name = value.value.id
             if array_name in ctx.global_vars and isinstance(
                 ctx.global_vars[array_name], np.ndarray
             ):
                 assert target_shape is not None and target_dtype is not None
                 np_array = ctx.global_vars[array_name]
-                # Evaluate the slice at compile time
+                # Evaluate slice with current context to validate shape
                 slice_expr = compile(ast.Expression(value.slice), "", "eval")
                 # pylint: disable=eval-used
                 slice_val = eval(slice_expr, ctx.global_vars)
-                # Extract the slice
                 sliced_array = np_array[slice_val]
-                # Ensure it's still a numpy array (scalar case)
                 if not isinstance(sliced_array, np.ndarray):
                     sliced_array = np.array([sliced_array], dtype=np_array.dtype)
                 assert (
                     sliced_array.shape == target_shape
                 ), f"Slice shape mismatch, got {sliced_array.shape} and {target_shape}"
-                TypeInferer.visit_constant_tensor(
-                    ctx, value, sliced_array, dtype=target_dtype
-                )
+                # Store source array for deferred evaluation in builder
+                # The slice AST is already available as value.slice
+                value.const_array_source = np_array
                 value.dtype = target_dtype
+                value.shape = target_shape
             else:
                 visit_stmt(ctx, value)
         else:


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR fixes const numpy array slicing with `pid` involved. Previously the sliced numpy array was only evaluated once, so the result was the same across different df.kernel. Now we move the slicing evaluation to the builder to make sure each grid point accesses the correct slice.

### Examples ###
```python
def test_const_arrays():
    Ty = int32
    np_array = np.array([[1, 2, 3, 4], [5, 6, 7, 8]], dtype=np.int32)

    @df.region()
    def top(A: Ty[2, 4]):
        @df.kernel(mapping=[2], args=[A])
        def producer(local_A: Ty[2, 4]):
            pid = allo.get_pid()
            const_array: Ty[4] = np_array[pid]
            local_A[pid, :] = const_array

    A = np.zeros((2, 4), dtype=np.int32)
    sim_mod = df.build(top, target="simulator")
    sim_mod(A)
    np.testing.assert_allclose(A, np_array)
    print("Dataflow Simulator Passed!")
```
Previous:
```
AssertionError: 
Not equal to tolerance rtol=1e-07, atol=0

Mismatched elements: 4 / 8 (50%)
Max absolute difference among violations: 4
Max relative difference among violations: 4.
 ACTUAL: array([[5, 6, 7, 8],
       [5, 6, 7, 8]], dtype=int32)
 DESIRED: array([[1, 2, 3, 4],
       [5, 6, 7, 8]], dtype=int32)
```

## Checklist ##

Please make sure to review and check all of these items:
- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] All changes have test coverage (It would be good to provide ~2 different test cases to test the robustness of your code)
- [x] Pass the [formatting check](https://cornell-zhang.github.io/allo/developer/index.html#id1) locally
- [x] Code is well-documented

cc: @Fangtangtang 