### PR TITLE
Add cosim mode for vitis_hls backend

### DIFF
--- a/.github/workflows/fpga_weekly.yml
+++ b/.github/workflows/fpga_weekly.yml
@@ -54,3 +54,10 @@ jobs:
         export PATH=/opt/xilinx/Vitis/2023.2/bin:/opt/xilinx/Vivado/2023.2/bin:/opt/xilinx/Vitis_HLS/2023.2/bin:$PATH
         cd examples/feather
         python gemm.py
+    - name: Run Dataflow Cosim Test
+      shell: bash
+      run: |
+        source activate allo
+        export LLVM_BUILD_DIR=/root/llvm-project/build
+        export PATH=/opt/xilinx/Vitis/2023.2/bin:/opt/xilinx/Vivado/2023.2/bin:/opt/xilinx/Vitis_HLS/2023.2/bin:$PATH
+        python -m pytest tests/dataflow/test_cosim.py -v

--- a/allo/backend/hls.py
+++ b/allo/backend/hls.py
@@ -20,6 +20,7 @@ from .._mlir.passmanager import PassManager
 from .config import DEFAULT_CONFIG, PART_NUMBER
 from .vitis import (
     codegen_host,
+    codegen_host_cosim,
     postprocess_hls_code,
     generate_description_file,
     write_tensor_to_file,
@@ -112,7 +113,7 @@ open_solution "solution1"
     out_str += "# Run HLS\n"
     if "csim" in mode or "sw_emu" in mode:
         out_str += "csim_design -O\n"
-    if "csyn" in mode or "debug" in mode:
+    if "csyn" in mode or "debug" in mode or "cosim" in mode:
         out_str += "csynth_design\n"
     if "cosim" in mode or "hw_emu" in mode:
         out_str += "cosim_design\n"
@@ -290,6 +291,7 @@ class HLSModule:
                 assert self.mode in {
                     "csim",
                     "csyn",
+                    "cosim",
                     "sw_emu",
                     "hw_emu",
                     "hw",
@@ -311,7 +313,18 @@ class HLSModule:
                 header, self.args = separate_header(self.hls_code, self.top_func_name)
                 with open(f"{project}/kernel.h", "w", encoding="utf-8") as outfile:
                     outfile.write(header)
-                self.hls_code = postprocess_hls_code(self.hls_code, self.top_func_name)
+                # For cosim mode, add depth to m_axi pragmas (required by cosim_design)
+                maxi_depths = None
+                if self.mode == "cosim":
+                    maxi_depths = []
+                    for _, shape in self.args:
+                        if len(shape) > 0:
+                            maxi_depths.append(int(np.prod([int(s) for s in shape])))
+                        else:
+                            maxi_depths.append(1)
+                self.hls_code = postprocess_hls_code(
+                    self.hls_code, self.top_func_name, maxi_depths=maxi_depths
+                )
 
                 # Generate HBM/DDR configuration file if hbm_mapping is provided
                 # This must be done AFTER postprocess_hls_code to get correct arg names
@@ -355,11 +368,19 @@ class HLSModule:
                         f"{project}/{cpp_file}", "w", encoding="utf-8"
                     ) as outfile:
                         outfile.write(new_code)
-                self.host_code = codegen_host(
-                    self.top_func_name,
-                    self.module,
-                    num_output_args=self.num_output_args,
-                )
+                if self.mode == "cosim":
+                    self.host_code = codegen_host_cosim(
+                        self.top_func_name,
+                        self.module,
+                        num_output_args=self.num_output_args,
+                        project_path=project,
+                    )
+                else:
+                    self.host_code = codegen_host(
+                        self.top_func_name,
+                        self.module,
+                        num_output_args=self.num_output_args,
+                    )
             elif self.platform == "catapult":
                 assert self.mode in {
                     "csim",
@@ -577,6 +598,55 @@ class HLSModule:
                 process.wait()
                 if process.returncode != 0:
                     raise RuntimeError("Failed to synthesize the design")
+                return
+            if self.mode == "cosim":
+                # Cosim: write input data, run vitis_hls with csynth+cosim, read output
+                func = find_func_in_module(self.module, self.top_func_name)
+                inputs, outputs = get_func_inputs_outputs(func)
+                assert len(args) == len(inputs) + len(
+                    outputs
+                ), f"Number of arguments mismatch, got {len(args)}, expected {len(inputs) + len(outputs)}"
+                for i, ((in_dtype, in_shape), arg) in enumerate(zip(inputs, args)):
+                    ele_bitwidth = get_bitwidth_from_type(in_dtype)
+                    assert (
+                        ele_bitwidth == 1 or ele_bitwidth % 8 == 0
+                    ), "can only handle bytes"
+                    with open(f"{self.project}/input{i}.data", "wb") as f:
+                        if np.isscalar(arg):
+                            arg = np.array(arg, dtype=np_supported_types[in_dtype])
+                        f.write(arg.tobytes())
+                cmd = f"cd {self.project}; vitis_hls -f run.tcl"
+                print(
+                    f"[{time.strftime('%H:%M:%S', time.gmtime())}] Begin C synthesis + co-simulation ..."
+                )
+                if shell:
+                    process = subprocess.Popen(cmd, shell=True)
+                else:
+                    process = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
+                process.wait()
+                if process.returncode != 0:
+                    raise RuntimeError("Failed to run co-simulation")
+                # Read output tensors from files
+                if len(outputs) > 0:
+                    if np.isscalar(args[-1]):
+                        raise RuntimeError("The output must be a tensor")
+                    arr = np.fromfile(
+                        f"{self.project}/output.data", dtype=args[-1].dtype
+                    )
+                    args[-1][:] = arr.reshape(args[-1].shape)
+                else:
+                    num_out = self.num_output_args if self.num_output_args > 0 else 1
+                    for idx in range(num_out):
+                        out_arg_idx = len(inputs) - num_out + idx
+                        if out_arg_idx < 0 or out_arg_idx >= len(args):
+                            continue
+                        out_arg = args[out_arg_idx]
+                        if np.isscalar(out_arg):
+                            continue
+                        arr = np.fromfile(
+                            f"{self.project}/output{idx}.data", dtype=out_arg.dtype
+                        )
+                        out_arg[:] = arr.reshape(out_arg.shape)
                 return
             # Use Makefile (sw_emu, hw_emu, hw)
             assert "XDEVICE" in os.environ, "Please set XDEVICE in your environment"

--- a/allo/backend/vitis.py
+++ b/allo/backend/vitis.py
@@ -117,24 +117,24 @@ def codegen_host_cosim(top, module, num_output_args=0, project_path=""):
         if len(in_shape) == 0:
             # scalar
             out_str += f"    uint8_t _raw_in{i}[{byte_num}];\n"
-            out_str += f"    {{\n"
+            out_str += "    {\n"
             out_str += f'        std::ifstream f((dir + "input{i}.data").c_str(), std::ios::binary);\n'
             out_str += (
                 f"        f.read(reinterpret_cast<char*>(_raw_in{i}), {byte_num});\n"
             )
-            out_str += f"    }}\n"
+            out_str += "    }\n"
             out_str += f"    {ctype} in{i} = *reinterpret_cast<{ctype}*>(_raw_in{i});\n"
             call_args.append(f"in{i}")
         else:
             out_str += f"    uint8_t buf_in{i}[{byte_num}];\n"
             if i in output_input_indices:
                 out_str += f"    std::memset(buf_in{i}, 0, {byte_num});\n"
-            out_str += f"    {{\n"
+            out_str += "    {\n"
             out_str += f'        std::ifstream f((dir + "input{i}.data").c_str(), std::ios::binary);\n'
             out_str += (
                 f"        f.read(reinterpret_cast<char*>(buf_in{i}), {byte_num});\n"
             )
-            out_str += f"    }}\n"
+            out_str += "    }\n"
             call_args.append(f"reinterpret_cast<{ctype}*>(buf_in{i})")
 
     # Allocate explicit output buffers
@@ -155,16 +155,16 @@ def codegen_host_cosim(top, module, num_output_args=0, project_path=""):
     # Write outputs
     if len(outputs) > 0:
         assert len(outputs) <= 1, "Only support one explicit output for now"
-        out_str += f'    std::ofstream ofile((dir + "output.data").c_str(), std::ios::binary);\n'
+        out_str += '    std::ofstream ofile((dir + "output.data").c_str(), std::ios::binary);\n'
         out_str += f"    ofile.write(reinterpret_cast<const char*>(buf_out0), {buffer_bytes[-1]});\n"
-        out_str += f"    ofile.close();\n"
+        out_str += "    ofile.close();\n"
     else:
         for idx, i in enumerate(sorted(output_input_indices)):
-            out_str += f"    {{\n"
+            out_str += "    {\n"
             out_str += f'        std::ofstream ofile((dir + "output{idx}.data").c_str(), std::ios::binary);\n'
             out_str += f"        ofile.write(reinterpret_cast<const char*>(buf_in{i}), {buffer_bytes[i]});\n"
-            out_str += f"        ofile.close();\n"
-            out_str += f"    }}\n"
+            out_str += "        ofile.close();\n"
+            out_str += "    }\n"
 
     out_str += "    return 0;\n}\n"
     return out_str

--- a/allo/backend/vitis.py
+++ b/allo/backend/vitis.py
@@ -68,6 +68,108 @@ ctype_map = {
 }
 
 
+def codegen_host_cosim(top, module, num_output_args=0, project_path=""):
+    """Generate a C++ testbench for Vitis HLS C/RTL co-simulation (cosim_design).
+
+    Unlike the OpenCL host (codegen_host), this testbench directly calls the
+    top function.  It reads binary input files, invokes the kernel, and writes
+    binary output files – matching the data format used by the Python __call__
+    method so that results can be read back seamlessly.
+
+    Uses absolute paths because cosim_design runs the testbench from a
+    subdirectory inside the HLS project (out.prj/solution1/sim/wrapc/).
+    """
+    func = find_func_in_module(module, top)
+    inputs, outputs = get_func_inputs_outputs(func)
+
+    # Ensure path ends with separator for concatenation
+    if project_path and not project_path.endswith("/"):
+        project_path += "/"
+
+    out_str = "#include <cstdio>\n#include <cstdlib>\n#include <cstring>\n"
+    out_str += "#include <fstream>\n#include <iostream>\n"
+    out_str += "#include <string>\n"
+    out_str += '#include "kernel.h"\n\n'
+    out_str += "int main() {\n"
+    out_str += f'    std::string dir = "{project_path}";\n'
+
+    # Determine which input indices are outputs
+    output_input_indices = set()
+    if len(outputs) == 0:
+        if num_output_args > 0:
+            output_input_indices = set(
+                range(len(inputs) - num_output_args, len(inputs))
+            )
+        else:
+            output_input_indices = {len(inputs) - 1}
+
+    # Allocate and read input buffers
+    buffer_bytes: list[int] = []
+    call_args = []
+    for i, (in_dtype, in_shape) in enumerate(inputs):
+        ele_bitwidth = get_bitwidth_from_type(in_dtype)
+        ele_bytes = 1 if ele_bitwidth == 1 else ele_bitwidth // 8
+        size = np.prod(in_shape) if len(in_shape) > 0 else 1
+        byte_num = size * ele_bytes
+        buffer_bytes.append(byte_num)
+        ctype = ctype_map.get(in_dtype, "char")
+
+        if len(in_shape) == 0:
+            # scalar
+            out_str += f"    uint8_t _raw_in{i}[{byte_num}];\n"
+            out_str += f"    {{\n"
+            out_str += f'        std::ifstream f((dir + "input{i}.data").c_str(), std::ios::binary);\n'
+            out_str += (
+                f"        f.read(reinterpret_cast<char*>(_raw_in{i}), {byte_num});\n"
+            )
+            out_str += f"    }}\n"
+            out_str += f"    {ctype} in{i} = *reinterpret_cast<{ctype}*>(_raw_in{i});\n"
+            call_args.append(f"in{i}")
+        else:
+            out_str += f"    uint8_t buf_in{i}[{byte_num}];\n"
+            if i in output_input_indices:
+                out_str += f"    std::memset(buf_in{i}, 0, {byte_num});\n"
+            out_str += f"    {{\n"
+            out_str += f'        std::ifstream f((dir + "input{i}.data").c_str(), std::ios::binary);\n'
+            out_str += (
+                f"        f.read(reinterpret_cast<char*>(buf_in{i}), {byte_num});\n"
+            )
+            out_str += f"    }}\n"
+            call_args.append(f"reinterpret_cast<{ctype}*>(buf_in{i})")
+
+    # Allocate explicit output buffers
+    for i, (out_dtype, out_shape) in enumerate(outputs):
+        ele_bitwidth = get_bitwidth_from_type(out_dtype)
+        ele_bytes = 1 if ele_bitwidth == 1 else ele_bitwidth // 8
+        size = np.prod(out_shape) if len(out_shape) > 0 else 1
+        byte_num = size * ele_bytes
+        buffer_bytes.append(byte_num)
+        ctype = ctype_map.get(out_dtype, "char")
+        out_str += f"    uint8_t buf_out{i}[{byte_num}];\n"
+        out_str += f"    std::memset(buf_out{i}, 0, {byte_num});\n"
+        call_args.append(f"reinterpret_cast<{ctype}*>(buf_out{i})")
+
+    # Call the top function
+    out_str += f"\n    {top}({', '.join(call_args)});\n\n"
+
+    # Write outputs
+    if len(outputs) > 0:
+        assert len(outputs) <= 1, "Only support one explicit output for now"
+        out_str += f'    std::ofstream ofile((dir + "output.data").c_str(), std::ios::binary);\n'
+        out_str += f"    ofile.write(reinterpret_cast<const char*>(buf_out0), {buffer_bytes[-1]});\n"
+        out_str += f"    ofile.close();\n"
+    else:
+        for idx, i in enumerate(sorted(output_input_indices)):
+            out_str += f"    {{\n"
+            out_str += f'        std::ofstream ofile((dir + "output{idx}.data").c_str(), std::ios::binary);\n'
+            out_str += f"        ofile.write(reinterpret_cast<const char*>(buf_in{i}), {buffer_bytes[i]});\n"
+            out_str += f"        ofile.close();\n"
+            out_str += f"    }}\n"
+
+    out_str += "    return 0;\n}\n"
+    return out_str
+
+
 def codegen_host(top, module, num_output_args=0):
     """Generate OpenCL host code for Vitis HLS.
 
@@ -376,7 +478,7 @@ def codegen_host(top, module, num_output_args=0):
     return out_str
 
 
-def postprocess_hls_code(hls_code, top=None, pragma=True):
+def postprocess_hls_code(hls_code, top=None, pragma=True, maxi_depths=None):
     out_str = ""
     func_decl = False
     has_endif = False
@@ -400,7 +502,10 @@ def postprocess_hls_code(hls_code, top=None, pragma=True):
             # Add extra interfaces
             if pragma:
                 for i, arg in enumerate(func_args):
-                    out_str += f"  #pragma HLS interface m_axi port={arg} offset=slave bundle=gmem{i}\n"
+                    depth_str = ""
+                    if maxi_depths is not None and i < len(maxi_depths):
+                        depth_str = f" depth={maxi_depths[i]}"
+                    out_str += f"  #pragma HLS interface m_axi port={arg} offset=slave bundle=gmem{i}{depth_str}\n"
         elif func_decl:
             if pragma:
                 dtype, var = line.strip().rsplit(" ", 1)

--- a/allo/dataflow.py
+++ b/allo/dataflow.py
@@ -511,8 +511,24 @@ def _build_top(s, stream_info, enable_layout=False):
             if isinstance(op, allo_d.StreamConstructOp):
                 stream_name = op.attributes["name"].value
                 stream_map[stream_name] = op
+
+        # Sort kernel calls so that stream producers come before consumers.
+        # Vitis HLS C simulation executes dataflow functions sequentially in
+        # declaration order; placing consumers (stream readers) after producers
+        # avoids "hls::stream read while empty" errors during cosim.
+        def _stream_order_key(func_op):
+            fname = func_op.attributes["sym_name"].value
+            dirs = {d for _, d in stream_info.get(fname, [])}
+            if dirs == {"out"}:
+                return 0  # pure producer  -> first
+            if dirs == {"in"}:
+                return 2  # pure consumer  -> last
+            return 1  # mixed / no streams -> middle
+
+        sorted_funcs = sorted(funcs, key=_stream_order_key)
+
         # add call functions
-        for i, func in enumerate(funcs):
+        for i, func in enumerate(sorted_funcs):
             func_name = func.attributes["sym_name"].value
             arg_lst = [new_top.arguments[idx] for idx in arg_mapping[func_name]]
             stream_lst = [
@@ -526,7 +542,7 @@ def _build_top(s, stream_info, enable_layout=False):
                     arg_lst + stream_lst,
                     ip=InsertionPoint.at_block_terminator(new_top.entry_block),
                 )
-                if i == len(funcs) - 1:
+                if i == len(sorted_funcs) - 1:
                     call_op.attributes["last"] = UnitAttr.get()
         new_top.attributes["dataflow"] = UnitAttr.get()
     s.top_func = new_top

--- a/tests/dataflow/test_cosim.py
+++ b/tests/dataflow/test_cosim.py
@@ -1,0 +1,81 @@
+# Copyright Allo authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Test for Vitis HLS C/RTL co-simulation (cosim) mode.
+# Related to: https://github.com/cornell-zhang/allo/issues/572
+
+import tempfile
+
+import allo
+from allo.ir.types import float32, Stream
+import allo.dataflow as df
+import allo.backend.hls as hls
+import allo.dsl as dsl
+import numpy as np
+
+# ---------------------------------------------------------------------------
+# Producer-consumer dataflow with a single stream channel.
+# Each stream is written by exactly one producer and read by exactly one
+# consumer, which satisfies the Vitis HLS dataflow constraint.
+# ---------------------------------------------------------------------------
+N = 8
+
+
+@df.region()
+def top(A: float32[N], B: float32[N], C: float32[N]):
+    pipe: Stream[float32, 16]
+
+    @df.kernel(mapping=[1], args=[A, B])
+    def producer(local_A: float32[N], local_B: float32[N]):
+        for i in range(N):
+            val: float32 = local_A[i] + local_B[i]
+            pipe.put(val)
+
+    @df.kernel(mapping=[1], args=[C])
+    def consumer(local_C: float32[N]):
+        for i in range(N):
+            local_C[i] = pipe.get()
+
+
+def test_producer_consumer_cosim():
+    A = np.random.rand(N).astype(np.float32)
+    B = np.random.rand(N).astype(np.float32)
+    C = np.zeros(N, dtype=np.float32)
+    C_golden = A + B
+
+    # Verify simulator
+    sim_mod = df.build(top, target="simulator")
+    sim_mod(A, B, C)
+    np.testing.assert_allclose(C, C_golden, atol=1e-5)
+    print("Simulator Passed!")
+
+    if hls.is_available("vitis_hls"):
+        # Test csyn to confirm synthesis works
+        with tempfile.TemporaryDirectory() as tmpdir:
+            mod = df.build(
+                top,
+                target="vitis_hls",
+                mode="csyn",
+                project=tmpdir,
+                wrap_io=False,
+            )
+            mod()
+            print("C Synthesis Passed!")
+
+        # Test cosim (C synthesis + C/RTL co-simulation)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            mod = df.build(
+                top,
+                target="vitis_hls",
+                mode="cosim",
+                project=tmpdir,
+                wrap_io=False,
+            )
+            C = np.zeros(N, dtype=np.float32)
+            mod(A, B, C)
+            np.testing.assert_allclose(C, C_golden, atol=1e-5)
+            print("Cosim Passed!")
+
+
+if __name__ == "__main__":
+    test_producer_consumer_cosim()


### PR DESCRIPTION
## Summary
- Adds `cosim` mode to the vitis_hls backend for C/RTL co-simulation via `cosim_design`, providing a lighter-weight alternative to the full `hw_emu` flow for verifying hardware correctness
- Fixes a bug in `codegen_tcl` where `csynth_design` was not emitted before `cosim_design` (the string `"cosim"` does not contain `"csyn"`)
- Generates a simple C++ testbench (`codegen_host_cosim`) that directly calls the top function instead of using OpenCL, with absolute file paths so output files are found when `cosim_design` runs from a subdirectory
- Adds required `depth=N` to `m_axi` interface pragmas for cosim compatibility
- Adds a producer-consumer dataflow cosim test and integrates it into the FPGA weekly CI

Fixes #572

## Test plan
- [x] Simulator test passes locally
- [x] C synthesis (`csyn`) passes locally  
- [x] C/RTL co-simulation (`cosim`) passes locally with `*** C/RTL co-simulation finished: PASS ***`
- [x] All lint checks pass (black, clang-format, pylint 10.00/10)
- [ ] FPGA weekly CI runs the new `test_cosim.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)