### PR TITLE
[Example] add example fused MHA systolic

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -84,3 +84,13 @@ jobs:
         python3 -m pip install torch==2.5.1
         python3 examples/torch/toy.py
         python3 examples/torch/mlp.py
+    - name: fused_MHA_systolic
+      shell: bash
+      run: |
+        source activate allo
+        export PATH=/root/llvm-project/build/bin:${PATH}
+        export LLVM_BUILD_DIR=/root/llvm-project/build
+        export OMP_NUM_THREADS=128
+        python3 examples/fused_MHA_systolic/test_systolic.py
+        unset OMP_NUM_THREADS
+

--- a/allo/backend/vitis.py
+++ b/allo/backend/vitis.py
@@ -90,8 +90,7 @@ def codegen_host(top, module, num_output_args=0):
     out_str = format_str(header, indent=0, strip=False)
     out_str += format_str(main_header, indent=0, strip=False)
     out_str += format_str("cl::Kernel krnl_" + top + ";\n", strip=False)
-    out_str += format_str(
-        """
+    out_str += format_str("""
         // Allocate Memory in Host Memory
         // When creating a buffer with user pointer (CL_MEM_USE_HOST_PTR), under the
         // hood user ptr is used if it is properly aligned. when not aligned, runtime had no choice
@@ -99,8 +98,7 @@ def codegen_host(top, module, num_output_args=0):
         // user wish to create buffer using CL_MEM_USE_HOST_PTR to align user buffer to page
         // boundary. It will ensure that user buffer is used when user create Buffer/Mem object with
         // CL_MEM_USE_HOST_PTR
-        """
-    )
+        """)
     # Generate in/out buffers
     buffer_bytes: list[int] = []
     for i, (in_dtype, in_shape) in enumerate(inputs):
@@ -158,8 +156,7 @@ def codegen_host(top, module, num_output_args=0):
         )
     out_str += "\n"
     # Generate OpenCL host code
-    out_str += format_str(
-        """
+    out_str += format_str("""
         // OPENCL HOST CODE AREA START
         // get_xil_devices() is a utility API which will find the xilinx
         // platforms and will return list of devices connected to Xilinx platform
@@ -180,8 +177,7 @@ def codegen_host(top, module, num_output_args=0):
                 std::cout << "Failed to program device[" << i << "] with xclbin file!\\n";
             } else {
                 std::cout << "Device[" << i << "]: program successful!\\n";
-        """
-    )
+        """)
     out_str += format_str(
         f'OCL_CHECK(err, krnl_{top} = cl::Kernel(program, "{top}", &err));', 12, False
     )
@@ -198,13 +194,11 @@ def codegen_host(top, module, num_output_args=0):
         strip=False,
         indent=0,
     )
-    out_str += format_str(
-        """
+    out_str += format_str("""
         // Allocate Buffer in Global Memory
         // Buffers are allocated using CL_MEM_USE_HOST_PTR for efficient memory and
         // Device-to-host communication
-        """
-    )
+        """)
     # Determine which input indices are actually outputs
     output_input_indices = set()
     if len(outputs) == 0:
@@ -262,15 +256,13 @@ def codegen_host(top, module, num_output_args=0):
             strip=False,
         )
     out_str += "\n"
-    out_str += format_str(
-        """
+    out_str += format_str("""
     cl::Event event;
     uint64_t nstimestart, nstimeend;
     std::cout << "|-------------------------+-------------------------|\\n"
               << "| Kernel                  |    Wall-Clock Time (ns) |\\n"
               << "|-------------------------+-------------------------|\\n";
-    """
-    )
+    """)
     out_str += "\n"
     # Launch kernel
     out_str += format_str("// Launch the Kernel", strip=False)
@@ -303,14 +295,12 @@ def codegen_host(top, module, num_output_args=0):
     out_str += format_str("// OpenCL Host Code Ends", strip=False)
     out_str += "\n"
     # Timing
-    out_str += format_str(
-        """
+    out_str += format_str("""
         // Get the execution time
         OCL_CHECK(err, err = event.getProfilingInfo<uint64_t>(CL_PROFILING_COMMAND_START, &nstimestart));
         OCL_CHECK(err, err = event.getProfilingInfo<uint64_t>(CL_PROFILING_COMMAND_END, &nstimeend));
         auto exe_time = nstimeend - nstimestart;
-        """
-    )
+        """)
     out_str += "\n"
     out_str += format_str(
         f'std::cout << "| " << std::left << std::setw(24) << "{top} "',

--- a/allo/backend/xls.py
+++ b/allo/backend/xls.py
@@ -272,8 +272,7 @@ def _gen_textproto(mems):
             write_resp = f"{name}_write_response"
 
         # Generate rewrite configuration (only difference is to_config kind)
-        lines.append(
-            f"""rewrites {{
+        lines.append(f"""rewrites {{
   from_config {{ kind: RAM_ABSTRACT depth: {depth} }}
   to_config {{ kind: {xls_ram_kind} depth: {depth} }}
   from_channels_logical_to_physical: {{ key: "abstract_read_req" value: "{read_req}" }}
@@ -282,8 +281,7 @@ def _gen_textproto(mems):
   from_channels_logical_to_physical: {{ key: "write_completion" value: "{write_resp}" }}
   to_name_prefix: "{name}_"
 }}
-"""
-        )
+""")
     return "\n".join(lines)
 
 

--- a/allo/harness/makefile_gen/makegen.py
+++ b/allo/harness/makefile_gen/makegen.py
@@ -15,8 +15,7 @@ config_file = 0
 
 
 def mk_copyright(target):
-    target.write(
-        """#
+    target.write("""#
 # Copyright 2019-2021 Xilinx, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -32,8 +31,7 @@ def mk_copyright(target):
 # limitations under the License.
 # makefile-generator v1.0.3
 #
-"""
-    )
+""")
     return
 
 

--- a/allo/harness/makefile_gen/makegen_us_alveo.py
+++ b/allo/harness/makefile_gen/makegen_us_alveo.py
@@ -11,8 +11,7 @@ config_file = 0
 
 
 def mk_copyright(target):
-    target.write(
-        """#
+    target.write("""#
 # Copyright 2019-2021 Xilinx, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,8 +27,7 @@ def mk_copyright(target):
 # limitations under the License.
 # makefile-generator v1.0.3
 #
-"""
-    )
+""")
     return
 
 

--- a/allo/harness/makefile_gen/makegen_versal_alveo.py
+++ b/allo/harness/makefile_gen/makegen_versal_alveo.py
@@ -11,8 +11,7 @@ config_file = 0
 
 
 def mk_copyright(target):
-    target.write(
-        """#
+    target.write("""#
 # Copyright 2019-2021 Xilinx, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,8 +27,7 @@ def mk_copyright(target):
 # limitations under the License.
 # makefile-generator v1.0.3
 #
-"""
-    )
+""")
     return
 
 

--- a/allo/harness/makefile_gen/makegen_versal_ps.py
+++ b/allo/harness/makefile_gen/makegen_versal_ps.py
@@ -11,8 +11,7 @@ config_file = 0
 
 
 def mk_copyright(target):
-    target.write(
-        """#
+    target.write("""#
 # Copyright 2019-2021 Xilinx, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,8 +27,7 @@ def mk_copyright(target):
 # limitations under the License.
 # makefile-generator v1.0.3
 #
-"""
-    )
+""")
     return
 
 

--- a/allo/harness/makefile_gen/makegen_zynqmp.py
+++ b/allo/harness/makefile_gen/makegen_zynqmp.py
@@ -11,8 +11,7 @@ config_file = 0
 
 
 def mk_copyright(target):
-    target.write(
-        """#
+    target.write("""#
 # Copyright 2019-2021 Xilinx, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,8 +27,7 @@ def mk_copyright(target):
 # limitations under the License.
 # makefile-generator v1.0.3
 #
-"""
-    )
+""")
     return
 
 

--- a/allo/library/gemv.py
+++ b/allo/library/gemv.py
@@ -9,9 +9,9 @@ from ..ir.types import int8
 from ..ir.utils import MockBuffer
 
 
-def pe_kernel[
-    L, D, P
-](x_in: "int8[P, D//P*L]", y_in: "int8[P, D//P*L]", o: "int8[P, D//P]", p: "index"):
+def pe_kernel[L, D, P](
+    x_in: "int8[P, D//P*L]", y_in: "int8[P, D//P*L]", o: "int8[P, D//P]", p: "index"
+):
     # """Finds the dot product of D//P vectors within given column of inputs."""
     for d in dsl.grid(D // P, name="l_loop"):
         total: int8 = 0
@@ -20,9 +20,11 @@ def pe_kernel[
         o[p, d] = total
 
 
-def int8xint8_mat_vec[
-    L, D, P
-](x_in: "Int(8 * P)[D // P, L]", y_in: "int8[L]", out: "int8[D]",):
+def int8xint8_mat_vec[L, D, P](
+    x_in: "Int(8 * P)[D // P, L]",
+    y_in: "int8[L]",
+    out: "int8[D]",
+):
     # """Gets the matrix vector multiply result."""
     x: int8[P, D // P * L]
     y_buff: int8[L]

--- a/allo/library/nn.py
+++ b/allo/library/nn.py
@@ -6,9 +6,9 @@ from .. import dsl
 from .systolic import systolic
 
 
-def linear2d[
-    TyX, TyW, TyO, M, N, K
-](X: "TyX[M, K]", W: "TyW[N, K]", b: "TyO[N]") -> "TyO[M, N]":
+def linear2d[TyX, TyW, TyO, M, N, K](
+    X: "TyX[M, K]", W: "TyW[N, K]", b: "TyO[N]"
+) -> "TyO[M, N]":
     # https://pytorch.org/docs/stable/generated/torch.nn.Linear.html
     Z: TyO[M, N]
     buf: TyO[N]
@@ -32,9 +32,9 @@ def schedule_linear2d(s):
     return s
 
 
-def linear3d[
-    TyX, TyW, TyO, B, L, D, M
-](X: "TyX[B, L, D]", W: "TyW[M, D]", bias: "TyO[M]") -> "TyO[B, L, M]":
+def linear3d[TyX, TyW, TyO, B, L, D, M](
+    X: "TyX[B, L, D]", W: "TyW[M, D]", bias: "TyO[M]"
+) -> "TyO[B, L, M]":
     # https://pytorch.org/docs/stable/generated/torch.nn.Linear.html
     Z: TyO[B, L, M]
     buf: TyO[M]
@@ -213,9 +213,9 @@ def residual_add[Ty, L, D](X1: "Ty[L, D]", X2: "Ty[L, D]") -> "Ty[L, D]":
     return Z
 
 
-def scaled_dot_product_attention[
-    Ty, H, L, D, M0, M1
-](Q: "Ty[L, D]", K: "Ty[L, D]", V: "Ty[L, D]") -> "Ty[L, D]":
+def scaled_dot_product_attention[Ty, H, L, D, M0, M1](
+    Q: "Ty[L, D]", K: "Ty[L, D]", V: "Ty[L, D]"
+) -> "Ty[L, D]":
     # softmax(QK^T/sqrt(D // H))
     Z: Ty[L, D]
 
@@ -246,9 +246,9 @@ def scaled_dot_product_attention[
     return Z
 
 
-def RoPE[
-    Ty, H, L, D
-](X: "Ty[L, D]", cos: "Ty[L, D // H // 2]", sin: "Ty[L, D // H // 2]") -> "Ty[L, D]":
+def RoPE[Ty, H, L, D](
+    X: "Ty[L, D]", cos: "Ty[L, D // H // 2]", sin: "Ty[L, D // H // 2]"
+) -> "Ty[L, D]":
     # Rotary Position Embedding
     # Reference: https://arxiv.org/abs/2104.09864
     X_rotary: Ty[L, D]
@@ -272,9 +272,9 @@ def RoPE[
     return X_rotary
 
 
-def modulate_fused[
-    Ty, L, D
-](X: "Ty[L,D]", scale: "Ty[D]", shift: "Ty[D]") -> "Ty[L, D]":
+def modulate_fused[Ty, L, D](
+    X: "Ty[L,D]", scale: "Ty[D]", shift: "Ty[D]"
+) -> "Ty[L, D]":
     Z: Ty[L, D]
     for i, j in dsl.grid(L, D, name="m_fused"):
         Z[i, j] = X[i, j] * (1 + scale[j]) + shift[j]
@@ -286,9 +286,7 @@ def schedule_modulate_fused(s):
     s.pipeline(lj)
 
 
-def conv2d[
-    Ty, B, Cin, Cout, H, W, Kh, Kw, Oh, Ow, Sh, Sw, Pd0, Pd1
-](
+def conv2d[Ty, B, Cin, Cout, H, W, Kh, Kw, Oh, Ow, Sh, Sw, Pd0, Pd1](
     inp: "Ty[B, Cin, H, W]", kernel: "Ty[Cout, Cin, Kh, Kw]", bias: "Ty[Cout]"
 ) -> "Ty[B, Cout, Oh, Ow]":
     # https://pytorch.org/docs/stable/generated/torch.nn.Conv2d.html
@@ -314,9 +312,9 @@ def schedule_conv2d(s):
     return s
 
 
-def maxpool2d[
-    Ty, B, C, H, W, K, Oh, Ow, S, Pd
-](inp: "Ty[B, C, H, W]",) -> "Ty[B, C, Oh, Ow]":
+def maxpool2d[Ty, B, C, H, W, K, Oh, Ow, S, Pd](
+    inp: "Ty[B, C, H, W]",
+) -> "Ty[B, C, Oh, Ow]":
     # https://pytorch.org/docs/stable/generated/torch.nn.MaxPool2d.html
     Z: Ty[B, C, Oh, Ow]
     for batch, c, oh, ow in dsl.grid(B, C, Oh, Ow):
@@ -337,9 +335,9 @@ def schedule_maxpool2d(s):
     return s
 
 
-def avgpool2d[
-    Ty, B, C, H, W, K, Oh, Ow, S, Pd
-](inp: "Ty[B, C, H, W]",) -> "Ty[B, C, Oh, Ow]":
+def avgpool2d[Ty, B, C, H, W, K, Oh, Ow, S, Pd](
+    inp: "Ty[B, C, H, W]",
+) -> "Ty[B, C, Oh, Ow]":
     # https://pytorch.org/docs/stable/generated/torch.nn.AvgPool2d.html
     Z: Ty[B, C, Oh, Ow]
     for batch, c, oh, ow in dsl.grid(B, C, Oh, Ow):
@@ -359,9 +357,7 @@ def schedule_avgpool2d(s):
     return s
 
 
-def batchnorm2d[
-    Ty, B, C, H, W
-](
+def batchnorm2d[Ty, B, C, H, W](
     X: "Ty[B, C, H, W]",
     gamma: "Ty[C]",
     beta: "Ty[C]",
@@ -384,9 +380,7 @@ def schedule_batchnorm2d(s):
     return s
 
 
-def batchnorm1d_2d[
-    Ty, B, C
-](
+def batchnorm1d_2d[Ty, B, C](
     X: "Ty[B, C]", gamma: "Ty[C]", beta: "Ty[C]", eps: "Ty", mean: "Ty[C]", var: "Ty[C]"
 ) -> "Ty[B, C]":
     # https://docs.pytorch.org/docs/stable/generated/torch.nn.BatchNorm1d.html
@@ -401,9 +395,7 @@ def schedule_batchnorm1d_2d(s):
     return s
 
 
-def batchnorm1d_3d[
-    Ty, B, C, L
-](
+def batchnorm1d_3d[Ty, B, C, L](
     X: "Ty[B, C, L]",
     gamma: "Ty[C]",
     beta: "Ty[C]",
@@ -440,9 +432,9 @@ def schedule_repeat_batch3d(s):
     return s
 
 
-def concat[
-    Ty, B, N1, N2, C
-](X1: "Ty[B, N1, C]", X2: "Ty[B, N2, C]") -> "Ty[B, N1+N2, C]":
+def concat[Ty, B, N1, N2, C](
+    X1: "Ty[B, N1, C]", X2: "Ty[B, N2, C]"
+) -> "Ty[B, N1+N2, C]":
     Y: Ty[B, N1 + N2, C]
     for b, n, c in dsl.grid(B, N1, C):
         Y[b, n, c] = X1[b, n, c]

--- a/allo/library/systolic.py
+++ b/allo/library/systolic.py
@@ -27,9 +27,7 @@ from .._mlir.dialects.affine import AffineExpr
 import re
 
 
-def PE_kernel[
-    TyA, TyB, TyC, K: int32, Mt: int32, Nt: int32
-](
+def PE_kernel[TyA, TyB, TyC, K: int32, Mt: int32, Nt: int32](
     A_in: "TyA[K]",
     B_in: "TyB[K]",
     A_out: "TyA[K]",
@@ -49,9 +47,7 @@ def PE_kernel[
     C[i, j] = v
 
 
-def PE_kernel_packed_int4xint8[
-    K: int32, Mt: int32, Nt: int32
-](
+def PE_kernel_packed_int4xint8[K: int32, Mt: int32, Nt: int32](
     A_in: "int8[K]",  # not bit-packed
     B_in: "int8[K]",  # bit-packed, each element is 4 bits
     A_out: "int8[K]",
@@ -88,9 +84,7 @@ def PE_kernel_packed_int4xint8[
     C[i, j] = v
 
 
-def PE_kernel_packed_int8xint8[
-    K: int32, Mt: int32, Nt: int32
-](
+def PE_kernel_packed_int8xint8[K: int32, Mt: int32, Nt: int32](
     A_in: "int8[K]",  # not bit-packed
     B_in: "int16[K]",  # bit-packed, each element is 8 bits
     A_out: "int8[K]",
@@ -128,9 +122,9 @@ def PE_kernel_packed_int8xint8[
     C[i, j] = v
 
 
-def systolic_tile[
-    TyA, TyB, TyC, K: int32, Mt: int32, Nt: int32
-](A: "TyA[Mt, K]", B: "TyB[K, Nt]", C: "TyC[Mt, Nt]"):
+def systolic_tile[TyA, TyB, TyC, K: int32, Mt: int32, Nt: int32](
+    A: "TyA[Mt, K]", B: "TyB[K, Nt]", C: "TyC[Mt, Nt]"
+):
     A_fifo: TyA[Mt, Nt + 1, K]
     B_fifo: TyB[Nt, Mt + 1, K]
     A_drain: TyA[Mt]
@@ -159,9 +153,9 @@ def systolic_tile[
             B_drain[n] = B_fifo[n, Mt, k]
 
 
-def systolic[
-    TyA, TyB, TyC, M: int32, K: int32, N: int32, Mt: int32, Nt: int32
-](A: "TyA[M, K]", B: "TyB[K, N]", C: "TyC[M, N]"):
+def systolic[TyA, TyB, TyC, M: int32, K: int32, N: int32, Mt: int32, Nt: int32](
+    A: "TyA[M, K]", B: "TyB[K, N]", C: "TyC[M, N]"
+):
     local_A: TyA[Mt, K]
     local_B: TyB[K, Nt]
     local_C: TyC[Mt, Nt]
@@ -245,7 +239,9 @@ def packed_int8xint8_systolic[
     Mt: int32,
     Nt: int32,
     P: int32,  # packing factor
-](A: "Int(8 * P)[M // P, K]", B: "Int(8 * P)[K, N // P]", C: "Int(8 * P)[M // P, N]"):
+](
+    A: "Int(8 * P)[M // P, K]", B: "Int(8 * P)[K, N // P]", C: "Int(8 * P)[M // P, N]"
+):
     local_A: int8[Mt, K]
     local_B: int16[K, Nt // 2]
     local_C: int32[Mt, Nt // 2]

--- a/examples/aie/attention.py
+++ b/examples/aie/attention.py
@@ -10,7 +10,6 @@ import numpy as np
 from ml_dtypes import bfloat16 as np_bfloat16
 from allo.library.aie.modules.flash_attn import FA
 
-
 # ################################################################
 # Flash Attention
 # ################################################################

--- a/examples/feather/feather.py
+++ b/examples/feather/feather.py
@@ -21,7 +21,6 @@ import allo.dataflow as df
 import allo.backend.hls as hls
 import numpy as np
 
-
 PS = 0  # Pass
 AR = 1  # Add Right
 AL = 2  # Add Left

--- a/examples/fused_MHA_systolic/__init__.py
+++ b/examples/fused_MHA_systolic/__init__.py
@@ -1,0 +1,2 @@
+# Copyright Allo authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/examples/fused_MHA_systolic/fused_MHA_systolic.py
+++ b/examples/fused_MHA_systolic/fused_MHA_systolic.py
@@ -7,14 +7,15 @@ from allo.ir.types import float32, Int, Stream
 import allo.dataflow as df
 import allo.backend.hls as hls
 
-int8  = Int(8)
+int8 = Int(8)
 int32 = Int(32)
+
 
 def get_systolic_top(
     BATCH_SIZE: int,
-    CONTEXT_LENGTH: int, 
-    HIDDEN_SIZE: int, 
-    NUM_HEADS: int, 
+    CONTEXT_LENGTH: int,
+    HIDDEN_SIZE: int,
+    NUM_HEADS: int,
     BLOCK_T: int,
 ):
     HEAD_DIM = HIDDEN_SIZE // NUM_HEADS
@@ -25,33 +26,32 @@ def get_systolic_top(
     P0 = BLOCK_T + 2
     P1 = BLOCK_T + 2
 
-    D_SQRT  = float(HEAD_DIM ** 0.5)
-    D       = 1.0 / D_SQRT
+    D_SQRT = float(HEAD_DIM**0.5)
+    D = 1.0 / D_SQRT
     THREE_H = 3 * HIDDEN_SIZE
-    IN_ELEMS  = BATCH_SIZE * CONTEXT_LENGTH * THREE_H
+    IN_ELEMS = BATCH_SIZE * CONTEXT_LENGTH * THREE_H
     OUT_ELEMS = BATCH_SIZE * CONTEXT_LENGTH * NUM_HEADS * HEAD_DIM
 
     @df.region()
     def top(
-        input_mem:  float32[IN_ELEMS],
+        input_mem: float32[IN_ELEMS],
         output_mem: float32[OUT_ELEMS],
     ):
-        fifo_Q:  Stream[int8[HEAD_DIM],    256][P0, P1]
-        fifo_K:  Stream[int8[HEAD_DIM],    256][P0, P1]
-        fifo_V:  Stream[float32[HEAD_DIM], 256][P0, P1]
-        fifo_dQ: Stream[float32,            32][P0, P1]
-        fifo_dK: Stream[float32,            32][P0, P1]
-        fifo_m:  Stream[float32,            32][P0, P1]
-        fifo_d:  Stream[float32,            32][P0, P1]
-        fifo_o:  Stream[float32[HEAD_DIM], 256][P0, P1]
+        fifo_Q: Stream[int8[HEAD_DIM], 256][P0, P1]
+        fifo_K: Stream[int8[HEAD_DIM], 256][P0, P1]
+        fifo_V: Stream[float32[HEAD_DIM], 256][P0, P1]
+        fifo_dQ: Stream[float32, 32][P0, P1]
+        fifo_dK: Stream[float32, 32][P0, P1]
+        fifo_m: Stream[float32, 32][P0, P1]
+        fifo_d: Stream[float32, 32][P0, P1]
+        fifo_o: Stream[float32[HEAD_DIM], 256][P0, P1]
 
-        fifo_in_Q:  Stream[int8[HEAD_DIM],    256][P0 - 2]
-        fifo_in_dQ: Stream[float32,            32][P0 - 2]
-        fifo_in_K:  Stream[int8[HEAD_DIM],    256][P1 - 2]
-        fifo_in_dK: Stream[float32,            32][P1 - 2]
-        fifo_in_V:  Stream[float32[HEAD_DIM], 256][P1 - 2]
-        fifo_out:   Stream[float32[HEAD_DIM], 256][P0 - 2]
-
+        fifo_in_Q: Stream[int8[HEAD_DIM], 256][P0 - 2]
+        fifo_in_dQ: Stream[float32, 32][P0 - 2]
+        fifo_in_K: Stream[int8[HEAD_DIM], 256][P1 - 2]
+        fifo_in_dK: Stream[float32, 32][P1 - 2]
+        fifo_in_V: Stream[float32[HEAD_DIM], 256][P1 - 2]
+        fifo_out: Stream[float32[HEAD_DIM], 256][P0 - 2]
 
         @df.kernel(mapping=[1], args=[input_mem])
         def load(input_d: float32[IN_ELEMS]):
@@ -62,10 +62,13 @@ def get_systolic_top(
                 k_mean: float32[HEAD_DIM] = 0
                 for t in range(CONTEXT_LENGTH):
                     for jj in range(HEAD_DIM):
-                        k_idx = (b * (CONTEXT_LENGTH * THREE_H)
-                                + t * THREE_H
-                                + 1 * HIDDEN_SIZE
-                                + h * HEAD_DIM + jj)
+                        k_idx = (
+                            b * (CONTEXT_LENGTH * THREE_H)
+                            + t * THREE_H
+                            + 1 * HIDDEN_SIZE
+                            + h * HEAD_DIM
+                            + jj
+                        )
                         k_mean[jj] += input_d[k_idx]
                 for jj in range(HEAD_DIM):
                     # annotation drives implicit float16/int division
@@ -76,15 +79,18 @@ def get_systolic_top(
 
                     # ── Q: fold 1/√d, per-vector INT8 quantization ────────
                     for i in range(BLOCK_T):
-                        q_scaled:  float32[HEAD_DIM] = 0
+                        q_scaled: float32[HEAD_DIM] = 0
                         q_abs_max: float32 = 1e-8
                         t_q = tr + i
                         for jj in range(HEAD_DIM):
-                            q_idx = (b * (CONTEXT_LENGTH * THREE_H)
-                                    + t_q * THREE_H
-                                    + 0 * HIDDEN_SIZE
-                                    + h * HEAD_DIM + jj)
-                            d_f16: float32 = D          # typed literal
+                            q_idx = (
+                                b * (CONTEXT_LENGTH * THREE_H)
+                                + t_q * THREE_H
+                                + 0 * HIDDEN_SIZE
+                                + h * HEAD_DIM
+                                + jj
+                            )
+                            d_f16: float32 = D  # typed literal
                             val: float32 = input_d[q_idx] * d_f16
                             q_scaled[jj] = val
                             neg_val: float32 = -val
@@ -117,16 +123,19 @@ def get_systolic_top(
                     # ── K: smooth + per-block INT8 quantization ───────────
                     for tc_b in range(NUM_TC):
 
-                        k_block:   float32[BLOCK_T, HEAD_DIM] = 0
+                        k_block: float32[BLOCK_T, HEAD_DIM] = 0
                         k_abs_max: float32 = 1e-8
 
                         for i in range(BLOCK_T):
                             t_k = tc_b * BLOCK_T + i
                             for jj in range(HEAD_DIM):
-                                k_idx = (b * (CONTEXT_LENGTH * THREE_H)
-                                        + t_k * THREE_H
-                                        + 1 * HIDDEN_SIZE
-                                        + h * HEAD_DIM + jj)
+                                k_idx = (
+                                    b * (CONTEXT_LENGTH * THREE_H)
+                                    + t_k * THREE_H
+                                    + 1 * HIDDEN_SIZE
+                                    + h * HEAD_DIM
+                                    + jj
+                                )
                                 val: float32 = input_d[k_idx] - k_mean[jj]
                                 k_block[i, jj] = val
                                 neg_val: float32 = -val
@@ -155,10 +164,13 @@ def get_systolic_top(
                             v_vec: float32[HEAD_DIM] = 0
                             t_k = tc_b * BLOCK_T + i
                             for jj in range(HEAD_DIM):
-                                v_idx = (b * (CONTEXT_LENGTH * THREE_H)
-                                        + t_k * THREE_H
-                                        + 2 * HIDDEN_SIZE
-                                        + h * HEAD_DIM + jj)
+                                v_idx = (
+                                    b * (CONTEXT_LENGTH * THREE_H)
+                                    + t_k * THREE_H
+                                    + 2 * HIDDEN_SIZE
+                                    + h * HEAD_DIM
+                                    + jj
+                                )
                                 v_vec[jj] = input_d[v_idx]
 
                             if tc_b == 0:
@@ -187,7 +199,7 @@ def get_systolic_top(
                         dK: float32 = fifo_in_dK[j - 1].get()
                         fifo_dK[i + 1, j].put(dK)
                         for k in range(BLOCK_T):
-                            kv: int8[HEAD_DIM]    = fifo_in_K[j - 1].get()
+                            kv: int8[HEAD_DIM] = fifo_in_K[j - 1].get()
                             vv: float32[HEAD_DIM] = fifo_in_V[j - 1].get()
                             fifo_K[i + 1, j].put(kv)
                             fifo_V[i + 1, j].put(vv)
@@ -196,11 +208,11 @@ def get_systolic_top(
                 for b, h in allo.grid(BATCH_SIZE, NUM_HEADS):
                     for tr in range(0, CONTEXT_LENGTH, BLOCK_T):
                         q_int8: int8[HEAD_DIM] = fifo_in_Q[i - 1].get()
-                        dQ:     float32        = fifo_in_dQ[i - 1].get()
-                        fifo_Q[i,  j + 1].put(q_int8)
+                        dQ: float32 = fifo_in_dQ[i - 1].get()
+                        fifo_Q[i, j + 1].put(q_int8)
                         fifo_dQ[i, j + 1].put(dQ)
-                        m_init: float32           = -1e4    # float16 safe large neg
-                        d_init: float32           = 0.0
+                        m_init: float32 = -1e4  # float16 safe large neg
+                        d_init: float32 = 0.0
                         o_init: float32[HEAD_DIM] = 0
                         fifo_m[i, j + 1].put(m_init)
                         fifo_d[i, j + 1].put(d_init)
@@ -209,48 +221,48 @@ def get_systolic_top(
             with allo.meta_elif(i == P0 - 1):
                 for b, h in allo.grid(BATCH_SIZE, NUM_HEADS):
                     for tr in range(0, CONTEXT_LENGTH, BLOCK_T):
-                        _dk: float32          = fifo_dK[i, j].get()
+                        _dk: float32 = fifo_dK[i, j].get()
                         for k in range(BLOCK_T):
-                            _k: int8[HEAD_DIM]    = fifo_K[i, j].get()
+                            _k: int8[HEAD_DIM] = fifo_K[i, j].get()
                             _v: float32[HEAD_DIM] = fifo_V[i, j].get()
 
             with allo.meta_elif(j == P1 - 1):
                 for b, h in allo.grid(BATCH_SIZE, NUM_HEADS):
                     for tr in range(0, CONTEXT_LENGTH, BLOCK_T):
-                        _q:  int8[HEAD_DIM]        = fifo_Q[i,  j].get()
-                        _dq: float32               = fifo_dQ[i, j].get()
-                        _m:  float32               = fifo_m[i,  j].get()
-                        _d:  float32               = fifo_d[i,  j].get()
-                        o_final: float32[HEAD_DIM] = fifo_o[i,  j].get()
+                        _q: int8[HEAD_DIM] = fifo_Q[i, j].get()
+                        _dq: float32 = fifo_dQ[i, j].get()
+                        _m: float32 = fifo_m[i, j].get()
+                        _d: float32 = fifo_d[i, j].get()
+                        o_final: float32[HEAD_DIM] = fifo_o[i, j].get()
                         fifo_out[i - 1].put(o_final)
 
             with allo.meta_else():
                 for b, h in allo.grid(BATCH_SIZE, NUM_HEADS):
                     for tr in range(0, CONTEXT_LENGTH, BLOCK_T):
 
-                        q_int8: int8[HEAD_DIM]    = fifo_Q[i,  j].get()
-                        dQ:     float32           = fifo_dQ[i, j].get()
-                        m_cur:  float32           = fifo_m[i,  j].get()
-                        d_cur:  float32           = fifo_d[i,  j].get()
-                        o_cur:  float32[HEAD_DIM] = fifo_o[i,  j].get()
+                        q_int8: int8[HEAD_DIM] = fifo_Q[i, j].get()
+                        dQ: float32 = fifo_dQ[i, j].get()
+                        m_cur: float32 = fifo_m[i, j].get()
+                        d_cur: float32 = fifo_d[i, j].get()
+                        o_cur: float32[HEAD_DIM] = fifo_o[i, j].get()
 
                         dK: float32 = fifo_dK[i, j].get()
                         fifo_dK[i + 1, j].put(dK)
 
                         for k in range(BLOCK_T):
-                            k_int8: int8[HEAD_DIM]    = fifo_K[i, j].get()
-                            vv:     float32[HEAD_DIM] = fifo_V[i, j].get()
+                            k_int8: int8[HEAD_DIM] = fifo_K[i, j].get()
+                            vv: float32[HEAD_DIM] = fifo_V[i, j].get()
 
                             # ── INT8 × INT8 → INT32 accumulator ───────────
                             # Declare int32 intermediates — Allo auto-widens int8
                             x_int32: int32 = 0
                             for dd in range(HEAD_DIM):
-                                qi: int32 = q_int8[dd]   # int8 → int32 via annotation
-                                ki: int32 = k_int8[dd]   # int8 → int32 via annotation
+                                qi: int32 = q_int8[dd]  # int8 → int32 via annotation
+                                ki: int32 = k_int8[dd]  # int8 → int32 via annotation
                                 x_int32 += qi * ki
 
                             # ── Dequantize INT32 → float32 via annotation ──
-                            x_f32: float32 = x_int32     # int32 → float32 via annotation
+                            x_f32: float32 = x_int32  # int32 → float32 via annotation
                             x: float32 = x_f32 * dQ * dK
 
                             # ── Online softmax — all float32 ───────────────
@@ -260,8 +272,8 @@ def get_systolic_top(
                             ep: float32 = allo.exp(m_cur - m_new)
                             ex: float32 = allo.exp(x - m_new)
                             d_new: float32 = d_cur * ep + ex
-                            al: float32    = d_cur * ep / d_new
-                            be: float32    = ex / d_new
+                            al: float32 = d_cur * ep / d_new
+                            be: float32 = ex / d_new
 
                             # ── P·V: float32 × float32 ─────────────────────
                             o_new: float32[HEAD_DIM] = 0
@@ -276,12 +288,11 @@ def get_systolic_top(
                             for dd in range(HEAD_DIM):
                                 o_cur[dd] = o_new[dd]
 
-                        fifo_Q[i,  j + 1].put(q_int8)
+                        fifo_Q[i, j + 1].put(q_int8)
                         fifo_dQ[i, j + 1].put(dQ)
-                        fifo_m[i,  j + 1].put(m_cur)
-                        fifo_d[i,  j + 1].put(d_cur)
-                        fifo_o[i,  j + 1].put(o_cur)
-
+                        fifo_m[i, j + 1].put(m_cur)
+                        fifo_d[i, j + 1].put(d_cur)
+                        fifo_o[i, j + 1].put(o_cur)
 
         @df.kernel(mapping=[1], args=[output_mem])
         def store(global_mem: float32[OUT_ELEMS]):
@@ -291,21 +302,30 @@ def get_systolic_top(
                         if i == 0:
                             o0: float32[HEAD_DIM] = fifo_out[0].get()
                             for jj in range(HEAD_DIM):
-                                idx = (((b * CONTEXT_LENGTH + (tr + i)) * NUM_HEADS + h) * HEAD_DIM + jj)
+                                idx = (
+                                    (b * CONTEXT_LENGTH + (tr + i)) * NUM_HEADS + h
+                                ) * HEAD_DIM + jj
                                 global_mem[idx] = o0[jj]
                         elif i == 1:
                             o1: float32[HEAD_DIM] = fifo_out[1].get()
                             for jj in range(HEAD_DIM):
-                                idx = (((b * CONTEXT_LENGTH + (tr + i)) * NUM_HEADS + h) * HEAD_DIM + jj)
+                                idx = (
+                                    (b * CONTEXT_LENGTH + (tr + i)) * NUM_HEADS + h
+                                ) * HEAD_DIM + jj
                                 global_mem[idx] = o1[jj]
                         elif i == 2:
                             o2: float32[HEAD_DIM] = fifo_out[2].get()
                             for jj in range(HEAD_DIM):
-                                idx = (((b * CONTEXT_LENGTH + (tr + i)) * NUM_HEADS + h) * HEAD_DIM + jj)
+                                idx = (
+                                    (b * CONTEXT_LENGTH + (tr + i)) * NUM_HEADS + h
+                                ) * HEAD_DIM + jj
                                 global_mem[idx] = o2[jj]
                         elif i == 3:
                             o3: float32[HEAD_DIM] = fifo_out[3].get()
                             for jj in range(HEAD_DIM):
-                                idx = (((b * CONTEXT_LENGTH + (tr + i)) * NUM_HEADS + h) * HEAD_DIM + jj)
+                                idx = (
+                                    (b * CONTEXT_LENGTH + (tr + i)) * NUM_HEADS + h
+                                ) * HEAD_DIM + jj
                                 global_mem[idx] = o3[jj]
+
     return top

--- a/examples/fused_MHA_systolic/fused_MHA_systolic.py
+++ b/examples/fused_MHA_systolic/fused_MHA_systolic.py
@@ -1,0 +1,311 @@
+# Copyright Allo authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import allo
+import numpy as np
+from allo.ir.types import float32, Int, Stream
+import allo.dataflow as df
+import allo.backend.hls as hls
+
+int8  = Int(8)
+int32 = Int(32)
+
+def get_systolic_top(
+    BATCH_SIZE: int,
+    CONTEXT_LENGTH: int, 
+    HIDDEN_SIZE: int, 
+    NUM_HEADS: int, 
+    BLOCK_T: int,
+):
+    HEAD_DIM = HIDDEN_SIZE // NUM_HEADS
+    NUM_TC = CONTEXT_LENGTH // BLOCK_T
+
+    assert NUM_TC == BLOCK_T, "This design requires NUM_TC == BLOCK_T"
+
+    P0 = BLOCK_T + 2
+    P1 = BLOCK_T + 2
+
+    D_SQRT  = float(HEAD_DIM ** 0.5)
+    D       = 1.0 / D_SQRT
+    THREE_H = 3 * HIDDEN_SIZE
+    IN_ELEMS  = BATCH_SIZE * CONTEXT_LENGTH * THREE_H
+    OUT_ELEMS = BATCH_SIZE * CONTEXT_LENGTH * NUM_HEADS * HEAD_DIM
+
+    @df.region()
+    def top(
+        input_mem:  float32[IN_ELEMS],
+        output_mem: float32[OUT_ELEMS],
+    ):
+        fifo_Q:  Stream[int8[HEAD_DIM],    256][P0, P1]
+        fifo_K:  Stream[int8[HEAD_DIM],    256][P0, P1]
+        fifo_V:  Stream[float32[HEAD_DIM], 256][P0, P1]
+        fifo_dQ: Stream[float32,            32][P0, P1]
+        fifo_dK: Stream[float32,            32][P0, P1]
+        fifo_m:  Stream[float32,            32][P0, P1]
+        fifo_d:  Stream[float32,            32][P0, P1]
+        fifo_o:  Stream[float32[HEAD_DIM], 256][P0, P1]
+
+        fifo_in_Q:  Stream[int8[HEAD_DIM],    256][P0 - 2]
+        fifo_in_dQ: Stream[float32,            32][P0 - 2]
+        fifo_in_K:  Stream[int8[HEAD_DIM],    256][P1 - 2]
+        fifo_in_dK: Stream[float32,            32][P1 - 2]
+        fifo_in_V:  Stream[float32[HEAD_DIM], 256][P1 - 2]
+        fifo_out:   Stream[float32[HEAD_DIM], 256][P0 - 2]
+
+
+        @df.kernel(mapping=[1], args=[input_mem])
+        def load(input_d: float32[IN_ELEMS]):
+
+            for b, h in allo.grid(BATCH_SIZE, NUM_HEADS):
+
+                # ── Pre-pass: compute mean(K) ──────────────────────────────
+                k_mean: float32[HEAD_DIM] = 0
+                for t in range(CONTEXT_LENGTH):
+                    for jj in range(HEAD_DIM):
+                        k_idx = (b * (CONTEXT_LENGTH * THREE_H)
+                                + t * THREE_H
+                                + 1 * HIDDEN_SIZE
+                                + h * HEAD_DIM + jj)
+                        k_mean[jj] += input_d[k_idx]
+                for jj in range(HEAD_DIM):
+                    # annotation drives implicit float16/int division
+                    inv_ctx: float32 = 1.0 / CONTEXT_LENGTH
+                    k_mean[jj] = k_mean[jj] * inv_ctx
+
+                for tr in range(0, CONTEXT_LENGTH, BLOCK_T):
+
+                    # ── Q: fold 1/√d, per-vector INT8 quantization ────────
+                    for i in range(BLOCK_T):
+                        q_scaled:  float32[HEAD_DIM] = 0
+                        q_abs_max: float32 = 1e-8
+                        t_q = tr + i
+                        for jj in range(HEAD_DIM):
+                            q_idx = (b * (CONTEXT_LENGTH * THREE_H)
+                                    + t_q * THREE_H
+                                    + 0 * HIDDEN_SIZE
+                                    + h * HEAD_DIM + jj)
+                            d_f16: float32 = D          # typed literal
+                            val: float32 = input_d[q_idx] * d_f16
+                            q_scaled[jj] = val
+                            neg_val: float32 = -val
+                            abs_val: float32 = val if val >= 0.0 else neg_val
+                            if abs_val > q_abs_max:
+                                q_abs_max = abs_val
+
+                        inv127: float32 = 1.0 / 127.0
+                        delta_Q: float32 = q_abs_max * inv127
+
+                        # ── implicit float16→int8 via typed target ─────────
+                        q_int8: int8[HEAD_DIM] = 0
+                        for jj in range(HEAD_DIM):
+                            # Allo sees target is int8, inserts cast from float16
+                            q_int8[jj] = q_scaled[jj] / delta_Q
+
+                        if i == 0:
+                            fifo_in_Q[0].put(q_int8)
+                            fifo_in_dQ[0].put(delta_Q)
+                        elif i == 1:
+                            fifo_in_Q[1].put(q_int8)
+                            fifo_in_dQ[1].put(delta_Q)
+                        elif i == 2:
+                            fifo_in_Q[2].put(q_int8)
+                            fifo_in_dQ[2].put(delta_Q)
+                        elif i == 3:
+                            fifo_in_Q[3].put(q_int8)
+                            fifo_in_dQ[3].put(delta_Q)
+
+                    # ── K: smooth + per-block INT8 quantization ───────────
+                    for tc_b in range(NUM_TC):
+
+                        k_block:   float32[BLOCK_T, HEAD_DIM] = 0
+                        k_abs_max: float32 = 1e-8
+
+                        for i in range(BLOCK_T):
+                            t_k = tc_b * BLOCK_T + i
+                            for jj in range(HEAD_DIM):
+                                k_idx = (b * (CONTEXT_LENGTH * THREE_H)
+                                        + t_k * THREE_H
+                                        + 1 * HIDDEN_SIZE
+                                        + h * HEAD_DIM + jj)
+                                val: float32 = input_d[k_idx] - k_mean[jj]
+                                k_block[i, jj] = val
+                                neg_val: float32 = -val
+                                abs_val: float32 = val if val >= 0.0 else neg_val
+                                if abs_val > k_abs_max:
+                                    k_abs_max = abs_val
+
+                        inv127k: float32 = 1.0 / 127.0
+                        delta_K: float32 = k_abs_max * inv127k
+
+                        if tc_b == 0:
+                            fifo_in_dK[0].put(delta_K)
+                        elif tc_b == 1:
+                            fifo_in_dK[1].put(delta_K)
+                        elif tc_b == 2:
+                            fifo_in_dK[2].put(delta_K)
+                        elif tc_b == 3:
+                            fifo_in_dK[3].put(delta_K)
+
+                        for i in range(BLOCK_T):
+                            # ── implicit float16→int8 via typed target ─────
+                            k_int8: int8[HEAD_DIM] = 0
+                            for jj in range(HEAD_DIM):
+                                k_int8[jj] = k_block[i, jj] / delta_K
+
+                            v_vec: float32[HEAD_DIM] = 0
+                            t_k = tc_b * BLOCK_T + i
+                            for jj in range(HEAD_DIM):
+                                v_idx = (b * (CONTEXT_LENGTH * THREE_H)
+                                        + t_k * THREE_H
+                                        + 2 * HIDDEN_SIZE
+                                        + h * HEAD_DIM + jj)
+                                v_vec[jj] = input_d[v_idx]
+
+                            if tc_b == 0:
+                                fifo_in_K[0].put(k_int8)
+                                fifo_in_V[0].put(v_vec)
+                            elif tc_b == 1:
+                                fifo_in_K[1].put(k_int8)
+                                fifo_in_V[1].put(v_vec)
+                            elif tc_b == 2:
+                                fifo_in_K[2].put(k_int8)
+                                fifo_in_V[2].put(v_vec)
+                            elif tc_b == 3:
+                                fifo_in_K[3].put(k_int8)
+                                fifo_in_V[3].put(v_vec)
+
+        @df.kernel(mapping=[P0, P1], args=[])
+        def pe():
+            i, j = df.get_pid()
+
+            with allo.meta_if(i in {0, P0 - 1} and j in {0, P1 - 1}):
+                pass
+
+            with allo.meta_elif(i == 0):
+                for b, h in allo.grid(BATCH_SIZE, NUM_HEADS):
+                    for tr in range(0, CONTEXT_LENGTH, BLOCK_T):
+                        dK: float32 = fifo_in_dK[j - 1].get()
+                        fifo_dK[i + 1, j].put(dK)
+                        for k in range(BLOCK_T):
+                            kv: int8[HEAD_DIM]    = fifo_in_K[j - 1].get()
+                            vv: float32[HEAD_DIM] = fifo_in_V[j - 1].get()
+                            fifo_K[i + 1, j].put(kv)
+                            fifo_V[i + 1, j].put(vv)
+
+            with allo.meta_elif(j == 0):
+                for b, h in allo.grid(BATCH_SIZE, NUM_HEADS):
+                    for tr in range(0, CONTEXT_LENGTH, BLOCK_T):
+                        q_int8: int8[HEAD_DIM] = fifo_in_Q[i - 1].get()
+                        dQ:     float32        = fifo_in_dQ[i - 1].get()
+                        fifo_Q[i,  j + 1].put(q_int8)
+                        fifo_dQ[i, j + 1].put(dQ)
+                        m_init: float32           = -1e4    # float16 safe large neg
+                        d_init: float32           = 0.0
+                        o_init: float32[HEAD_DIM] = 0
+                        fifo_m[i, j + 1].put(m_init)
+                        fifo_d[i, j + 1].put(d_init)
+                        fifo_o[i, j + 1].put(o_init)
+
+            with allo.meta_elif(i == P0 - 1):
+                for b, h in allo.grid(BATCH_SIZE, NUM_HEADS):
+                    for tr in range(0, CONTEXT_LENGTH, BLOCK_T):
+                        _dk: float32          = fifo_dK[i, j].get()
+                        for k in range(BLOCK_T):
+                            _k: int8[HEAD_DIM]    = fifo_K[i, j].get()
+                            _v: float32[HEAD_DIM] = fifo_V[i, j].get()
+
+            with allo.meta_elif(j == P1 - 1):
+                for b, h in allo.grid(BATCH_SIZE, NUM_HEADS):
+                    for tr in range(0, CONTEXT_LENGTH, BLOCK_T):
+                        _q:  int8[HEAD_DIM]        = fifo_Q[i,  j].get()
+                        _dq: float32               = fifo_dQ[i, j].get()
+                        _m:  float32               = fifo_m[i,  j].get()
+                        _d:  float32               = fifo_d[i,  j].get()
+                        o_final: float32[HEAD_DIM] = fifo_o[i,  j].get()
+                        fifo_out[i - 1].put(o_final)
+
+            with allo.meta_else():
+                for b, h in allo.grid(BATCH_SIZE, NUM_HEADS):
+                    for tr in range(0, CONTEXT_LENGTH, BLOCK_T):
+
+                        q_int8: int8[HEAD_DIM]    = fifo_Q[i,  j].get()
+                        dQ:     float32           = fifo_dQ[i, j].get()
+                        m_cur:  float32           = fifo_m[i,  j].get()
+                        d_cur:  float32           = fifo_d[i,  j].get()
+                        o_cur:  float32[HEAD_DIM] = fifo_o[i,  j].get()
+
+                        dK: float32 = fifo_dK[i, j].get()
+                        fifo_dK[i + 1, j].put(dK)
+
+                        for k in range(BLOCK_T):
+                            k_int8: int8[HEAD_DIM]    = fifo_K[i, j].get()
+                            vv:     float32[HEAD_DIM] = fifo_V[i, j].get()
+
+                            # ── INT8 × INT8 → INT32 accumulator ───────────
+                            # Declare int32 intermediates — Allo auto-widens int8
+                            x_int32: int32 = 0
+                            for dd in range(HEAD_DIM):
+                                qi: int32 = q_int8[dd]   # int8 → int32 via annotation
+                                ki: int32 = k_int8[dd]   # int8 → int32 via annotation
+                                x_int32 += qi * ki
+
+                            # ── Dequantize INT32 → float32 via annotation ──
+                            x_f32: float32 = x_int32     # int32 → float32 via annotation
+                            x: float32 = x_f32 * dQ * dK
+
+                            # ── Online softmax — all float32 ───────────────
+                            m_new: float32 = m_cur
+                            if x > m_cur:
+                                m_new = x
+                            ep: float32 = allo.exp(m_cur - m_new)
+                            ex: float32 = allo.exp(x - m_new)
+                            d_new: float32 = d_cur * ep + ex
+                            al: float32    = d_cur * ep / d_new
+                            be: float32    = ex / d_new
+
+                            # ── P·V: float32 × float32 ─────────────────────
+                            o_new: float32[HEAD_DIM] = 0
+                            for dd in range(HEAD_DIM):
+                                o_new[dd] = o_cur[dd] * al + be * vv[dd]
+
+                            fifo_K[i + 1, j].put(k_int8)
+                            fifo_V[i + 1, j].put(vv)
+
+                            m_cur = m_new
+                            d_cur = d_new
+                            for dd in range(HEAD_DIM):
+                                o_cur[dd] = o_new[dd]
+
+                        fifo_Q[i,  j + 1].put(q_int8)
+                        fifo_dQ[i, j + 1].put(dQ)
+                        fifo_m[i,  j + 1].put(m_cur)
+                        fifo_d[i,  j + 1].put(d_cur)
+                        fifo_o[i,  j + 1].put(o_cur)
+
+
+        @df.kernel(mapping=[1], args=[output_mem])
+        def store(global_mem: float32[OUT_ELEMS]):
+            for b, h in allo.grid(BATCH_SIZE, NUM_HEADS):
+                for tr in range(0, CONTEXT_LENGTH, BLOCK_T):
+                    for i in range(BLOCK_T):
+                        if i == 0:
+                            o0: float32[HEAD_DIM] = fifo_out[0].get()
+                            for jj in range(HEAD_DIM):
+                                idx = (((b * CONTEXT_LENGTH + (tr + i)) * NUM_HEADS + h) * HEAD_DIM + jj)
+                                global_mem[idx] = o0[jj]
+                        elif i == 1:
+                            o1: float32[HEAD_DIM] = fifo_out[1].get()
+                            for jj in range(HEAD_DIM):
+                                idx = (((b * CONTEXT_LENGTH + (tr + i)) * NUM_HEADS + h) * HEAD_DIM + jj)
+                                global_mem[idx] = o1[jj]
+                        elif i == 2:
+                            o2: float32[HEAD_DIM] = fifo_out[2].get()
+                            for jj in range(HEAD_DIM):
+                                idx = (((b * CONTEXT_LENGTH + (tr + i)) * NUM_HEADS + h) * HEAD_DIM + jj)
+                                global_mem[idx] = o2[jj]
+                        elif i == 3:
+                            o3: float32[HEAD_DIM] = fifo_out[3].get()
+                            for jj in range(HEAD_DIM):
+                                idx = (((b * CONTEXT_LENGTH + (tr + i)) * NUM_HEADS + h) * HEAD_DIM + jj)
+                                global_mem[idx] = o3[jj]
+    return top

--- a/examples/fused_MHA_systolic/test_systolic.py
+++ b/examples/fused_MHA_systolic/test_systolic.py
@@ -1,0 +1,134 @@
+# Copyright Allo authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import tempfile
+import numpy as np
+import allo.backend.hls as hls
+import allo.dataflow as df
+
+from examples.fused_MHA_systolic.fused_MHA_systolic import get_systolic_top
+
+
+def run_test_with_params(BATCH_SIZE, CONTEXT_LENGTH, HIDDEN_SIZE, NUM_HEADS, BLOCK_T):
+
+    assert (
+        HIDDEN_SIZE % NUM_HEADS == 0
+    ), f"HIDDEN_SIZE ({HIDDEN_SIZE}) must be exactly divisible by NUM_HEADS ({NUM_HEADS})"
+    assert (
+        CONTEXT_LENGTH % BLOCK_T == 0
+    ), f"CONTEXT_LENGTH ({CONTEXT_LENGTH}) must be exactly divisible by BLOCK_T ({BLOCK_T})"
+    assert (
+        CONTEXT_LENGTH // BLOCK_T == BLOCK_T
+    ), f"CONTEXT_LENGTH ({CONTEXT_LENGTH}) must be exactly square of BLOCK_T ({BLOCK_T})"
+
+    print("=" * 60)
+    print(
+        f"Testing Fused MHA Systolic: BATCH={BATCH_SIZE}, SEQ_LEN={CONTEXT_LENGTH}, "
+        f"HIDDEN={HIDDEN_SIZE}, HEADS={NUM_HEADS}, BLOCK_T={BLOCK_T}"
+    )
+    print("=" * 60)
+
+    HEAD_DIM = HIDDEN_SIZE // NUM_HEADS
+    D_SQRT = HEAD_DIM**0.5
+    THREE_H = 3 * HIDDEN_SIZE
+    IN_ELEMS = BATCH_SIZE * CONTEXT_LENGTH * THREE_H
+    OUT_ELEMS = BATCH_SIZE * CONTEXT_LENGTH * NUM_HEADS * HEAD_DIM
+
+    A = np.random.rand(IN_ELEMS).astype(np.float32)
+    B_out = np.zeros(OUT_ELEMS, dtype=np.float32)
+
+    A_reshaped = A.reshape((BATCH_SIZE, CONTEXT_LENGTH, 3, NUM_HEADS, HEAD_DIM))
+    Q_np = A_reshaped[:, :, 0, :, :].transpose((0, 2, 1, 3))
+    K_np = A_reshaped[:, :, 1, :, :].transpose((0, 2, 1, 3))
+    V_np = A_reshaped[:, :, 2, :, :].transpose((0, 2, 1, 3))
+
+    scores = np.matmul(Q_np, K_np.transpose((0, 1, 3, 2)))
+    scores = scores * (1.0 / D_SQRT)
+    max_scores = np.max(scores, axis=-1, keepdims=True)
+    exp_scores = np.exp(scores - max_scores)
+    attn_weights = exp_scores / np.sum(exp_scores, axis=-1, keepdims=True)
+
+    out_np = np.matmul(attn_weights, V_np)
+    B_golden = out_np.transpose((0, 2, 1, 3)).flatten()
+
+    s = get_systolic_top(
+        BATCH_SIZE=BATCH_SIZE,
+        CONTEXT_LENGTH=CONTEXT_LENGTH,
+        HIDDEN_SIZE=HIDDEN_SIZE,
+        NUM_HEADS=NUM_HEADS,
+        BLOCK_T=BLOCK_T,
+    )
+    with tempfile.TemporaryDirectory() as sim_dir:
+        print("Running Software Simulator for numerical correctness...")
+        sim_mod = df.build(s, project=sim_dir)
+        sim_mod(A, B_out)
+
+    try:
+        np.testing.assert_allclose(B_out, B_golden, rtol=0.05, atol=1e-2)
+        print("✅ Simulator Test Passed: Outputs match Golden Reference!")
+    except AssertionError as e:
+        print("❌ Simulator Test Failed!")
+        raise e
+
+    if hls.is_available("vitis_hls"):
+        print("Running Vitis HLS Synthesis")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            hls_mod = df.build(s, target="vitis_hls", mode="csyn", project=tmpdir)
+            hls_mod()
+            print("✅ HLS Synthesis Passed!")
+    else:
+        print("⚠️ Vitis HLS not available, skipping C synthesis.")
+
+
+def test_fused_MHA_systolic():
+    run_test_with_params(
+        BATCH_SIZE=4, CONTEXT_LENGTH=16, HIDDEN_SIZE=16, NUM_HEADS=4, BLOCK_T=4
+    )
+
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(description="Allo Fused MHA Systolic Testbench")
+
+    parser.add_argument(
+        "--BATCH_SIZE",
+        type=int,
+        default=4,
+        required=False,
+        help="Batch size of input data",
+    )
+    parser.add_argument(
+        "--CONTEXT_LENGTH",
+        type=int,
+        default=16,
+        required=False,
+        help="Context length of input data",
+    )
+    parser.add_argument(
+        "--HIDDEN_SIZE",
+        type=int,
+        default=16,
+        required=False,
+        help="Hidden size of input data",
+    )
+    parser.add_argument(
+        "--NUM_HEADS",
+        type=int,
+        default=4,
+        required=False,
+        help="Number of heads of input data",
+    )
+    parser.add_argument(
+        "--BLOCK_T", type=int, default=4, required=False, help="Size of tiles"
+    )
+
+    args = parser.parse_args()
+
+    run_test_with_params(
+        BATCH_SIZE=args.BATCH_SIZE,
+        CONTEXT_LENGTH=args.CONTEXT_LENGTH,
+        HIDDEN_SIZE=args.HIDDEN_SIZE,
+        NUM_HEADS=args.NUM_HEADS,
+        BLOCK_T=args.BLOCK_T,
+    )

--- a/examples/machsuite/bfs/bulk/run_test.py
+++ b/examples/machsuite/bfs/bulk/run_test.py
@@ -101,8 +101,8 @@ def test_bfs_bulk(psize="small"):
     np_B = np.array(edges_list, np.int32)
     np_C = generated_data["starting_node"]
 
-    (D, F) = mod(np_A, np_B, np_C)
-    (golden_D, golden_F) = bfs_bulk_ref(np_A, np_B, np_C)
+    D, F = mod(np_A, np_B, np_C)
+    golden_D, golden_F = bfs_bulk_ref(np_A, np_B, np_C)
 
     np.testing.assert_allclose(D, golden_D, rtol=1e-5, atol=1e-5)
     np.testing.assert_allclose(F, golden_F, rtol=1e-5, atol=1e-5)

--- a/examples/machsuite/bfs/queue/run_test.py
+++ b/examples/machsuite/bfs/queue/run_test.py
@@ -103,8 +103,8 @@ def test_bfs_queue(psize="small"):
     np_B = np.array(edges_list, np.int32)
     np_C = generated_data["starting_node"]
 
-    (D, F) = mod(np_A, np_B, np_C)
-    (golden_D, golden_F) = bfs_queue_ref(np_A, np_B, np_C)
+    D, F = mod(np_A, np_B, np_C)
+    golden_D, golden_F = bfs_queue_ref(np_A, np_B, np_C)
 
     np.testing.assert_allclose(D, golden_D, rtol=1e-5, atol=1e-5)
     np.testing.assert_allclose(F, golden_F, rtol=1e-5, atol=1e-5)

--- a/examples/machsuite/gemm/run_test.py
+++ b/examples/machsuite/gemm/run_test.py
@@ -7,7 +7,6 @@ import json
 import allo
 import numpy as np
 
-
 _dir = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, _dir)
 from gemm_ncubed import gemm

--- a/examples/machsuite/kmp/kmp.py
+++ b/examples/machsuite/kmp/kmp.py
@@ -40,9 +40,9 @@ def python_kmp(pattern, input):
 
 ### allo implementation ###
 def kmp(concrete_type, s, p):
-    def kmp_kernal[
-        T: (uint8, int32), S: uint8, P: uint8
-    ](pattern: "T[P]", input_str: "T[S]", kmp_next: "T[P]", matches: "T[1]"):
+    def kmp_kernal[T: (uint8, int32), S: uint8, P: uint8](
+        pattern: "T[P]", input_str: "T[S]", kmp_next: "T[P]", matches: "T[1]"
+    ):
 
         k: index = 0
         x: index = 1

--- a/examples/machsuite/merge/run_test.py
+++ b/examples/machsuite/merge/run_test.py
@@ -7,7 +7,6 @@ import json
 import allo
 import numpy as np
 
-
 _dir = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, _dir)
 import mergesort

--- a/examples/polybench/adi.py
+++ b/examples/polybench/adi.py
@@ -70,9 +70,9 @@ e = 0.0
 f = 0.0
 
 
-def kernel_adi[
-    T: (float32, int32), TSTEPS: int32, N: int32
-](u: "T[N, N]", v: "T[N, N]", p: "T[N, N]", q: "T[N, N]"):
+def kernel_adi[T: (float32, int32), TSTEPS: int32, N: int32](
+    u: "T[N, N]", v: "T[N, N]", p: "T[N, N]", q: "T[N, N]"
+):
     for t in range(1, TSTEPS + 1):
         for i in range(1, N - 1):
             v[0, i] = 1.0

--- a/examples/polybench/atax.py
+++ b/examples/polybench/atax.py
@@ -16,25 +16,25 @@ def atax_np(A, x):
     return y
 
 
-def stage_M[
-    T: (float32, int32), M: int32, N: int32
-](A: "T[M, N]", x: "T[N]", out_Ax: "T[M]"):
+def stage_M[T: (float32, int32), M: int32, N: int32](
+    A: "T[M, N]", x: "T[N]", out_Ax: "T[M]"
+):
     for m in allo.grid(M):
         for r in allo.reduction(N):
             out_Ax[m] += A[m, r] * x[r]
 
 
-def stage_N[
-    T: (float32, int32), M: int32, N: int32
-](A: "T[M, N]", out_Ax: "T[M]", y: "T[N]"):
+def stage_N[T: (float32, int32), M: int32, N: int32](
+    A: "T[M, N]", out_Ax: "T[M]", y: "T[N]"
+):
     for n in allo.grid(N):
         for k in allo.reduction(M):
             y[n] += A[k, n] * out_Ax[k]
 
 
-def kernel_atax[
-    T: (float32, int32), M: int32, N: int32
-](A: "T[M, N]", x: "T[N]", y: "T[N]"):
+def kernel_atax[T: (float32, int32), M: int32, N: int32](
+    A: "T[M, N]", x: "T[N]", y: "T[N]"
+):
     out_Ax: T[M] = 0
     stage_M[T, M, N](A, x, out_Ax)
     stage_N[T, M, N](A, out_Ax, y)

--- a/examples/polybench/bicg.py
+++ b/examples/polybench/bicg.py
@@ -34,9 +34,9 @@ def stageQ[T: (float32, int32), M: int32, N: int32](A: "T[N, M]", p: "T[M]", q: 
             q[i1] += A[i1, j1] * p[j1]
 
 
-def kernel_bicg[
-    T: (float32, int32), M: int32, N: int32
-](A: "T[N, M]", A_copy: "T[N, M]", p: "T[M]", r: "T[N]", q: "T[N]", s: "T[M]"):
+def kernel_bicg[T: (float32, int32), M: int32, N: int32](
+    A: "T[N, M]", A_copy: "T[N, M]", p: "T[M]", r: "T[N]", q: "T[N]", s: "T[M]"
+):
     stageS(A, r, s)
     stageQ(A_copy, p, q)
 

--- a/examples/polybench/correlation.py
+++ b/examples/polybench/correlation.py
@@ -47,9 +47,9 @@ def correlation_np(data, mean, stddev, corr, M, N, N_float, epsilon):
     return data, mean, stddev, corr
 
 
-def compute_mean[
-    T: (float32, int32), M: int32, N: int32
-](data: "T[N, M]", mean: "T[M]"):
+def compute_mean[T: (float32, int32), M: int32, N: int32](
+    data: "T[N, M]", mean: "T[M]"
+):
     for x in allo.grid(M):
         total: T = 0.0
         for k in allo.grid(N):
@@ -57,9 +57,9 @@ def compute_mean[
         mean[x] = total / N
 
 
-def compute_stddev[
-    T: (float32, int32), M: int32, N: int32
-](data: "T[N, M]", mean: "T[M]", mean_passed_on: "T[M]", stddev: "T[M]"):
+def compute_stddev[T: (float32, int32), M: int32, N: int32](
+    data: "T[N, M]", mean: "T[M]", mean_passed_on: "T[M]", stddev: "T[M]"
+):
     for x in allo.grid(M):
         variance: T = 0.0
         for m in allo.grid(N):
@@ -71,9 +71,9 @@ def compute_stddev[
             stddev[x] = 1.0
 
 
-def center_reduce[
-    T: (float32, int32), M: int32, N: int32
-](data: "T[N, M]", data_out: "T[N, M]", mean: "T[M]", stddev: "T[M]"):
+def center_reduce[T: (float32, int32), M: int32, N: int32](
+    data: "T[N, M]", data_out: "T[N, M]", mean: "T[M]", stddev: "T[M]"
+):
     for x in allo.grid(N):
         for y in allo.grid(M):
             d: T = data[x, y]
@@ -82,9 +82,9 @@ def center_reduce[
             data_out[x, y] = d
 
 
-def compute_corr[
-    T: (float32, int32), M: int32, N: int32
-](data: "T[N, M]", corr: "T[M, M]"):
+def compute_corr[T: (float32, int32), M: int32, N: int32](
+    data: "T[N, M]", corr: "T[M, M]"
+):
     for i in range(M - 1):
         corr[i, i] = 1.0
         for j in range(M):
@@ -98,9 +98,7 @@ def compute_corr[
     corr[M - 1, M - 1] = 1.0
 
 
-def kernel_correlation[
-    T: (float32, int32), M: int32, N: int32
-](
+def kernel_correlation[T: (float32, int32), M: int32, N: int32](
     data_mean: "T[N, M]",
     data_stddev: "T[N, M]",
     data_for_center: "T[N, M]",

--- a/examples/polybench/covariance.py
+++ b/examples/polybench/covariance.py
@@ -30,9 +30,9 @@ def covariance_np(data, mean, cov, M, N):
     return data, mean, cov
 
 
-def kernel_covariance[
-    T: (float32, int32), M: int32, N: int32
-](data: "T[N, M]", mean: "T[M]", cov: "T[M, M]"):
+def kernel_covariance[T: (float32, int32), M: int32, N: int32](
+    data: "T[N, M]", mean: "T[M]", cov: "T[M, M]"
+):
     # Compute mean
     for x in allo.grid(M):
         total: float32 = 0.0

--- a/examples/polybench/deriche.py
+++ b/examples/polybench/deriche.py
@@ -75,9 +75,9 @@ def deriche_np(imgIn, imgOut, y1, y2, a1, a2, a3, a4, a5, a6, a7, a8, b1, b2, c1
 a1 = a2 = a3 = a4 = a5 = a6 = a7 = a8 = b1 = b2 = c1 = c2 = 0.0
 
 
-def kernel_deriche[
-    T: (float32, int32), W: int32, H: int32
-](imgIn: "T[W, H]", imgOut: "T[W, H]", y1: "T[W, H]", y2: "T[W, H]"):
+def kernel_deriche[T: (float32, int32), W: int32, H: int32](
+    imgIn: "T[W, H]", imgOut: "T[W, H]", y1: "T[W, H]", y2: "T[W, H]"
+):
     for i in range(W):
         ym1: T = 0.0
         ym2: T = 0.0

--- a/examples/polybench/doitgen.py
+++ b/examples/polybench/doitgen.py
@@ -23,9 +23,9 @@ def doitgen_np(A, x, sum):
     return A, x, sum
 
 
-def kernel_doitgen[
-    T: (float32, int32), R: int32, Q: int32, P: int32, S: int32
-](A: "T[R, Q, S]", x: "T[P, S]", sum_: "T[P]"):
+def kernel_doitgen[T: (float32, int32), R: int32, Q: int32, P: int32, S: int32](
+    A: "T[R, Q, S]", x: "T[P, S]", sum_: "T[P]"
+):
     for r, q in allo.grid(R, Q):
         for p in allo.grid(P):
             sum_[p] = 0

--- a/examples/polybench/fdtd_2d.py
+++ b/examples/polybench/fdtd_2d.py
@@ -31,9 +31,12 @@ def fdtd_2d_np(ex, ey, hz, fict):
     return ex, ey, hz, fict
 
 
-def kernel_fdtd_2d[
-    T: (float32, int32), Nx: int32, Ny: int32, Tmax: int32
-](ex: "T[Nx, Ny]", ey: "T[Nx, Ny]", hz: "T[Nx, Ny]", fict: "T[Tmax]",):
+def kernel_fdtd_2d[T: (float32, int32), Nx: int32, Ny: int32, Tmax: int32](
+    ex: "T[Nx, Ny]",
+    ey: "T[Nx, Ny]",
+    hz: "T[Nx, Ny]",
+    fict: "T[Tmax]",
+):
     for m in allo.grid(Tmax):
         for j in allo.grid(Ny):
             ey[0, j] = fict[m]

--- a/examples/polybench/gemm.py
+++ b/examples/polybench/gemm.py
@@ -16,24 +16,24 @@ def gemm_np(A, B, C, beta):
     return out_ABC
 
 
-def mm1[
-    T: (float32, int32), P: int32, Q: int32, R: int32
-](A: "T[P, Q]", B: "T[Q, R]", out_AB: "T[P, R]"):
+def mm1[T: (float32, int32), P: int32, Q: int32, R: int32](
+    A: "T[P, Q]", B: "T[Q, R]", out_AB: "T[P, R]"
+):
     for i0, j0 in allo.grid(P, R, name="mm1"):
         for k0 in allo.reduction(Q):
             out_AB[i0, j0] += A[i0, k0] * B[k0, j0]
 
 
-def ele_add[
-    T: (float32, int32), P: int32, R: int32
-](out_AB: "T[P, R]", C: "T[P, R]", output: "T[P, R]"):
+def ele_add[T: (float32, int32), P: int32, R: int32](
+    out_AB: "T[P, R]", C: "T[P, R]", output: "T[P, R]"
+):
     for i2, j2 in allo.grid(P, R):
         output[i2, j2] = beta * C[i2, j2] + out_AB[i2, j2]
 
 
-def kernel_gemm[
-    T: (float32, int32), P: int32, Q: int32, R: int32
-](A: "T[P, Q]", B: "T[Q, R]", C: "T[P, R]", output: "T[P, R]"):
+def kernel_gemm[T: (float32, int32), P: int32, Q: int32, R: int32](
+    A: "T[P, Q]", B: "T[Q, R]", C: "T[P, R]", output: "T[P, R]"
+):
     out_AB: T[P, R] = 0
     mm1[T, P, Q, R](A, B, out_AB)
     ele_add[T, P, R](out_AB, C, output)

--- a/examples/polybench/gemver.py
+++ b/examples/polybench/gemver.py
@@ -29,9 +29,7 @@ def gemver_np(A, u1, u2, v1, v2, x, y, w, z, alpha, beta):
     return A, x, y, w
 
 
-def kernel_gemver[
-    T: (float32, int32), N: int32
-](
+def kernel_gemver[T: (float32, int32), N: int32](
     A: "T[N, N]",
     u1: "T[N]",
     u2: "T[N]",

--- a/examples/polybench/gesummv.py
+++ b/examples/polybench/gesummv.py
@@ -22,9 +22,9 @@ def gesummv_np(A, B, x, y, alpha, beta):
     return y
 
 
-def compute_tmp[
-    T: (float32, int32), N: int32
-](y_in: "T[N]", y_out: "T[N]", A: "T[N, N]", B: "T[N, N]", x: "T[N]", tmp: "T[N]"):
+def compute_tmp[T: (float32, int32), N: int32](
+    y_in: "T[N]", y_out: "T[N]", A: "T[N, N]", B: "T[N, N]", x: "T[N]", tmp: "T[N]"
+):
     tt: T[N] = 0.0
     yy: T[N]
     for i0 in allo.grid(N, name="load"):
@@ -42,9 +42,9 @@ def compute_y[T: (float32, int32), N: int32](y_in: "T[N]", y_out: "T[N]", tmp: "
         y_out[i0] = alpha * tmp[i0] + beta * y_in[i0]
 
 
-def kernel_gesummv[
-    T: (float32, int32), N: int32
-](A: "T[N, N]", B: "T[N, N]", x: "T[N]", y: "T[N]"):
+def kernel_gesummv[T: (float32, int32), N: int32](
+    A: "T[N, N]", B: "T[N, N]", x: "T[N]", y: "T[N]"
+):
     y_init: T[N] = 0
     y_fifo: T[N]
     tmp: T[N]

--- a/examples/polybench/gramschmidt.py
+++ b/examples/polybench/gramschmidt.py
@@ -33,9 +33,9 @@ def gramschmidt_np(A, Q, R):
     return A, Q, R
 
 
-def kernel_gramschmidt[
-    T: (float32, int32), M: int32, N: int32
-](A: "T[M, N]", Q: "T[M, N]", R: "T[N, N]"):
+def kernel_gramschmidt[T: (float32, int32), M: int32, N: int32](
+    A: "T[M, N]", Q: "T[M, N]", R: "T[N, N]"
+):
     for k in range(N):
         nrm: T = 0.0
         for i in range(M):

--- a/examples/polybench/heat_3d.py
+++ b/examples/polybench/heat_3d.py
@@ -32,9 +32,9 @@ def heat_3d_np(A, B, TSTEPS, N):
     return A, B
 
 
-def kernel_heat_3d[
-    T: (float32, int32), TSTEPS: int32, N: int32
-](A: "T[N, N, N]", B: "T[N, N, N]"):
+def kernel_heat_3d[T: (float32, int32), TSTEPS: int32, N: int32](
+    A: "T[N, N, N]", B: "T[N, N, N]"
+):
     const0: float32 = 0.125
     const1: float32 = 2.0
 

--- a/examples/polybench/jacobi_1d.py
+++ b/examples/polybench/jacobi_1d.py
@@ -20,9 +20,9 @@ def jacobi_1d_np(A, B, TSTEPS, N):
     return A, B
 
 
-def kernel_jacobi_1d[
-    T: (float32, int32), TSTEPS: int32, N: int32
-](A: "T[N]", B: "T[N]"):
+def kernel_jacobi_1d[T: (float32, int32), TSTEPS: int32, N: int32](
+    A: "T[N]", B: "T[N]"
+):
     for m in range(TSTEPS):
         for i0 in range(1, N - 1):
             B[i0] = 0.33333 * (A[i0 - 1] + A[i0] + A[i0 + 1])

--- a/examples/polybench/ludcmp.py
+++ b/examples/polybench/ludcmp.py
@@ -38,9 +38,9 @@ def ludcmp_np(A, b, x, y):
     return A, b, x, y
 
 
-def kernel_ludcmp[
-    T: (float32, int32), N: int32
-](A: "T[N, N]", b: "T[N]", x: "T[N]", y: "T[N]"):
+def kernel_ludcmp[T: (float32, int32), N: int32](
+    A: "T[N, N]", b: "T[N]", x: "T[N]", y: "T[N]"
+):
     # LU decomposition of A
     for i in range(N):
         for j in range(i):

--- a/examples/polybench/mvt.py
+++ b/examples/polybench/mvt.py
@@ -19,9 +19,9 @@ def mvt_np(A, x1, x2, y1, y2):
     return x1, x2
 
 
-def stageA[
-    T: (float32, int32), N: int32
-](x1_in: "T[N]", x1_out: "T[N]", A: "T[N, N]", y1: "T[N]"):
+def stageA[T: (float32, int32), N: int32](
+    x1_in: "T[N]", x1_out: "T[N]", A: "T[N, N]", y1: "T[N]"
+):
     for i0 in allo.grid(N, name="A"):
         x: T = x1_in[i0]
         for j0 in allo.reduction(N):
@@ -29,9 +29,9 @@ def stageA[
         x1_out[i0] = x
 
 
-def stageB[
-    T: (float32, int32), N: int32
-](x2_in: "T[N]", x2_out: "T[N]", A: "T[N, N]", y2: "T[N]"):
+def stageB[T: (float32, int32), N: int32](
+    x2_in: "T[N]", x2_out: "T[N]", A: "T[N, N]", y2: "T[N]"
+):
     for i1 in allo.grid(N, name="B"):
         x: T = x2_in[i1]
         for j1 in allo.reduction(N):
@@ -39,9 +39,7 @@ def stageB[
         x2_out[i1] = x
 
 
-def kernel_mvt[
-    T: (float32, int32), N: int32
-](
+def kernel_mvt[T: (float32, int32), N: int32](
     A: "T[N, N]",
     A_copy: "T[N, N]",
     y1: "T[N]",

--- a/examples/polybench/symm.py
+++ b/examples/polybench/symm.py
@@ -21,18 +21,21 @@ def symm_np(A, B, C, alpha, beta, M, N):
     return C
 
 
-def compute_sum[
-    T: (float32, int32), M: int32, N: int32
-](A: "T[M, M]", B: "T[M, N]", summ: "T[M, N]"):
+def compute_sum[T: (float32, int32), M: int32, N: int32](
+    A: "T[M, M]", B: "T[M, N]", summ: "T[M, N]"
+):
     for i1, j1 in allo.grid(M, N, name="sum"):
         for k1 in allo.reduction(M, name="k1"):
             if k1 < i1:
                 summ[i1, j1] += B[k1, j1] * A[i1, k1]
 
 
-def update_C[
-    T: (float32, int32), M: int32, N: int32
-](A: "T[M, M]", B: "T[M, N]", summ: "T[M, N]", C: "T[M, N]",):
+def update_C[T: (float32, int32), M: int32, N: int32](
+    A: "T[M, M]",
+    B: "T[M, N]",
+    summ: "T[M, N]",
+    C: "T[M, N]",
+):
     for i in range(M):
         for k in range(i):  # pipeline
             for j in range(N):  # unroll
@@ -43,9 +46,9 @@ def update_C[
             )
 
 
-def kernel_symm[
-    T: (float32, int32), M: int32, N: int32
-](A0: "T[M, M]", A1: "T[M, M]", B0: "T[M, N]", B1: "T[M, N]", C: "T[M, N]"):
+def kernel_symm[T: (float32, int32), M: int32, N: int32](
+    A0: "T[M, M]", A1: "T[M, M]", B0: "T[M, N]", B1: "T[M, N]", C: "T[M, N]"
+):
     # dataflow
     summ: T[M, N] = 0
     compute_sum(A0, B0, summ)

--- a/examples/polybench/syr2k.py
+++ b/examples/polybench/syr2k.py
@@ -28,9 +28,7 @@ def update_C[T: (float32, int32), N: int32](Cin: "T[N, N]", Cout: "T[N, N]"):
             Cout[i0, j0] = Cin[i0, j0]
 
 
-def compute_sum[
-    T: (float32, int32), N: int32, M: int32
-](
+def compute_sum[T: (float32, int32), N: int32, M: int32](
     A: "T[N, M]",
     A_copy: "T[N, M]",
     B: "T[N, M]",
@@ -50,9 +48,7 @@ def compute_sum[
         Cout[i2, j2] = buffer[i2, j2]
 
 
-def kernel_syr2k[
-    T: (float32, int32), N: int32, M: int32
-](
+def kernel_syr2k[T: (float32, int32), N: int32, M: int32](
     A: "T[N, M]",
     A_copy: "T[N, M]",
     B: "T[N, M]",

--- a/examples/polybench/syrk.py
+++ b/examples/polybench/syrk.py
@@ -28,9 +28,9 @@ def update_C[T: (float32, int32), N: int32](Cin: "T[N, N]", Cout: "T[N, N]"):
             Cout[i0, j0] = Cin[i0, j0]
 
 
-def compute_sum[
-    T: (float32, int32), N: int32, M: int32
-](A: "T[N, M]", A_copy: "T[N, M]", Cin: "T[N, N]", Cout: "T[N, N]"):
+def compute_sum[T: (float32, int32), N: int32, M: int32](
+    A: "T[N, M]", A_copy: "T[N, M]", Cin: "T[N, N]", Cout: "T[N, N]"
+):
     buffer: T[N, N] = 0
     for i0, j0 in allo.grid(N, N, name="load"):
         buffer[i0, j0] = Cin[i0, j0]
@@ -41,9 +41,9 @@ def compute_sum[
         Cout[i2, j2] = buffer[i2, j2]
 
 
-def kernel_syr2k[
-    T: (float32, int32), N: int32, M: int32
-](A: "T[N, M]", A_copy: "T[N, M]", Cin: "T[N, N]", Cout: "T[N, N]"):
+def kernel_syr2k[T: (float32, int32), N: int32, M: int32](
+    A: "T[N, M]", A_copy: "T[N, M]", Cin: "T[N, N]", Cout: "T[N, N]"
+):
     C: T[N, N] = 0
     update_C[T, N](Cin, C)
     compute_sum[T, N, M](A, A_copy, C, Cout)

--- a/examples/polybench/three_mm.py
+++ b/examples/polybench/three_mm.py
@@ -17,25 +17,25 @@ def three_mm_np(A, B, C, D):
     return out_ABC
 
 
-def mm1[
-    DType: (float32, int32), P: int32, Q: int32, R: int32
-](A: "DType[P, Q]", B: "DType[Q, R]", out_AB: "DType[P, R]"):
+def mm1[DType: (float32, int32), P: int32, Q: int32, R: int32](
+    A: "DType[P, Q]", B: "DType[Q, R]", out_AB: "DType[P, R]"
+):
     for i0, j0 in allo.grid(P, R, name="mm1"):
         for k0 in allo.reduction(Q):
             out_AB[i0, j0] += A[i0, k0] * B[k0, j0]
 
 
-def mm2[
-    DType: (float32, int32), R: int32, S: int32, T: int32
-](C: "DType[R, S]", D: "DType[S, T]", out_CD: "DType[R, T]"):
+def mm2[DType: (float32, int32), R: int32, S: int32, T: int32](
+    C: "DType[R, S]", D: "DType[S, T]", out_CD: "DType[R, T]"
+):
     for i1, j1 in allo.grid(R, T, name="mm2"):
         for k1 in allo.reduction(S):
             out_CD[i1, j1] += C[i1, k1] * D[k1, j1]
 
 
-def mm3[
-    DType: (float32, int32), P: int32, R: int32, T: int32
-](out_AB: "DType[P, R]", out_CD: "DType[R, T]", out_ABC: "DType[P, T]"):
+def mm3[DType: (float32, int32), P: int32, R: int32, T: int32](
+    out_AB: "DType[P, R]", out_CD: "DType[R, T]", out_ABC: "DType[P, T]"
+):
     for i2, j2 in allo.grid(P, T, name="mm3"):
         for k2 in allo.reduction(R):
             out_ABC[i2, j2] += out_AB[i2, k2] * out_CD[k2, j2]

--- a/examples/polybench/trisolv.py
+++ b/examples/polybench/trisolv.py
@@ -20,9 +20,9 @@ def trisolv_np(L, x, b):
     return x
 
 
-def kernel_trisolv[
-    T: (float32, int32), N: int32
-](L: float32[N, N], b: float32[N], x: float32[N]):
+def kernel_trisolv[T: (float32, int32), N: int32](
+    L: float32[N, N], b: float32[N], x: float32[N]
+):
     for i in range(N):
         x[i] = b[i]
         for j in range(i):

--- a/examples/polybench/two_mm.py
+++ b/examples/polybench/two_mm.py
@@ -17,32 +17,32 @@ def two_mm_np(A, B, C, D, alpha, beta):
     return output
 
 
-def mm1[
-    T: (float32, int32), P: int32, Q: int32, R: int32
-](A: "T[P, Q]", B: "T[Q, R]", out_AB: "T[P, R]"):
+def mm1[T: (float32, int32), P: int32, Q: int32, R: int32](
+    A: "T[P, Q]", B: "T[Q, R]", out_AB: "T[P, R]"
+):
     for i0, j0 in allo.grid(P, R, name="mm1"):
         for k0 in allo.reduction(Q):
             out_AB[i0, j0] += A[i0, k0] * B[k0, j0]
 
 
-def mm2[
-    T: (float32, int32), P: int32, R: int32, S: int32
-](out_AB: "T[P, R]", C: "T[R, S]", out_ABC: "T[P, S]"):
+def mm2[T: (float32, int32), P: int32, R: int32, S: int32](
+    out_AB: "T[P, R]", C: "T[R, S]", out_ABC: "T[P, S]"
+):
     for i1, j1 in allo.grid(P, S, name="mm2"):
         for k1 in allo.reduction(R):
             out_ABC[i1, j1] += out_AB[i1, k1] * C[k1, j1]
 
 
-def ele_add[
-    T: (float32, int32), P: int32, S: int32
-](out_ABC: "T[P, S]", D: "T[P, S]", output: "T[P, S]"):
+def ele_add[T: (float32, int32), P: int32, S: int32](
+    out_ABC: "T[P, S]", D: "T[P, S]", output: "T[P, S]"
+):
     for i2, j2 in allo.grid(P, S):
         output[i2, j2] = out_ABC[i2, j2] * beta + D[i2, j2] * alpha
 
 
-def kernel_2mm[
-    T: (float32, int32), P: int32, R: int32, Q: int32, S: int32
-](A: "T[P, Q]", B: "T[Q, R]", C: "T[R, S]", D: "T[P, S]") -> "T[P, S]":
+def kernel_2mm[T: (float32, int32), P: int32, R: int32, Q: int32, S: int32](
+    A: "T[P, Q]", B: "T[Q, R]", C: "T[R, S]", D: "T[P, S]"
+) -> "T[P, S]":
     out_AB: T[P, R] = 0
     out_ABC: T[P, S] = 0
     output: T[P, S]

--- a/scripts/lint/add_license_header.py
+++ b/scripts/lint/add_license_header.py
@@ -3,6 +3,7 @@
 # Modification: Slapo. See https://github.com/awslabs/slapo/blob/main/scripts/lint/add_license_header.py
 
 """Helper tool to add license header to files."""
+
 import os
 import sys
 import subprocess
@@ -144,7 +145,7 @@ def main(args):
     if len(file_list) == 1 and file_list[0] == "all":
         cmd = ["git", "ls-tree", "--full-tree", "--name-only", "-r", "HEAD"]
         proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-        (out, _) = proc.communicate()
+        out, _ = proc.communicate()
         assert proc.returncode == 0, f'{" ".join(cmd)} errored: {out}'
         file_list = out.decode("utf-8").split("\n")
 

--- a/scripts/lint/check_license_header.py
+++ b/scripts/lint/check_license_header.py
@@ -3,6 +3,7 @@
 # Modification: Slapo. See https://github.com/awslabs/slapo/blob/main/scripts/lint/check_license_header.py
 
 """Helper tool to check license header."""
+
 import os
 import sys
 import subprocess
@@ -41,7 +42,7 @@ def main():
     else:
         cmd = ["git", "diff", "--name-only", "--diff-filter=ACMRTUX", commit]
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-    (out, _) = proc.communicate()
+    out, _ = proc.communicate()
     assert proc.returncode == 0, f'{" ".join(cmd)} errored: {out}'
     res = out.decode("utf-8")
 

--- a/tests/autoscheduler/polybench.py
+++ b/tests/autoscheduler/polybench.py
@@ -17,7 +17,6 @@ from examples.polybench.gemm import kernel_gemm, gemm_np
 from examples.polybench.gesummv import kernel_gesummv, gesummv_np
 from examples.polybench.mvt import kernel_mvt, mvt_np
 
-
 polybench_registry: dict[str, tuple[Callable, Callable, Callable]] = {}
 
 

--- a/tests/dataflow/aie/test_trace_conv.py
+++ b/tests/dataflow/aie/test_trace_conv.py
@@ -12,7 +12,6 @@ import numpy as np
 from allo.backend.aie.external_kernel import ExternalModule
 from allo.backend.aie import is_available
 
-
 # Convolution dimensions
 IN_H = 3  # Input height (smaller for int32)
 IN_W = 3  # Input width (smaller for int32)

--- a/tests/dataflow/test_1D_systolic.py
+++ b/tests/dataflow/test_1D_systolic.py
@@ -9,7 +9,6 @@ import allo.dataflow as df
 import allo.backend.hls as hls
 import numpy as np
 
-
 M, N, K = 16, 16, 16
 P0 = K + 2
 

--- a/tests/dataflow/test_mlp.py
+++ b/tests/dataflow/test_mlp.py
@@ -10,7 +10,6 @@ import allo.dataflow as df
 import allo.backend.hls as hls
 import numpy as np
 
-
 Ty = float32
 BS = 2
 M0, M1, M2 = 256, 128, 64

--- a/tests/dataflow/test_multi_cache_gemm.py
+++ b/tests/dataflow/test_multi_cache_gemm.py
@@ -14,9 +14,7 @@ import numpy as np
 
 
 @df.region()
-def MXU[
-    Rt, Ct, M, N, K
-](
+def MXU[Rt, Ct, M, N, K](
     A_Packed: "UInt(Rt * 8)[M * K // Rt]",
     B_Packed: "UInt(Ct * 8)[K * N // Ct]",
     C_Packed: "UInt(Rt * 8)[M * N // Rt]",

--- a/tests/dataflow/test_smith_waterman_systolic.py
+++ b/tests/dataflow/test_smith_waterman_systolic.py
@@ -9,7 +9,6 @@ import allo.dataflow as df
 import allo.backend.hls as hls
 import numpy as np
 
-
 W: int32 = 2  # gap penalty score per length, assuming a linear increament
 
 M, N = 4, 4

--- a/tests/dataflow/test_tiled_systolic.py
+++ b/tests/dataflow/test_tiled_systolic.py
@@ -10,7 +10,6 @@ import allo.dataflow as df
 import allo.backend.hls as hls
 import numpy as np
 
-
 # M, N, K = 512, 512, 512
 # Mt, Nt = 16, 16
 M, N, K = 16, 16, 16

--- a/tests/dataflow/test_unified_systolic.py
+++ b/tests/dataflow/test_unified_systolic.py
@@ -10,7 +10,6 @@ import allo.dataflow as df
 import allo.backend.hls as hls
 import numpy as np
 
-
 U = 4  # Require for same size in two dimension if not tiling
 M, N, K = U, 4, U
 P0, P1 = U + 2, U + 2

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -524,7 +524,7 @@ def test_layernorm_gelu_ops():
     beta = np.random.uniform(size=(hidden_size)).astype(np.float32)
 
     def foo(
-        inp: float32[bs, seq_len, hidden_size]
+        inp: float32[bs, seq_len, hidden_size],
     ) -> float32[bs, seq_len, hidden_size]:
         outp = allo.gelu(inp)
         return outp

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -204,9 +204,7 @@ def test_bert():
     H, L, D, Dffn = 2, 8, 8, 16
     M0, M1 = 2, 2
 
-    def BertLayer[
-        Ty, H, L, D, Dffn, M0, M1
-    ](
+    def BertLayer[Ty, H, L, D, Dffn, M0, M1](
         X: "Ty[L, D]",
         Wq: "Ty[D, D]",
         Wk: "Ty[D, D]",

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -7,9 +7,9 @@ import allo
 from allo.ir.types import int8, int32, float32
 
 
-def kernel[
-    TyA, TyB, TyC, M: int32, K: int32, N: int32
-](A: "TyA[M, K]", B: "TyB[K, N]") -> "TyC[M, N]":
+def kernel[TyA, TyB, TyC, M: int32, K: int32, N: int32](
+    A: "TyA[M, K]", B: "TyB[K, N]"
+) -> "TyC[M, N]":
     C: TyC[M, N]
     for i in range(M):
         for j in range(N):

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -528,7 +528,9 @@ def test_polymorphism():
         M: int32,
         N: int32,
         K: int32,
-    ](A: "T[M, K]", B: "T[K, N]") -> "T[M, N]":
+    ](
+        A: "T[M, K]", B: "T[K, N]"
+    ) -> "T[M, N]":
         C: T[M, N] = 0
         for i, j, k in allo.grid(M, N, K):
             C[i, j] += A[i, k] * B[k, j]
@@ -561,7 +563,9 @@ def test_multiple_poly_types():
         ),
         M: int32,
         N: int32,
-    ](A: "T0[M, N]", B: "T1[M, N]") -> "T2[M, N]":
+    ](
+        A: "T0[M, N]", B: "T1[M, N]"
+    ) -> "T2[M, N]":
         C: T2[M, N] = 0
         for i in range(M):
             for j in range(N):

--- a/tutorials/tutorial_01_get_started.py
+++ b/tutorials/tutorial_01_get_started.py
@@ -16,7 +16,6 @@ First we import the necessary packages.
 
 import allo
 
-
 ##############################################################################
 # Algorithm Definition
 # --------------------


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This request's central contribution is a fused MHA systolic array. Our design is a pure dataflow description in Allo dataflow programming. We re-architect the algorithm-to-hardware mapping so that the entire FlashAttention loop fits a strictly unidirectional, feedback-free dataflow with one tc block per PE column. We additionally apply SageAttention( https://arxiv.org/abs/2410.02367), a quantization method that preserves precision under 8-bit quantization, to save resources.

### Problems ###
Using online softmax we can fuse the self-attention calculation into one single pass. Is it possible to implement it in a pure dataflow architecture? Cascading two systolic arrays does not seem to be the optimal implementation.


### Proposed Solutions ###
The kernel routes three concurrent streams through a block_T * block_T PE array. The query $Q$ and the FlashAttention state $(m, d, \mathbf{O})$ enter from the left boundary and propagate strictly rightward in lockstep, with each PE forwarding both to its right neighbour after one use. The key and value blocks $K$ and $V$ enter from the top and propagate downward, where column $j$ is statically bound to tc block j-1: column 1 owns the first block_T keys, column 2 the next block_T, and so on. Each compute PE iterates over its assigned $tc$ block, computing $\mathbf{q}\cdot\mathbf{k}$, applying the online softmax update against the incoming state, and accumulating $V$ into $\mathbf{O}$ before passing the updated state right and $K{,}V$ down. State traverses the array exactly once, so the channel graph is acyclic and no feedback FIFOs are required.


### Examples ###
This is an example


## Checklist ##

Please make sure to review and check all of these items:
- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [x] All changes have test coverage (It would be good to provide ~2 different test cases to test the robustness of your code)
- [x] Pass the [formatting check](https://cornell-zhang.github.io/allo/developer/index.html#id1) locally
- [x] Code is well-documented
