### PR TITLE
[Feat][AIE] Add Support for Attention on XDNA2

### DIFF
--- a/allo/backend/aie/utils.py
+++ b/allo/backend/aie/utils.py
@@ -296,12 +296,12 @@ matmul_external_kernel_config_map = {
     ("bf16", "bf16"): {
         "ctype": ("bfloat16", "bfloat16"),
         "aie2": (4, 8, 4),
-        "aie2p": (8, 8, 8),
+        "aie2p": (4, 8, 8),
     },
     ("bf16", "f32"): {
         "ctype": ("bfloat16", "bfloat"),
         "aie2": (4, 8, 4),
-        "aie2p": (8, 8, 8),
+        "aie2p": (4, 8, 8),
     },
 }
 

--- a/allo/backend/aie/utils.py
+++ b/allo/backend/aie/utils.py
@@ -455,7 +455,7 @@ def inject_external_kernels(
                         input_idx.extend([0, 1])
                         output_idx.append(2)
                         path = os.environ.get("ALLO_EXTERNAL_KERNEL_DIR")
-                        if path is None or lib_dir != "aie2":
+                        if path is None:
                             kernel_header += f"#define DIM_M {M}\n"
                             kernel_header += f"#define DIM_N {N}\n"
                             kernel_header += f"#define DIM_K {K}\n"
@@ -718,7 +718,7 @@ def codegen_external_kernels(
                 kernel_file_code += mm_kernel
         elif "mm.cc" in src:  # this file is too large to be included
             path = os.environ.get("ALLO_EXTERNAL_KERNEL_DIR")
-            if path is None or lib_dir != "aie2":
+            if path is None:
                 path = os.path.expandvars(
                     f"$MLIR_AIE_EXTERNAL_KERNEL_DIR/{lib_dir}/mm.cc"
                 )
@@ -729,7 +729,11 @@ def codegen_external_kernels(
                         pattern, f'#include "{lib_dir}/zero.cc"', mm_kernel
                     )
             else:
-                with open(f"{path}/mm.cc", "r", encoding="utf-8") as f:
+                with open(
+                    f"{path}/mm{"" if lib_dir == "aie2" else f"_{lib_dir}"}.cc",
+                    "r",
+                    encoding="utf-8",
+                ) as f:
                     mm_kernel = f.read()
             kernel_file_code += mm_kernel
         else:

--- a/allo/library/aie/kernels/mm_aie2p.cc
+++ b/allo/library/aie/kernels/mm_aie2p.cc
@@ -1,0 +1,446 @@
+/*
+ * Copyright Allo authors. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This file is modified from:
+ *   https://github.com/Xilinx/mlir-aie/blob/v1.1.0/aie_kernels/aie2p/mm.cc
+ *
+ * Acknowledgements:
+ *   - This file is adapted from the MLIR-AIE project by Xilinx.
+ *   - We thank the original authors for their contributions and for releasing
+ *     their work under the Apache 2.0 License with LLVM Exceptions.
+ *
+ * Notes:
+ *   - The modifications include adding reference and acknowledgement
+ * statements, as well as project-specific adjustments for Allo.
+ */
+
+//===- mm.cc ----------------------------------------------000---*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2025, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+#define NOCPP
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#define REL_WRITE 0
+#define REL_READ 1
+
+#include <aie_api/aie.hpp>
+
+template <typename T_in, typename T_out, int rowA, int colA, int colB,
+          bool b_row_maj = true, bool c_row_maj = true>
+static inline void matmul_scalar(T_in *a, T_in *b, T_out *c) {
+  event0();
+  for (int row = 0; row < rowA; row++) {
+    for (int col = 0; col < colB; col++) {
+      T_out running_sum = 0;
+      for (int i = 0; i < colA; i++) {
+        T_in a_val = a[row * colA + i];
+        T_in b_val;
+        if constexpr (b_row_maj) {
+          b_val = b[i * colB + col];
+        } else {
+          b_val = b[i + col * colA];
+        }
+        running_sum += a_val * b_val;
+      }
+      T_out *c_ptr;
+      if constexpr (c_row_maj) {
+        c_ptr = &c[row * colB + col];
+      } else {
+        c_ptr = &c[row + col * rowA];
+      }
+      *c_ptr += running_sum;
+    }
+  }
+  event1();
+}
+
+/* Blocked MatMul kernel (vectorized) utilizing the aie::mmul class.
+ * The matrices are assumed to be pre-tiled with the following shapes
+ * for the aie:mmul class: A => rxs, B => sxt, C => rxt.
+ *
+ * The matrix dimensions of the kernel are defined by rowA, colA and colB.
+ * In this particular kernel we expand the aie::mmul two times in each
+ * input matrices A (in 'm' dimension, or rowA) and B (in 'n' dimension, or
+ * ColB), leading to a 2x2 expansion in output matrix C (see C00, C01, C10, C11
+ * below). This expansion helps with accumulator registers usage, which leads in
+ * attaining high kernel efficiency (SIMD utilization).
+ *
+ * Data within each tile (rxs, sxt and rxt) are assumed to be in row-major
+ * order. Also, the entire tiles themselves are stored in row-major order, as
+ * shown in the example below for matrix A:
+ *
+ *      <-s->
+ *    _  ________________________
+ * 	  r |  1 |  2 |  3 | ...
+ * 	  _ |____|____|____|
+ * 	    |  x | x+1| x+2| ...
+ * 	    |____|____|____|
+ * 	    |.
+ * 	    |.
+ * 	    |.
+ *
+ * A simplified example of this kernel can be found in the AIE-API
+ * documentation: https://xilinx.github.io/aie_api/group__group__mmul.html
+ */
+template <typename T_in, typename T_out, unsigned rowA, unsigned colA,
+          unsigned colB, unsigned r, unsigned s, unsigned t,
+          bool b_row_maj = true, bool c_row_maj = true>
+static inline void matmul_vectorized_2x2_mmul(const T_in *__restrict pA,
+                                              const T_in *__restrict pB,
+                                              T_out *__restrict pC) {
+
+  using MMUL = aie::mmul<r, s, t, T_in, T_in, accauto>;
+
+  event0();
+
+  for (unsigned z = 0; z < rowA; z += 2)
+    chess_prepare_for_pipelining chess_loop_range(4, ) {
+
+      T_out *__restrict pC1;
+      T_out *__restrict pC2;
+      if constexpr (c_row_maj) {
+        pC1 = pC + (z * colB) * MMUL::size_C;
+        pC2 = pC + ((z + 1) * colB) * MMUL::size_C;
+      }
+
+      for (unsigned j = 0; j < colB; j += 2)
+#ifdef OPT_PERF_ENABLED
+        chess_flatten_loop
+#endif
+        {
+
+          if constexpr (!c_row_maj) {
+            pC1 = pC + j * rowA * MMUL::size_C + z * MMUL::size_C;
+            pC2 = pC + (j + 1) * rowA * MMUL::size_C + z * MMUL::size_C;
+          }
+          const T_in *__restrict pA1 = pA + (z * colA) * MMUL::size_A;
+          const T_in *__restrict pA2 = pA + ((z + 1) * colA) * MMUL::size_A;
+          const T_in *__restrict pB1;
+          const T_in *__restrict pB2;
+          if constexpr (b_row_maj) {
+            pB1 = pB + (j)*MMUL::size_B;
+            pB2 = pB + (j + 1) * MMUL::size_B;
+          } else {
+            pB1 = pB + (j * colA) * MMUL::size_B;
+            pB2 = pB + ((j + 1) * colA) * MMUL::size_B;
+          }
+
+          aie::vector<T_in, MMUL::size_A> A0;
+          aie::vector<T_in, MMUL::size_A> A1;
+          aie::vector<T_in, MMUL::size_B> B0;
+          aie::vector<T_in, MMUL::size_B> B1;
+
+          // Load partial results from C buffer for accumulation in-place. The
+          // zero.cc function handles the zeroing of data when a new
+          // accumulation is needed (after the 'K' reduction dimension)
+          aie::vector<T_out, MMUL::size_C> acc_C00;
+          aie::vector<T_out, MMUL::size_C> acc_C01;
+          aie::vector<T_out, MMUL::size_C> acc_C10;
+          aie::vector<T_out, MMUL::size_C> acc_C11;
+          if constexpr (c_row_maj) {
+            acc_C00 = aie::load_v<MMUL::size_C>(pC1);
+            acc_C01 = aie::load_v<MMUL::size_C>(pC1 + MMUL::size_C);
+            acc_C10 = aie::load_v<MMUL::size_C>(pC2);
+            acc_C11 = aie::load_v<MMUL::size_C>(pC2 + MMUL::size_C);
+          } else {
+            acc_C00 = aie::transpose(aie::load_v<MMUL::size_C>(pC1), t, r);
+            acc_C01 = aie::transpose(aie::load_v<MMUL::size_C>(pC2), t, r);
+            acc_C10 = aie::transpose(
+                aie::load_v<MMUL::size_C>(pC1 + MMUL::size_C), t, r);
+            acc_C11 = aie::transpose(
+                aie::load_v<MMUL::size_C>(pC2 + MMUL::size_C), t, r);
+          }
+
+          MMUL C00(acc_C00);
+          MMUL C01(acc_C01);
+          MMUL C10(acc_C10);
+          MMUL C11(acc_C11);
+
+          for (unsigned i = 0; i < colA; ++i)
+#ifdef OPT_PERF_ENABLED
+            chess_flatten_loop
+#endif
+            {
+              A0 = aie::load_v<MMUL::size_A>(pA1);
+              pA1 += MMUL::size_A;
+              A1 = aie::load_v<MMUL::size_A>(pA2);
+              pA2 += MMUL::size_A;
+              if constexpr (b_row_maj) {
+                B0 = aie::load_v<MMUL::size_B>(pB1);
+                pB1 += MMUL::size_B * colB;
+                B1 = aie::load_v<MMUL::size_B>(pB2);
+                pB2 += MMUL::size_B * colB;
+              } else {
+                B0 = aie::transpose(aie::load_v<MMUL::size_B>(pB1), t, s);
+                pB1 += MMUL::size_B;
+                B1 = aie::transpose(aie::load_v<MMUL::size_B>(pB2), t, s);
+                pB2 += MMUL::size_B;
+              }
+
+              C00.mac(A0, B0);
+              C01.mac(A0, B1);
+              C10.mac(A1, B0);
+              C11.mac(A1, B1);
+            }
+
+          // TODO make shift right here to keep most significat bits
+          // when lowering the output
+          // example below shows how to shift right 10 bits
+          // #define SHIFT 10
+          // aie::store_v(pC1, C00.template to_vector<T_out>(SHIFT));
+
+          if constexpr (c_row_maj) {
+            aie::store_v(pC1, C00.template to_vector<T_out>());
+            pC1 += MMUL::size_C;
+            aie::store_v(pC1, C01.template to_vector<T_out>());
+            pC1 += MMUL::size_C;
+            aie::store_v(pC2, C10.template to_vector<T_out>());
+            pC2 += MMUL::size_C;
+            aie::store_v(pC2, C11.template to_vector<T_out>());
+            pC2 += MMUL::size_C;
+          } else {
+            aie::store_v(pC1,
+                         aie::transpose(C00.template to_vector<T_out>(), r, t));
+            pC1 += MMUL::size_C;
+            aie::store_v(pC2,
+                         aie::transpose(C01.template to_vector<T_out>(), r, t));
+            pC2 += MMUL::size_C;
+            aie::store_v(pC1,
+                         aie::transpose(C10.template to_vector<T_out>(), r, t));
+            pC1 += MMUL::size_C;
+            aie::store_v(pC2,
+                         aie::transpose(C11.template to_vector<T_out>(), r, t));
+            pC2 += MMUL::size_C;
+          }
+        }
+    }
+
+  event1();
+}
+
+#ifdef B_COL_MAJ
+constexpr bool is_b_row_maj = false;
+#else
+constexpr bool is_b_row_maj = true;
+#endif
+
+#ifdef C_COL_MAJ
+constexpr bool is_c_row_maj = false;
+#else
+constexpr bool is_c_row_maj = true;
+#endif
+
+// The following kernel definitions use mmul shapes that have been found to be
+// optimal for AIE2P in combination with the 2x2 mmul expanded kernel.
+//
+// All available matrix multiplication shapes in the AIE-API can be found here:
+// https://xilinx.github.io/aie_api/group__group__mmul.html
+//
+// They are all defined based on the shape of the mmul, the input data format
+// and the output data format.
+//
+// Additionally, they check for the correct
+// divisibility of the tile dimensions. Note that while both the 'm' and 'n'
+// dimensions of the mmul are expanded, the 'k' dimension is not.
+
+template <unsigned m, unsigned k, unsigned n>
+static inline void matmul_vectorized_4x4x8_i16_i16(const int16 *__restrict pA,
+                                                   const int16 *__restrict pB,
+                                                   int16 *__restrict pC) {
+  constexpr int r = 4;
+  constexpr int s = 4;
+  constexpr int t = 8;
+
+  static_assert(m % (2 * r) == 0);
+  static_assert(k % s == 0);
+  static_assert(n % (2 * t) == 0);
+
+  return matmul_vectorized_2x2_mmul<int16, int16, (m / r), (k / s), (n / t), r,
+                                    s, t, is_b_row_maj, is_c_row_maj>(pA, pB,
+                                                                      pC);
+}
+
+template <unsigned m, unsigned k, unsigned n>
+static inline void matmul_vectorized_4x4x8_i16_i32(const int16 *__restrict pA,
+                                                   const int16 *__restrict pB,
+                                                   int32 *__restrict pC) {
+  constexpr int r = 4;
+  constexpr int s = 4;
+  constexpr int t = 8;
+
+  static_assert(m % (2 * r) == 0);
+  static_assert(k % s == 0);
+  static_assert(n % (2 * t) == 0);
+
+  return matmul_vectorized_2x2_mmul<int16, int32, (m / r), (k / s), (n / t), r,
+                                    s, t, is_b_row_maj, is_c_row_maj>(pA, pB,
+                                                                      pC);
+}
+
+template <unsigned m, unsigned k, unsigned n>
+static inline void
+matmul_vectorized_4x8x8_bf16_bf16(const bfloat16 *__restrict pA,
+                                  const bfloat16 *__restrict pB,
+                                  bfloat16 *__restrict pC) {
+  constexpr int r = 4;
+  constexpr int s = 8;
+  constexpr int t = 8;
+
+  static_assert(m % (2 * r) == 0);
+  static_assert(k % s == 0);
+  static_assert(n % (2 * t) == 0);
+
+  return matmul_vectorized_2x2_mmul<bfloat16, bfloat16, (m / r), (k / s),
+                                    (n / t), r, s, t, is_b_row_maj,
+                                    is_c_row_maj>(pA, pB, pC);
+}
+
+// Note that this shape is only possible for bf16 when using bfp16 emulation
+// during matmuls.
+template <unsigned m, unsigned k, unsigned n>
+static inline void
+matmul_vectorized_8x8x8_bf16_bf16(const bfloat16 *__restrict pA,
+                                  const bfloat16 *__restrict pB,
+                                  bfloat16 *__restrict pC) {
+  constexpr int r = 8;
+  constexpr int s = 8;
+  constexpr int t = 8;
+
+  static_assert(m % (2 * r) == 0);
+  static_assert(k % s == 0);
+  static_assert(n % (2 * t) == 0);
+
+  return matmul_vectorized_2x2_mmul<bfloat16, bfloat16, (m / r), (k / s),
+                                    (n / t), r, s, t, is_b_row_maj,
+                                    is_c_row_maj>(pA, pB, pC);
+}
+
+template <unsigned m, unsigned k, unsigned n>
+static inline void
+matmul_vectorized_4x8x8_bf16_f32(const bfloat16 *__restrict pA,
+                                 const bfloat16 *__restrict pB,
+                                 float *__restrict pC) {
+  constexpr int r = 4;
+  constexpr int s = 8;
+  constexpr int t = 8;
+
+  static_assert(m % (2 * r) == 0);
+  static_assert(k % s == 0);
+  static_assert(n % (2 * t) == 0);
+
+  return matmul_vectorized_2x2_mmul<bfloat16, float, (m / r), (k / s), (n / t),
+                                    r, s, t, is_b_row_maj, is_c_row_maj>(pA, pB,
+                                                                         pC);
+}
+
+template <unsigned m, unsigned k, unsigned n>
+static inline void
+matmul_vectorized_8x8x8_bf16_f32(const bfloat16 *__restrict pA,
+                                 const bfloat16 *__restrict pB,
+                                 float *__restrict pC) {
+  constexpr int r = 8;
+  constexpr int s = 8;
+  constexpr int t = 8;
+
+  static_assert(m % (2 * r) == 0);
+  static_assert(k % s == 0);
+  static_assert(n % (2 * t) == 0);
+
+  return matmul_vectorized_2x2_mmul<bfloat16, float, (m / r), (k / s), (n / t),
+                                    r, s, t, is_b_row_maj, is_c_row_maj>(pA, pB,
+                                                                         pC);
+}
+
+template <unsigned m, unsigned k, unsigned n>
+static inline void matmul_vectorized_8x8x8_i8_i8(const int8 *__restrict pA,
+                                                 const int8 *__restrict pB,
+                                                 int8 *__restrict pC) {
+  constexpr int r = 8;
+  constexpr int s = 8;
+  constexpr int t = 8;
+
+  static_assert(m % (2 * r) == 0);
+  static_assert(k % s == 0);
+  static_assert(n % (2 * t) == 0);
+
+  return matmul_vectorized_2x2_mmul<int8, int8, (m / r), (k / s), (n / t), r, s,
+                                    t, is_b_row_maj, is_c_row_maj>(pA, pB, pC);
+}
+
+template <unsigned m, unsigned k, unsigned n>
+static inline void matmul_vectorized_8x8x8_i8_i16(const int8 *__restrict pA,
+                                                  const int8 *__restrict pB,
+                                                  int16 *__restrict pC) {
+  constexpr int r = 8;
+  constexpr int s = 8;
+  constexpr int t = 8;
+
+  static_assert(m % (2 * r) == 0);
+  static_assert(k % s == 0);
+  static_assert(n % (2 * t) == 0);
+
+  return matmul_vectorized_2x2_mmul<int8, int16, (m / r), (k / s), (n / t), r,
+                                    s, t, is_b_row_maj, is_c_row_maj>(pA, pB,
+                                                                      pC);
+}
+
+template <unsigned m, unsigned k, unsigned n>
+static inline void matmul_vectorized_8x8x8_i8_i32(const int8 *__restrict pA,
+                                                  const int8 *__restrict pB,
+                                                  int32 *__restrict pC) {
+  constexpr int r = 8;
+  constexpr int s = 8;
+  constexpr int t = 8;
+
+  static_assert(m % (2 * r) == 0);
+  static_assert(k % s == 0);
+  static_assert(n % (2 * t) == 0);
+
+  return matmul_vectorized_2x2_mmul<int8, int32, (m / r), (k / s), (n / t), r,
+                                    s, t, is_b_row_maj, is_c_row_maj>(pA, pB,
+                                                                      pC);
+}
+
+#define CAT(a, b) a##b
+#define CAT3(a, b, c) a##b##c
+#define CAT5(a, b, c, d, e) a##b##c##d##e
+#define EXPAND_AND_CAT(a, b) CAT(a, b)
+#define EXPAND_AND_CAT3(a, b, c) CAT3(a, b, c)
+#define EXPAND_AND_CAT5(a, b, c, d, e) CAT5(a, b, c, d, e)
+
+#define GEN_VECTOR_FUNC_NAME(type_in, type_out, m, k, n)                       \
+  EXPAND_AND_CAT5(matmul_##type_in##_##type_out##_, m, x, k,                   \
+                  EXPAND_AND_CAT(x, n))
+
+#define GEN_SCALAR_FUNC_NAME(type_in, type_out, m, k, n)                       \
+  EXPAND_AND_CAT5(matmul_scalar_##type_in##_##type_out##_, m, x, k,            \
+                  EXPAND_AND_CAT(x, n))
+
+#define matmul_vectorized_c_func(ctype_in, mlir_type_in, ctype_out,            \
+                                 mlir_type_out, r, s, t, DIM_M_, DIM_K_,       \
+                                 DIM_N_)                                       \
+  void GEN_VECTOR_FUNC_NAME(mlir_type_in, mlir_type_out, DIM_M_, DIM_K_,       \
+                            DIM_N_)(ctype_in * a_in, ctype_in * b_in,          \
+                                    ctype_out * c_out) {                       \
+    matmul_vectorized_##r##x##s##x##t##_##mlir_type_in##_##mlir_type_out<      \
+        DIM_M_, DIM_K_, DIM_N_>(a_in, b_in, c_out);                            \
+  }
+
+#define matmul_scalar_c_func(ctype_in, mlir_type_in, ctype_out, mlir_type_out, \
+                             r, s, t, DIM_M_, DIM_K_, DIM_N_)                  \
+  void GEN_SCALAR_FUNC_NAME(mlir_type_in, mlir_type_out, DIM_M_, DIM_K_,       \
+                            DIM_N_)(ctype_in * a_in, ctype_in * b_in,          \
+                                    ctype_out * c_out) {                       \
+    matmul_scalar<ctype_in, ctype_out, DIM_M_, DIM_K_, DIM_N_, is_b_row_maj,   \
+                  is_c_row_maj>(a_in, b_in, c_out);                            \
+  }

--- a/allo/library/aie/kernels/softmax_bf16.cc
+++ b/allo/library/aie/kernels/softmax_bf16.cc
@@ -613,6 +613,65 @@ void init_softmax(bfloat16 *__restrict max_logit,
   }
 }
 
+// Numerically-stable 1D softmax of length N.
+//  Pass 1: m = max_i x_i
+//  Pass 2: write (x_i - m) into the output buffer (buffer intermediate results)
+//  Pass 3: in-place LUT-based exp via fa_exp_bf16, returning S = sum exp.
+//  Pass 4: y_i = exp_i / S.
+template <int N>
+void softmax_simple_bf16(bfloat16 *__restrict input_vector,
+                         bfloat16 *__restrict output_vector) {
+  constexpr int VecLen = 16;
+  static_assert(N % VecLen == 0);
+
+  // Pass 1: global max of the input.
+  uint16 neg_inf_u16 = (uint16)0xff80;
+  bfloat16 *bf_neg_inf = (bfloat16 *)&neg_inf_u16;
+  aie::vector<bfloat16, VecLen> max_vec =
+      aie::broadcast<bfloat16, VecLen>(*bf_neg_inf);
+  bfloat16 *pScan = input_vector;
+  for (int i = 0; i < N / VecLen; i++)
+    chess_prepare_for_pipelining chess_loop_range(4, ) {
+      aie::vector<bfloat16, VecLen> v = aie::load_v<VecLen>(pScan);
+      pScan += VecLen;
+      max_vec = aie::max(max_vec, v);
+    }
+  bfloat16 max_val = aie::reduce_max(max_vec);
+  aie::vector<bfloat16, VecLen> max_bcast = aie::broadcast<bfloat16, VecLen>(max_val);
+
+  // Pass 2: store (input - max) into the output buffer (scratch).
+  aie::accum<accfloat, VecLen> max_acc;
+  max_acc.from_vector(max_bcast, 0);
+  bfloat16 *pIn = input_vector;
+  bfloat16 *pShift = output_vector;
+  for (int i = 0; i < N / VecLen; i++)
+    chess_prepare_for_pipelining chess_loop_range(4, ) {
+      aie::vector<bfloat16, VecLen> v = aie::load_v<VecLen>(pIn);
+      pIn += VecLen;
+      aie::accum<accfloat, VecLen> v_acc, diff_acc;
+      v_acc.from_vector(v, 0);
+      diff_acc = sub(v_acc, max_acc);
+      aie::store_v(pShift, diff_acc.template to_vector<bfloat16>());
+      pShift += VecLen;
+    }
+
+  // Pass 3: in-place LUT exp on the shifted values, returns sum.
+  const bfloat16 *__restrict pExpIn = output_vector;
+  bfloat16 *__restrict pExpOut = output_vector;
+  float accum_exp_val = fa_exp_bf16<VecLen>(N, pExpIn, pExpOut);
+
+  // Pass 4: scale by 1 / sum.
+  bfloat16 accum_inv = compute_inv_as_bf16(accum_exp_val);
+  bfloat16 *pOut = output_vector;
+  for (int i = 0; i < N / VecLen; i++)
+    chess_prepare_for_pipelining chess_loop_range(4, ) {
+      aie::vector<bfloat16, VecLen> v = aie::load_v<VecLen>(pOut);
+      aie::accum<accfloat, VecLen> scaled = aie::mul(v, accum_inv);
+      aie::store_v(pOut, scaled.template to_vector<bfloat16>());
+      pOut += VecLen;
+    }
+}
+
 extern "C" {
 
 void init_softmax(bfloat16 max_logit[32], bfloat16 sum_exp[32]) {
@@ -684,4 +743,9 @@ void softmax_bf16(const bfloat16 in[4][1024], bfloat16 out[4][1024]) {
       }
   }
 }
+
+void vector_softmax_bf16(bfloat16 a_in[1024], bfloat16 c_out[1024]) {
+  softmax_simple_bf16<1024>(a_in, c_out);
+}
+
 }

--- a/allo/library/aie/kernels/softmax_bf16.cc
+++ b/allo/library/aie/kernels/softmax_bf16.cc
@@ -637,7 +637,8 @@ void softmax_simple_bf16(bfloat16 *__restrict input_vector,
       max_vec = aie::max(max_vec, v);
     }
   bfloat16 max_val = aie::reduce_max(max_vec);
-  aie::vector<bfloat16, VecLen> max_bcast = aie::broadcast<bfloat16, VecLen>(max_val);
+  aie::vector<bfloat16, VecLen> max_bcast =
+      aie::broadcast<bfloat16, VecLen>(max_val);
 
   // Pass 2: store (input - max) into the output buffer (scratch).
   aie::accum<accfloat, VecLen> max_acc;
@@ -747,5 +748,4 @@ void softmax_bf16(const bfloat16 in[4][1024], bfloat16 out[4][1024]) {
 void vector_softmax_bf16(bfloat16 a_in[1024], bfloat16 c_out[1024]) {
   softmax_simple_bf16<1024>(a_in, c_out);
 }
-
 }

--- a/allo/library/aie/kernels/softmax_bf16_aie2p.cc
+++ b/allo/library/aie/kernels/softmax_bf16_aie2p.cc
@@ -116,6 +116,27 @@ void softmax_simple_bf16(bfloat16 *restrict input_vector,
   return;
 }
 
+template <int L>
+void init_softmax(bfloat16 *__restrict max_logit,
+                  bfloat16 *__restrict sum_exp) {
+  // max_logit = np.full((L, 1), -np.inf)
+  // sum_exp = np.zeros((L, 1))
+  constexpr int vec_factor =
+      256 / (sizeof(bfloat16) * 8); // one 256 bit store unit
+  static_assert(L % vec_factor == 0);
+  const bfloat16 neg_inf = bfloat16(-std::numeric_limits<float>::infinity());
+  const aie::vector<bfloat16, vec_factor> neg_infs =
+      aie::broadcast<bfloat16, vec_factor>(neg_inf);
+  const aie::vector<bfloat16, vec_factor> zeros =
+      aie::zeros<bfloat16, vec_factor>();
+  for (int iter = 0; iter < L; iter += vec_factor) {
+    aie::store_v(max_logit, neg_infs);
+    max_logit += vec_factor;
+    aie::store_v(sum_exp, zeros);
+    sum_exp += vec_factor;
+  }
+}
+
 extern "C" {
 
 void exp_bf16(bfloat16 a_in[1024], bfloat16 c_out[1024]) {
@@ -124,6 +145,68 @@ void exp_bf16(bfloat16 a_in[1024], bfloat16 c_out[1024]) {
 
 void vector_softmax_bf16(bfloat16 a_in[1024], bfloat16 c_out[1024]) {
   softmax_simple_bf16<1024>(a_in, c_out);
+}
+
+void init_softmax(bfloat16 max_logit[32], bfloat16 sum_exp[32]) {
+  init_softmax<32>(max_logit, sum_exp);
+}
+
+void online_softmax(bfloat16 attention_score[32][32],
+                    bfloat16 prev_max_logit[32], bfloat16 prev_sum_exp[32],
+                    bfloat16 attention_weight[32][32], bfloat16 scale_exp[32],
+                    bfloat16 new_max_logit[32], bfloat16 new_sum_exp[32]) {
+  constexpr int ROW = 32;
+  constexpr int COL = 32; // == VEC_LEN, one row per vector
+  const bfloat16 scale = bfloat16(0.125f);
+  aie::vector<bfloat16, VEC_LEN> log2e_vec =
+      aie::broadcast<bfloat16, VEC_LEN>((bfloat16)log2e);
+
+  alignas(aie::vector_decl_align) bfloat16 tmp_max_logit[ROW];
+
+  // Pass 1: row max + write (scores * 0.125 - row_max) back into
+  // attention_score
+  for (int r = 0; r < ROW; r++) {
+    bfloat16 *row_ptr = &attention_score[r][0];
+    aie::vector<bfloat16, COL> scores = aie::load_v<COL>(row_ptr);
+    aie::accum<accfloat, COL> scaled = aie::mul(scores, scale);
+    aie::vector<bfloat16, COL> scaled_vec =
+        scaled.template to_vector<bfloat16>();
+    bfloat16 row_max = std::max(prev_max_logit[r], aie::reduce_max(scaled_vec));
+
+    tmp_max_logit[r] = bfloat16(prev_max_logit[r] - row_max);
+    new_max_logit[r] = row_max;
+
+    aie::vector<bfloat16, COL> row_max_vec =
+        aie::broadcast<bfloat16, COL>(row_max);
+    aie::accum<accfloat, COL> shifted = aie::sub(scaled, row_max_vec);
+    aie::store_v(row_ptr, shifted.template to_vector<bfloat16>());
+  }
+
+  // Pass 2: scale_exp[0..32) = exp(tmp_max_logit) via 2^(log2e * x)
+  {
+    aie::vector<bfloat16, COL> v = aie::load_v<COL>(&tmp_max_logit[0]);
+    aie::accum<accfloat, COL> z = aie::mul(v, log2e_vec);
+    aie::vector<bfloat16, COL> e =
+        aie::exp2<bfloat16>(z.template to_vector<float>());
+    aie::store_v(&scale_exp[0], e);
+  }
+
+  // Pass 3: per-row exp, sum, and new_sum_exp update
+  for (int r = 0; r < ROW; r++) {
+    aie::vector<bfloat16, COL> shifted =
+        aie::load_v<COL>(&attention_score[r][0]);
+    aie::accum<accfloat, COL> z = aie::mul(shifted, log2e_vec);
+    aie::vector<bfloat16, COL> exp_val =
+        aie::exp2<bfloat16>(z.template to_vector<float>());
+    aie::store_v(&attention_weight[r][0], exp_val);
+
+    aie::accum<accfloat, COL> sum_acc;
+    sum_acc.from_vector(exp_val, 0);
+    float accum_exp_val = aie::reduce_add(sum_acc.template to_vector<float>());
+
+    new_sum_exp[r] =
+        bfloat16(prev_sum_exp[r] * scale_exp[r] + bfloat16(accum_exp_val));
+  }
 }
 
 } // extern "C"

--- a/allo/library/aie/kernels/softmax_bf16_aie2p.cc
+++ b/allo/library/aie/kernels/softmax_bf16_aie2p.cc
@@ -1,13 +1,8 @@
-//===- bf16_exp.cc ---------------------------*- C++-----*-===//
-//
-// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-// Copyright (C) 2025, Advanced Micro Devices, Inc.
-//
-//===-----------------------------------------------------===//
-
+/*
+ * Copyright Allo authors. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+ 
 #include <aie_api/aie.hpp>
 #include <stdint.h>
 

--- a/allo/library/aie/kernels/softmax_bf16_aie2p.cc
+++ b/allo/library/aie/kernels/softmax_bf16_aie2p.cc
@@ -1,0 +1,129 @@
+//===- bf16_exp.cc ---------------------------*- C++-----*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2025, Advanced Micro Devices, Inc.
+//
+//===-----------------------------------------------------===//
+
+#include <aie_api/aie.hpp>
+#include <stdint.h>
+
+#define VEC_LEN 32
+#define log2e 1.44269504089
+
+using namespace aie;
+
+template <const int N>
+void exp_bf16_func(bfloat16 *restrict in, bfloat16 *restrict out) {
+  auto it_exp_in = aie::cbegin_vector<VEC_LEN>((bfloat16 *)in);
+  auto it_exp_out = aie::begin_vector<VEC_LEN>((bfloat16 *)out);
+
+  const int elem_iters = N / VEC_LEN;
+
+  // Calculate the e^(x) function as 2^(log2e * x)
+  aie::vector<bfloat16, VEC_LEN> input_bf16;
+  aie::accum<accfloat, VEC_LEN> exp_in;
+  aie::vector<bfloat16, VEC_LEN> exp_val;
+  aie::vector<bfloat16, VEC_LEN> log2e_vec =
+      aie::broadcast<bfloat16, VEC_LEN>(log2e);
+
+  for (int i = 0; i < elem_iters; i++) {
+    input_bf16 = *it_exp_in++;
+    exp_in = aie::mul(input_bf16, log2e_vec);
+    exp_val = aie::exp2<bfloat16>(exp_in.to_vector<float>());
+    *it_exp_out++ = exp_val;
+  }
+}
+
+template <const int N>
+void softmax_simple_bf16(bfloat16 *restrict input_vector,
+                         bfloat16 *restrict output_vector) {
+  event0();
+  // VJUNG: We do 3 passes on the vector:
+  // 1. Find the max value scaled by log2e in the vector
+  // 2. Calculate the exponentials of the scaled values minus the maximum
+  // 3. Calculate the softmax by dividing each exponential by the sum of all
+  // exponentials Note: The multiplication by log2e is very sensitive, casting
+  // it to bf16 before exponentiation leads to wrong output.
+  auto it_log_in =
+      aie::cbegin_restrict_vector<VEC_LEN>((bfloat16 *)input_vector);
+  auto it_log_out =
+      aie::begin_restrict_vector<VEC_LEN>((bfloat16 *)input_vector);
+  auto it_exp_in =
+      aie::cbegin_restrict_vector<VEC_LEN>((bfloat16 *)input_vector);
+  auto it_exp_out =
+      aie::begin_restrict_vector<VEC_LEN>((bfloat16 *)output_vector);
+  auto it_scale =
+      aie::cbegin_restrict_vector<VEC_LEN>((bfloat16 *)output_vector);
+  auto it_soft_out =
+      aie::begin_restrict_vector<VEC_LEN>((bfloat16 *)output_vector);
+
+  aie::vector<bfloat16, VEC_LEN> in_elems, exp_val, input_bf16, log2e_vec,
+      max_val_vec;
+  aie::accum<accfloat, VEC_LEN> out_vals, exp_val_accum, scaled_accum,
+      exp_in_accum;
+
+  float max_val = 0;
+  float accum_exp_val = 0;
+  float running_max = 0;
+  bfloat16 col_sum_inv;
+  const int elem_iters = N / VEC_LEN;
+
+  exp_val_accum = aie::zeros<accfloat, VEC_LEN>();
+
+  log2e_vec = aie::broadcast<bfloat16, VEC_LEN>((bfloat16)log2e);
+
+  // First pass - Optimized: element-wise max + single final reduce_max
+  // Use vector max accumulation, then reduce once at the end
+  aie::vector<bfloat16, VEC_LEN> max_accum_vec =
+      aie::broadcast<bfloat16, VEC_LEN>((bfloat16)-32768.0f);
+  for (int i = 0; i < elem_iters; i++) {
+    input_bf16 = *it_log_in++;
+    scaled_accum = aie::mul(input_bf16, log2e_vec);
+    max_accum_vec = aie::max(max_accum_vec, scaled_accum.to_vector<bfloat16>());
+  }
+  max_val = aie::reduce_max(max_accum_vec);
+  max_val_vec = aie::broadcast<bfloat16, VEC_LEN>(max_val);
+
+  // Second pass
+  for (int i = 0; i < elem_iters; i++) {
+
+    input_bf16 = *it_exp_in++;
+
+    scaled_accum = aie::mul(input_bf16, log2e_vec);
+    exp_in_accum = aie::sub(scaled_accum, max_val_vec);
+    exp_val = aie::exp2<bfloat16>(exp_in_accum.to_vector<float>());
+    exp_val_accum = add(exp_val_accum, exp_val);
+
+    *it_exp_out++ = exp_val;
+  }
+
+  // Final reduction after loop
+  aie::vector<float, VEC_LEN> reduce = exp_val_accum.to_vector<float>();
+  accum_exp_val = aie::reduce_add(reduce);
+  col_sum_inv = (bfloat16)aie::inv(accum_exp_val);
+
+  for (int c = 0; c < elem_iters; c++) {
+    in_elems = *it_scale++;
+    out_vals = aie::mul(in_elems, col_sum_inv);
+    *it_soft_out++ = out_vals.to_vector<bfloat16>();
+  }
+
+  event1();
+  return;
+}
+
+extern "C" {
+
+void exp_bf16(bfloat16 a_in[1024], bfloat16 c_out[1024]) {
+  exp_bf16_func<1024>(a_in, c_out);
+}
+
+void vector_softmax_bf16(bfloat16 a_in[1024], bfloat16 c_out[1024]) {
+  softmax_simple_bf16<1024>(a_in, c_out);
+}
+
+} // extern "C"

--- a/allo/library/aie/modules/flash_attn.py
+++ b/allo/library/aie/modules/flash_attn.py
@@ -161,7 +161,7 @@ def FA(SEQ_LEN, HEAD_DIM, Q_tile_size, q_chunk_size, kv_chunk_size):
                 ("chain", [f"send_q_{idx}_0", f"cal_attn_score_{idx}_0"])
             )
             sub_graphs.append((f"send_q_{idx}_0-cal_attn_score_{idx}_0",))
-    col_num = 4
+    col_num = 8 if os.getenv("NPU2") == "1" else 4
     if iteration > col_num:
         for idx in range(col_num):
             nodes = [sub_graphs[idx + i * col_num] for i in range(iteration // col_num)]

--- a/allo/library/aie/modules/flash_attn.py
+++ b/allo/library/aie/modules/flash_attn.py
@@ -15,17 +15,20 @@ R = Layout.Replicate
 def FA(SEQ_LEN, HEAD_DIM, Q_tile_size, q_chunk_size, kv_chunk_size):
     KERNEL_LIB_PATH = os.getenv("ALLO_EXTERNAL_KERNEL_DIR")
     iteration = Q_tile_size // q_chunk_size
+    softmax_microkernel = (
+        "softmax_bf16_aie2p.cc" if os.getenv("NPU2") == "1" else "softmax_bf16.cc"
+    )
 
     init_softmax = ExternalModule(
         top="init_softmax",
-        impl_path=KERNEL_LIB_PATH + "softmax_bf16.cc",
+        impl_path=KERNEL_LIB_PATH + softmax_microkernel,
         input_idx=[],
         output_idx=[0, 1],
     )
 
     online_softmax = ExternalModule(
         top="online_softmax",
-        impl_path=KERNEL_LIB_PATH + "softmax_bf16.cc",
+        impl_path=KERNEL_LIB_PATH + softmax_microkernel,
         input_idx=[0, 1, 2],
         output_idx=[3, 4, 5, 6],
     )

--- a/tests/dataflow/aie/test_bf16_exp.py
+++ b/tests/dataflow/aie/test_bf16_exp.py
@@ -1,0 +1,100 @@
+# Copyright Allo authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+from allo.ir.types import bfloat16
+from ml_dtypes import bfloat16 as np_bfloat16
+import allo.dataflow as df
+import numpy as np
+from allo.backend.aie.external_kernel import ExternalModule
+from allo.backend.aie import is_available
+
+
+def test_exp():
+    dir_path = os.path.dirname(os.path.abspath(__file__))
+    kernel_path = os.path.abspath(
+        os.path.join(
+            dir_path, "../../../allo/library/aie/kernels/softmax_bf16_aie2p.cc"
+        )
+    )
+    exp_ = ExternalModule(
+        top="exp_bf16",
+        impl_path=kernel_path,
+        input_idx=[0],
+        output_idx=[1],
+    )
+
+    Ty = bfloat16
+    LEN = 1024
+
+    @df.region()
+    def top(A: Ty[LEN], B: Ty[LEN]):
+        @df.kernel(mapping=[1], args=[A, B])
+        def core(local_A: Ty[LEN], local_B: Ty[LEN]):
+            exp_(local_A, local_B)
+
+    A = (np.random.rand(LEN).astype(np.float32) * 4.0 - 2.0).astype(np_bfloat16)
+    ref = np.exp(A.astype(np.float32)).astype(np_bfloat16)
+
+    if os.getenv("NPU2") == "1" and is_available():
+        mod = df.build(top, target="aie")
+        B = np.zeros(LEN).astype(np_bfloat16)
+        mod(A, B)
+        np.testing.assert_allclose(
+            B.astype(np.float32), ref.astype(np.float32), rtol=8e-2
+        )
+        print("PASSED!")
+    else:
+        print("MLIR_AIE_INSTALL_DIR unset. Skipping AIE backend test.")
+
+
+def test_softmax():
+    dir_path = os.path.dirname(os.path.abspath(__file__))
+    if os.getenv("NPU2") == "1":
+        kernel_path = os.path.abspath(
+            os.path.join(
+                dir_path, "../../../allo/library/aie/kernels/softmax_bf16_aie2p.cc"
+            )
+        )
+    else:
+        kernel_path = os.path.abspath(
+            os.path.join(dir_path, "../../../allo/library/aie/kernels/softmax_bf16.cc")
+        )
+
+    softmax_ = ExternalModule(
+        top="vector_softmax_bf16",
+        impl_path=kernel_path,
+        input_idx=[0],
+        output_idx=[1],
+    )
+
+    Ty = bfloat16
+    LEN = 1024
+
+    @df.region()
+    def top(A: Ty[LEN], B: Ty[LEN]):
+        @df.kernel(mapping=[1], args=[A, B])
+        def core(local_A: Ty[LEN], local_B: Ty[LEN]):
+            softmax_(local_A, local_B)
+
+    # safe softmax
+    A = (np.random.rand(LEN).astype(np.float32) * 4.0 - 2.0).astype(np_bfloat16)
+    A_f32 = A.astype(np.float32)
+    shifted = np.exp(A_f32 - A_f32.max())
+    ref = (shifted / shifted.sum()).astype(np_bfloat16)
+
+    if os.getenv("NPU2") == "1" and is_available():
+        mod = df.build(top, target="aie")
+        B = np.zeros(LEN).astype(np_bfloat16)
+        mod(A, B)
+        np.testing.assert_allclose(
+            B.astype(np.float32), ref.astype(np.float32), rtol=8e-2, atol=1e-4
+        )
+        print("PASSED!")
+    else:
+        print("MLIR_AIE_INSTALL_DIR unset. Skipping AIE backend test.")
+
+
+if __name__ == "__main__":
+    test_exp()
+    test_softmax()


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
fixes #583 

### Proposed Solutions ###

- [x] fix configuration for bf16 matmul kernel on XDNA2
- [x] fix matmul kernel naming conflict (matmul with same data type but different matrix shape should use different name)
- [x] add `exp` and `softmax` microkernels to allo's kernel library
- [x] attention dataflow on `4x8`array 

- [ ] microkernel optimizations and dataflow optimizations


### Examples ###
(Please provide an example of the input program and the expected behavior, e.g., the generated IR.)


## Checklist ##

Please make sure to review and check all of these items:
- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [ ] All changes have test coverage (It would be good to provide ~2 different test cases to test the robustness of your code)
- [ ] Pass the [formatting check](https://cornell-zhang.github.io/allo/developer/index.html#id1) locally
- [ ] Code is well-documented
