### PR TITLE
[Fix][CI] Update CI runner labels

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build:
     # This job runs on Linux
-    runs-on: ace2
+    runs-on: [self-hosted, Linux]
     container:
       image: chhzh123/allo:latest
 


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
Updated the GitHub Actions workflow to use the standard `self-hosted` and `Linux` runner labels, replacing the unavailable `ace2` runner label.

## Checklist ##

Please make sure to review and check all of these items:
- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [ ] All changes have test coverage (It would be good to provide ~2 different test cases to test the robustness of your code)
- [ ] Pass the [formatting check](https://cornell-zhang.github.io/allo/developer/index.html#id1) locally
- [ ] Code is well-documented
