### PR TITLE
[Fix][Codegen][AIE] Fix Problematic Optimization on Stream Operations

### DIFF
--- a/.github/workflows/aie_weekly.yml
+++ b/.github/workflows/aie_weekly.yml
@@ -3,11 +3,8 @@
 
 name: "Allo AIE (XDNA1) Weekly Test"
 on:
-  pull_request:
-    branches:
-      - main
-  # schedule:
-  #   - cron: '0 8 * * 0' # Sunday 08:00 UTC 
+  schedule:
+    - cron: '0 8 * * 0' # Sunday 08:00 UTC 
 
 jobs:
   aie_test:

--- a/.github/workflows/aie_weekly.yml
+++ b/.github/workflows/aie_weekly.yml
@@ -3,8 +3,11 @@
 
 name: "Allo AIE (XDNA1) Weekly Test"
 on:
-  schedule:
-    - cron: '0 8 * * 0' # Sunday 08:00 UTC 
+  pull_request:
+    branches:
+      - main
+  # schedule:
+  #   - cron: '0 8 * * 0' # Sunday 08:00 UTC 
 
 jobs:
   aie_test:

--- a/allo/backend/aie/mlir_codegen.py
+++ b/allo/backend/aie/mlir_codegen.py
@@ -373,57 +373,9 @@ class CodeGenerator:
                                 if isinstance(fifo, tuple):
                                     fifo = fifo[0 if is_put else 1]
                                 if is_put:
-                                    if (
-                                        getattr(op, "name", None) == "memref.copy"
-                                        and len(list(op.operands[1].uses)) == 1
-                                    ):
-                                        alloc_op = op.operands[0].owner
-                                        # put once
-                                        if (
-                                            getattr(alloc_op, "name", None)
-                                            == "memref.alloc"
-                                        ):
-                                            uses = list(op.operands[0].uses)
-                                            with aie_ir.InsertionPoint(alloc_op):
-                                                acquired = fifo.acquire(0, 1)
-                                            for use in uses:
-                                                for i, v in enumerate(
-                                                    use.owner.operands
-                                                ):
-                                                    if (
-                                                        v.type == alloc_op.result.type
-                                                        and v == alloc_op.result
-                                                    ):
-                                                        use.owner.operands[i] = acquired
-                                            with aie_ir.InsertionPoint.at_block_terminator(
-                                                alloc_op.parent.regions[0].blocks[0]
-                                            ):
-                                                fifo.release(0, 1)
-                                            op.erase()
-                                            alloc_op.erase()
-                                            continue
                                     op.operands[1] = fifo.acquire(0, 1)
                                     new_op = op.clone()  # no use, no need to replace
                                     fifo.release(0, 1)
-                                elif is_tensor and len(list(op.operands[0].uses)) == 1:
-                                    # an optimize to reduce memref.copy
-                                    # get once
-                                    replaced = op.operands[1]
-                                    uses = list(replaced.uses)
-                                    with aie_ir.InsertionPoint(op):
-                                        acquired = fifo.acquire(1, 1)
-                                    for use in uses:
-                                        for i, v in enumerate(use.owner.operands):
-                                            if (
-                                                v.type == replaced.type
-                                                and v == replaced
-                                            ):
-                                                use.owner.operands[i] = acquired
-
-                                    with aie_ir.InsertionPoint.at_block_terminator(
-                                        op.parent.regions[0].blocks[0]
-                                    ):
-                                        fifo.release(1, 1)
                                 else:
                                     acquired = fifo.acquire(1, 1)
                                     op.operands[0] = acquired

--- a/allo/backend/aie/mlir_codegen.py
+++ b/allo/backend/aie/mlir_codegen.py
@@ -442,14 +442,13 @@ class CodeGenerator:
             for fifo_name, args in inter_ct_fifo.items():
                 fifo = self.fifo_map[fifo_name]
                 uses = []
-                is_put, is_tensor = None, None
                 for arg in args:
                     uses_ = list(arg.uses)
-                    if is_put is None:
-                        is_put, is_tensor = check_stream_op_type(arg, uses_[0].owner)
+                    is_put, is_tensor = check_stream_op_type(arg, uses_[0].owner)
                     uses.extend(uses_)
                 for use_ in uses:
                     op = use_.owner
+                    # TODO: add optimization to reduce memcpy
                     with aie_ir.InsertionPoint(op.operation):
                         if isinstance(fifo, tuple):
                             fifo = fifo[0 if is_put else 1]

--- a/allo/backend/aie/mlir_codegen.py
+++ b/allo/backend/aie/mlir_codegen.py
@@ -276,7 +276,7 @@ class CodeGenerator:
         func_body = func_core.regions[0]
         entry_block = aie_ir.Block.create_at_start(func_body)
 
-        def check_stream_op_type(argument, op) -> tuple[bool, bool]:
+        def check_stream_op_type(argument, op) -> tuple[bool | None, bool | None]:
             is_put, is_tensor = None, None
             if getattr(op, "name", None) == "memref.store" or (
                 getattr(op, "name", None) == "memref.copy"
@@ -446,12 +446,36 @@ class CodeGenerator:
                     uses_ = list(arg.uses)
                     is_put, is_tensor = check_stream_op_type(arg, uses_[0].owner)
                     uses.extend(uses_)
+                if isinstance(fifo, tuple):
+                    fifo = fifo[0 if is_put else 1]
+                if len(uses) == 1:
+                    op = uses[0].owner
+                    if is_put:
+                        alloc_op = op.operands[0].owner
+                        if getattr(alloc_op, "name", None) == "memref.alloc":
+                            with aie_ir.InsertionPoint(alloc_op.operation):
+                                acquired = fifo.acquire(0, 1)
+                            op.operands[0].replace_all_uses_with(acquired)
+                            with aie_ir.InsertionPoint(op.operation):
+                                fifo.release(0, 1)
+                            op.erase()
+                            alloc_op.erase()
+                            continue
+                    elif is_tensor and len(list(op.operands[0].uses)) == 1:
+                        # get tensor once
+                        with aie_ir.InsertionPoint(op):
+                            acquired = fifo.acquire(1, 1)
+                        op.operands[1].replace_all_uses_with(acquired)
+                        op.erase()
+                        acquired_uses = list(acquired.uses)
+                        assert len(acquired_uses) == 1, "To be implemented..."
+                        with aie_ir.InsertionPoint(acquired_uses[0].owner.operation):
+                            fifo.release(1, 1)
+                        continue
+
                 for use_ in uses:
                     op = use_.owner
-                    # TODO: add optimization to reduce memcpy
                     with aie_ir.InsertionPoint(op.operation):
-                        if isinstance(fifo, tuple):
-                            fifo = fifo[0 if is_put else 1]
                         if is_put:
                             op.operands[1] = fifo.acquire(0, 1)
                             new_op = op.clone()  # no use, no need to replace

--- a/allo/backend/aie/mlir_codegen.py
+++ b/allo/backend/aie/mlir_codegen.py
@@ -449,6 +449,8 @@ class CodeGenerator:
                     uses.extend(uses_)
                 if isinstance(fifo, tuple):
                     fifo = fifo[0 if is_put else 1]
+
+                # optimization to reduce memcpy
                 if len(uses) == 1:
                     op = uses[0].owner
                     if is_put:

--- a/allo/backend/aie/mlir_codegen.py
+++ b/allo/backend/aie/mlir_codegen.py
@@ -364,8 +364,7 @@ class CodeGenerator:
                     # TODO: add guard to ensure that in this case fifo won't be reused
                     for use_ in argument.uses:
                         op = use_.owner
-                        # get loop nests
-                        loop_nests = {}
+                        loop_nests = {}  # get loop nests
                         parent = op.parent
                         while parent is not None and not isinstance(
                             parent, aie_func_d.FuncOp
@@ -467,7 +466,7 @@ class CodeGenerator:
                                     old.replace_all_uses_with(new)
                             fifo.release(1, 1)
                     op.erase()
- 
+
             for fifo_name, (is_input, region) in reused_fifo_info.items():
                 with aie_ir.InsertionPoint.at_block_terminator(region):
                     self.fifo_map[fifo_name].release(1 if is_input else 0, 1)

--- a/allo/backend/aie/mlir_codegen.py
+++ b/allo/backend/aie/mlir_codegen.py
@@ -275,6 +275,22 @@ class CodeGenerator:
         assert not parsed_function is None
         func_body = func_core.regions[0]
         entry_block = aie_ir.Block.create_at_start(func_body)
+
+        def check_stream_op_type(argument, op) -> tuple[bool, bool]:
+            is_put, is_tensor = None, None
+            if getattr(op, "name", None) == "memref.store" or (
+                getattr(op, "name", None) == "memref.copy"
+                and argument == op.operands[1]
+            ):  # allo.stream_put
+                is_put = True
+            elif (
+                getattr(op, "name", None) == "memref.load"
+            ):  # allo.stream_get, non-tensor
+                is_put, is_tensor = False, False
+            elif getattr(op, "name", None) == "memref.copy":  # allo.stream_get, tensor
+                is_put, is_tensor = False, True
+            return is_put, is_tensor
+
         with aie_ir.InsertionPoint(entry_block):
             index_type = aie_ir.IndexType.get()
             # compute core wrapper: fake while(1)
@@ -284,6 +300,8 @@ class CodeGenerator:
             # scf.for %arg0 = %c0 to %cmax step %c1
             loop = aie_scf_d.ForOp(lower_bound=c0, upper_bound=cmax, step=c1)
             reused_fifo_info: dict[str, tuple[bool, Any]] = {}
+            # fifo name -> argument placeholders
+            inter_ct_fifo: dict[str, list] = defaultdict(list)
             for i, argument in enumerate(parsed_function.arguments):
                 if not i in func_args:
                     continue
@@ -332,12 +350,18 @@ class CodeGenerator:
                 else:
                     fifo_list = []
                     if isinstance(arg_info[0], Argument):
+                        stream = arg_info[0].stream
                         fifo_list.append(self.fifo_map[arg_info[0].stream.name])
                     else:
+                        stream = arg_info[0][0].stream
                         for stream_arg in arg_info[0]:
                             fifo_list.append(self.fifo_map[stream_arg.stream.name])
-                    compact_flag = len(fifo_list) == 1 or len(set(fifo_list)) == 1
-                    fifo = fifo_list[0]
+                    if (
+                        len(fifo_list) == 1 or len(set(fifo_list)) == 1
+                    ):  # no need to use 'switch'
+                        inter_ct_fifo[stream.name].append(argument)
+                        continue
+                    # TODO: add guard to ensure that in this case fifo won't be reused
                     for use_ in argument.uses:
                         op = use_.owner
                         # get loop nests
@@ -353,104 +377,97 @@ class CodeGenerator:
                                 loop_nests[parent.attributes["op_name"].value] = parent
                             parent = parent.parent
                         with aie_ir.InsertionPoint(op.operation):
-                            is_put, is_tensor = None, None
-                            if getattr(op, "name", None) == "memref.store" or (
-                                getattr(op, "name", None) == "memref.copy"
-                                and argument == op.operands[1]
-                            ):  # allo.stream_put
-                                is_put = True
-                            elif (
-                                getattr(op, "name", None) == "memref.load"
-                            ):  # allo.stream_get, non-tensor
-                                is_put, is_tensor = False, False
-                            elif (
-                                getattr(op, "name", None) == "memref.copy"
-                            ):  # allo.stream_get, tensor
-                                is_put, is_tensor = False, True
-                            else:
+                            is_put, is_tensor = check_stream_op_type(argument, op)
+                            if is_put is None:
                                 continue
-                            if compact_flag:
+                            assert len(loop_nests) == 1, "To be implemented..."
+                            loop_name = list(loop_nests.keys())[0]
+                            cases = []
+                            case_val = []
+                            for fifo, stream_arg in zip(fifo_list, arg_info[0]):
+                                if is_put:
+                                    cases.append(
+                                        stream_arg.stream.src_related_iter_info[
+                                            loop_name
+                                        ]
+                                    )
+                                else:
+                                    cases.append(
+                                        stream_arg.stream.dst_related_iter_info[
+                                            loop_name
+                                        ]
+                                    )
                                 if isinstance(fifo, tuple):
-                                    fifo = fifo[0 if is_put else 1]
-                                if is_put:
-                                    op.operands[1] = fifo.acquire(0, 1)
-                                    new_op = op.clone()  # no use, no need to replace
-                                    fifo.release(0, 1)
+                                    case_val.append(fifo[0 if is_put else 1])
                                 else:
-                                    acquired = fifo.acquire(1, 1)
-                                    op.operands[0] = acquired
-                                    new_op = op.clone()
-                                    if not is_tensor:
-                                        for old, new in zip(op.results, new_op.results):
-                                            old.replace_all_uses_with(new)
-                                    fifo.release(1, 1)
+                                    case_val.append(fifo)
+                            switch_op = aie_scf_d.IndexSwitchOp(
+                                [op.operands[1].type],
+                                loop_nests[loop_name].regions[0].blocks[0].arguments[0],
+                                cases[1:],
+                                len(cases[1:]),
+                            )
+                            cnt = 0
+                            for region in switch_op.caseRegions:
+                                block = region.blocks.append()
+                                with aie_ir.InsertionPoint(block):
+                                    acquired = case_val[cnt].acquire(
+                                        0 if is_put else 1, 1
+                                    )
+                                    aie_scf_d.YieldOp([acquired])
+                                    cnt += 1
+                            if is_put:
+                                op.operands[1] = switch_op.result
+                                new_op = op.clone()  # no use, no need to replace
                             else:
-                                assert len(loop_nests) == 1, "To be implemented..."
-                                loop_name = list(loop_nests.keys())[0]
-                                cases = []
-                                case_val = []
-                                for fifo, stream_arg in zip(fifo_list, arg_info[0]):
-                                    if is_put:
-                                        cases.append(
-                                            stream_arg.stream.src_related_iter_info[
-                                                loop_name
-                                            ]
-                                        )
-                                    else:
-                                        cases.append(
-                                            stream_arg.stream.dst_related_iter_info[
-                                                loop_name
-                                            ]
-                                        )
-                                    if isinstance(fifo, tuple):
-                                        case_val.append(fifo[0 if is_put else 1])
-                                    else:
-                                        case_val.append(fifo)
-                                switch_op = aie_scf_d.IndexSwitchOp(
-                                    [op.operands[1].type],
-                                    loop_nests[loop_name]
-                                    .regions[0]
-                                    .blocks[0]
-                                    .arguments[0],
-                                    cases[1:],
-                                    len(cases[1:]),
-                                )
-                                cnt = 0
-                                for region in switch_op.caseRegions:
-                                    block = region.blocks.append()
-                                    with aie_ir.InsertionPoint(block):
-                                        acquired = case_val[cnt].acquire(
-                                            0 if is_put else 1, 1
-                                        )
-                                        aie_scf_d.YieldOp([acquired])
-                                        cnt += 1
-                                if is_put:
-                                    op.operands[1] = switch_op.result
-                                    new_op = op.clone()  # no use, no need to replace
-                                else:
-                                    op.operands[0] = switch_op.result
-                                    new_op = op.clone()
-                                    if not is_tensor:
-                                        for old, new in zip(op.results, new_op.results):
-                                            old.replace_all_uses_with(new)
-                                switch_op = aie_scf_d.IndexSwitchOp(
-                                    [],
-                                    loop_nests[loop_name]
-                                    .regions[0]
-                                    .blocks[0]
-                                    .arguments[0],
-                                    cases[1:],
-                                    len(cases[1:]),
-                                )
-                                cnt = 0
-                                for region in switch_op.caseRegions:
-                                    block = region.blocks.append()
-                                    with aie_ir.InsertionPoint(block):
-                                        case_val[cnt].release(0 if is_put else 1, 1)
-                                        aie_scf_d.YieldOp([])
-                                        cnt += 1
+                                op.operands[0] = switch_op.result
+                                new_op = op.clone()
+                                if not is_tensor:
+                                    for old, new in zip(op.results, new_op.results):
+                                        old.replace_all_uses_with(new)
+                            switch_op = aie_scf_d.IndexSwitchOp(
+                                [],
+                                loop_nests[loop_name].regions[0].blocks[0].arguments[0],
+                                cases[1:],
+                                len(cases[1:]),
+                            )
+                            cnt = 0
+                            for region in switch_op.caseRegions:
+                                block = region.blocks.append()
+                                with aie_ir.InsertionPoint(block):
+                                    case_val[cnt].release(0 if is_put else 1, 1)
+                                    aie_scf_d.YieldOp([])
+                                    cnt += 1
                             op.erase()
 
+            for fifo_name, args in inter_ct_fifo.items():
+                fifo = self.fifo_map[fifo_name]
+                uses = []
+                is_put, is_tensor = None, None
+                for arg in args:
+                    uses_ = list(arg.uses)
+                    if is_put is None:
+                        is_put, is_tensor = check_stream_op_type(arg, uses_[0].owner)
+                    uses.extend(uses_)
+                for use_ in uses:
+                    op = use_.owner
+                    with aie_ir.InsertionPoint(op.operation):
+                        if isinstance(fifo, tuple):
+                            fifo = fifo[0 if is_put else 1]
+                        if is_put:
+                            op.operands[1] = fifo.acquire(0, 1)
+                            new_op = op.clone()  # no use, no need to replace
+                            fifo.release(0, 1)
+                        else:
+                            acquired = fifo.acquire(1, 1)
+                            op.operands[0] = acquired
+                            new_op = op.clone()
+                            if not is_tensor:
+                                for old, new in zip(op.results, new_op.results):
+                                    old.replace_all_uses_with(new)
+                            fifo.release(1, 1)
+                    op.erase()
+ 
             for fifo_name, (is_input, region) in reused_fifo_info.items():
                 with aie_ir.InsertionPoint.at_block_terminator(region):
                     self.fifo_map[fifo_name].release(1 if is_input else 0, 1)

--- a/allo/backend/aie/mlir_codegen.py
+++ b/allo/backend/aie/mlir_codegen.py
@@ -276,6 +276,7 @@ class CodeGenerator:
         func_body = func_core.regions[0]
         entry_block = aie_ir.Block.create_at_start(func_body)
 
+        # pylint: disable=unsupported-binary-operation
         def check_stream_op_type(argument, op) -> tuple[bool | None, bool | None]:
             is_put, is_tensor = None, None
             if getattr(op, "name", None) == "memref.store" or (

--- a/tests/dataflow/aie/test_mapping_atb.py
+++ b/tests/dataflow/aie/test_mapping_atb.py
@@ -1,0 +1,74 @@
+# Copyright Allo authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import allo
+import allo.dataflow as df
+from allo.backend.aie import is_available
+from allo.ir.types import int16, Stream
+import numpy as np
+
+Ty = int16
+M, N, K = 64, 16, 16
+RHO_VALUES = [1, 2, 4, 8]  # Change rho value here
+
+
+def make_atb_top(rho):
+    assert M % rho == 0
+    Ma = M // rho
+
+    @df.region()
+    def top(A: Ty[M, K], B: Ty[K, N], C: Ty[M, N]):
+        pipe_a: Stream[Ty[Ma, K], 2][rho]
+        pipe_b: Stream[Ty[K, N], 2][rho]
+        pipe_c: Stream[Ty[Ma, N], 2][rho]
+
+        @df.kernel(mapping=[1], args=[A])
+        def load_a(local_A: Ty[M, K]):
+            with allo.meta_for(rho) as i:
+                pipe_a[i].put(local_A[i * Ma : (i + 1) * Ma, :])
+
+        @df.kernel(mapping=[1], args=[B])
+        def load_b(local_B: Ty[K, N]):
+            with allo.meta_for(rho) as i:
+                pipe_b[i].put(local_B)
+
+        @df.kernel(mapping=[rho])
+        def compute():
+            pk = df.get_pid()
+            local_A: Ty[Ma, K] = pipe_a[pk].get()
+            local_B: Ty[K, N] = pipe_b[pk].get()
+            pipe_c[pk].put(allo.matmul(local_A, local_B))
+
+        @df.kernel(mapping=[1], args=[C])
+        def store_c(local_C: Ty[M, N]):
+            with allo.meta_for(rho) as i:
+                local_C[i * Ma : (i + 1) * Ma, :] = pipe_c[i].get()
+
+    return top
+
+
+def run_atb(rho):
+    top = make_atb_top(rho)
+    mapping_primitives = None
+    if rho > 1:
+        mapping_primitives = [("bundle", [f"compute_{i}" for i in range(rho)])]
+
+    A = np.random.randint(0, 64, (M, K)).astype(np.int16)
+    B = np.random.randint(0, 64, (K, N)).astype(np.int16)
+    C = np.zeros((M, N)).astype(np.int16)
+
+    if is_available():
+        os.environ["FORCE_UNROLL_INDEX"] = "1"
+        mod = df.build(top, target="aie", mapping_primitives=mapping_primitives)
+        mod(A, B, C)
+        del os.environ["FORCE_UNROLL_INDEX"]
+        np.testing.assert_allclose(C, A @ B, atol=1e-5)
+        print(f"rho={rho} PASSED!")
+    else:
+        print("MLIR_AIE_INSTALL_DIR unset. Skipping AIE backend test.")
+
+
+if __name__ == "__main__":
+    for rho in RHO_VALUES:
+        run_atb(rho)

--- a/tests/dataflow/aie/test_mapping_atb.py
+++ b/tests/dataflow/aie/test_mapping_atb.py
@@ -2,18 +2,18 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+import pytest
 import allo
 import allo.dataflow as df
 from allo.backend.aie import is_available
 from allo.ir.types import int16, Stream
 import numpy as np
 
-Ty = int16
-M, N, K = 64, 16, 16
-RHO_VALUES = [1, 2, 4, 8]  # Change rho value here
 
-
-def make_atb_top(rho):
+@pytest.mark.parametrize("rho", [1, 2, 4])
+def test_atb(rho):
+    Ty = int16
+    M, N, K = 64, 16, 16
     assert M % rho == 0
     Ma = M // rho
 
@@ -45,11 +45,6 @@ def make_atb_top(rho):
             with allo.meta_for(rho) as i:
                 local_C[i * Ma : (i + 1) * Ma, :] = pipe_c[i].get()
 
-    return top
-
-
-def run_atb(rho):
-    top = make_atb_top(rho)
     mapping_primitives = None
     if rho > 1:
         mapping_primitives = [("bundle", [f"compute_{i}" for i in range(rho)])]
@@ -70,5 +65,6 @@ def run_atb(rho):
 
 
 if __name__ == "__main__":
+    RHO_VALUES = [1, 2, 4, 8]  # Change rho value here
     for rho in RHO_VALUES:
-        run_atb(rho)
+        test_atb(rho)

--- a/tests/dataflow/aie/test_mapping_atb.py
+++ b/tests/dataflow/aie/test_mapping_atb.py
@@ -3,15 +3,19 @@
 
 import os
 import pytest
+import numpy as np
 import allo
 import allo.dataflow as df
 from allo.backend.aie import is_available
 from allo.ir.types import int16, Stream
-import numpy as np
+from allo.memory import Layout
+
+S = Layout.Shard
+R = Layout.Replicate
 
 
 @pytest.mark.parametrize("rho", [1, 2, 4])
-def test_atb(rho):
+def test_atb_onchip_tiling(rho):
     Ty = int16
     M, N, K = 64, 16, 16
     assert M % rho == 0
@@ -64,7 +68,56 @@ def test_atb(rho):
         print("MLIR_AIE_INSTALL_DIR unset. Skipping AIE backend test.")
 
 
+@pytest.mark.parametrize("rho", [1, 2, 4])
+def test_atb(rho):
+    Ty = int16
+    M, N, K = 64, 16, 16
+    assert M % rho == 0
+    Ma = M // rho
+
+    @df.region()
+    def top(A: Ty[M, K], B: Ty[K, N], C: Ty[M, N]):
+        pipeB: Stream[Ty[K, N], 1][rho]
+        pipeC: Stream[Ty[Ma, N], 1][rho]
+
+        @df.kernel(mapping=[1], args=[B])
+        def loadB(local_B: Ty[K, N]):
+            with allo.meta_for(rho) as i:
+                pipeB[i].put(local_B)
+
+        @df.kernel(mapping=[rho], args=[A])
+        def compute(local_A: Ty[M, K] @ [S(0), R]):
+            pk = df.get_pid()
+            c = allo.matmul(local_A, pipeB[pk].get())
+            pipeC[pk].put(c)
+
+        @df.kernel(mapping=[1], args=[C])
+        def store(local_C: Ty[M, N]):
+            with allo.meta_for(rho) as i:
+                local_C[i * Ma : (i + 1) * Ma, :] = pipeC[i].get()
+
+    mapping_primitives = None
+    if rho > 1:
+        mapping_primitives = [("bundle", [f"compute_{i}" for i in range(rho)])]
+
+    A = np.random.randint(0, 64, (M, K)).astype(np.int16)
+    B = np.random.randint(0, 64, (K, N)).astype(np.int16)
+    C = np.zeros((M, N)).astype(np.int16)
+
+    if is_available():
+        os.environ["FORCE_UNROLL_INDEX"] = "1"
+        mod = df.build(top, target="aie", mapping_primitives=mapping_primitives)
+        mod(A, B, C)
+        del os.environ["FORCE_UNROLL_INDEX"]
+        np.testing.assert_allclose(C, A @ B, atol=1e-5)
+        print(f"rho={rho} PASSED!")
+    else:
+        print("MLIR_AIE_INSTALL_DIR unset. Skipping AIE backend test.")
+
+
 if __name__ == "__main__":
-    RHO_VALUES = [1, 2, 4, 8]  # Change rho value here
+    RHO_VALUES = [1, 2, 4]  # Change rho value here
+    for rho in RHO_VALUES:
+        test_atb_onchip_tiling(rho)
     for rho in RHO_VALUES:
         test_atb(rho)

--- a/tests/dataflow/aie/test_matrix.py
+++ b/tests/dataflow/aie/test_matrix.py
@@ -192,7 +192,7 @@ def test_gemm_atb():
     Ma = M // P0
 
     @df.region()
-    def top1(A0: Ty[Ma, K], A1: Ty[Ma, K], B: Ty[K, N], C: Ty[M, N]):
+    def top(A0: Ty[Ma, K], A1: Ty[Ma, K], B: Ty[K, N], C: Ty[M, N]):
         pipeB: Stream[Ty[K, N], 1][P0]
         pipeC: Stream[Ty[Ma, N], 1][P0]
 


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##
This PR partially fixes #601 

### Problems ###
Previous optimization on stream operation lowering is too aggressive and didn't consider inter-compute-tile fifo reuse. The leads to the bug mentioned in #601

### Proposed Solutions ###
(What changes have you made)


### Examples ###
```python
import os
import allo
import allo.dataflow as df
from allo.backend.aie import is_available
from allo.ir.types import int16, Stream
import numpy as np

Ty = int16
M, N, K = 64, 16, 16

def make_atb_top(rho):
    assert M % rho == 0
    Ma = M // rho

    @df.region()
    def top(A: Ty[M, K], B: Ty[K, N], C: Ty[M, N]):
        pipe_a: Stream[Ty[Ma, K], 2][rho]
        pipe_b: Stream[Ty[K, N], 2][rho]
        pipe_c: Stream[Ty[Ma, N], 2][rho]

        @df.kernel(mapping=[1], args=[A])
        def load_a(local_A: Ty[M, K]):
            with allo.meta_for(rho) as i:
                pipe_a[i].put(local_A[i * Ma : (i + 1) * Ma, :])

        @df.kernel(mapping=[1], args=[B])
        def load_b(local_B: Ty[K, N]):
            with allo.meta_for(rho) as i:
                pipe_b[i].put(local_B)

        @df.kernel(mapping=[rho])
        def compute():
            pk = df.get_pid()
            local_A: Ty[Ma, K] = pipe_a[pk].get()
            local_B: Ty[K, N] = pipe_b[pk].get()
            pipe_c[pk].put(allo.matmul(local_A, local_B))

        @df.kernel(mapping=[1], args=[C])
        def store_c(local_C: Ty[M, N]):
            with allo.meta_for(rho) as i:
                local_C[i * Ma : (i + 1) * Ma, :] = pipe_c[i].get()

    return top


def run_atb(rho):
    top = make_atb_top(rho)
    mapping_primitives = None
    if rho > 1:
        mapping_primitives = [("bundle", [f"compute_{i}" for i in range(rho)])]

    A = np.random.randint(0, 64, (M, K)).astype(np.int16)
    B = np.random.randint(0, 64, (K, N)).astype(np.int16)
    C = np.zeros((M, N)).astype(np.int16)

    if is_available():
        os.environ["FORCE_UNROLL_INDEX"] = "1"
        mod = df.build(top, target="aie", mapping_primitives=mapping_primitives)
        mod(A, B, C)
        del os.environ["FORCE_UNROLL_INDEX"]
        np.testing.assert_allclose(C, A @ B, atol=1e-5)
        print(f"rho={rho} PASSED!")
    else:
        print("MLIR_AIE_INSTALL_DIR unset. Skipping AIE backend test.")

run_atb(2)
```

## Checklist ##

Please make sure to review and check all of these items:
- [x] PR's title starts with a category (e.g. [Bugfix], [IR], [Builder], etc)
- [ ] All changes have test coverage (It would be good to provide ~2 different test cases to test the robustness of your code)
- [ ] Pass the [formatting check](https://cornell-zhang.github.io/allo/developer/index.html#id1) locally
- [ ] Code is well-documented
