### PR TITLE
[Doc] Improve source installation troubleshooting

### DIFF
--- a/docs/source/setup/index.rst
+++ b/docs/source/setup/index.rst
@@ -49,11 +49,37 @@ Install from Source
 
 Please follow the instructions below to build the LLVM project from source. You can also refer to the `official guide <https://mlir.llvm.org/getting_started/>`_ for more details. As the LLVM/MLIR API changes a lot, if you are using a different LLVM version, the Allo package may not work properly. The LLVM version we used can be found in the `externals <https://github.com/cornell-zhang/allo/tree/main/externals>`_ folder.
 
+.. note::
+
+   The current source-installation dependencies target CPython 3.12 on Linux
+   x86-64. Use the Docker installation above on other platforms.
+
+Create and activate the Python environment before configuring LLVM. This makes
+LLVM and Allo use the same Python interpreter. Keep the repository root in
+``ALLO_ROOT`` because the LLVM build takes place several directories below it.
+
 .. code-block:: bash
 
     git clone --recursive https://github.com/cornell-zhang/allo.git
-    cd allo/externals/llvm-project
-    # Python 3.12 is required
+    cd allo
+    export ALLO_ROOT="$(pwd)"
+
+    # Python 3.12 is required by the current dependency set
+    conda create -n allo python=3.12
+    conda activate allo
+
+    python3 -m pip install --upgrade pip
+    python3 -m pip install cmake ninja "nanobind>=2.9,<3.0"
+
+    # Check the tools that will be used for the build
+    python3 --version
+    cmake --version
+    ninja --version
+    cc --version
+    c++ --version
+    python3 -m pip show nanobind
+
+    cd "$ALLO_ROOT/externals/llvm-project"
     mkdir -p build && cd build
     cmake -G Ninja ../llvm \
         -DLLVM_ENABLE_PROJECTS="clang;mlir;openmp" \
@@ -63,24 +89,22 @@ Please follow the instructions below to build the LLVM project from source. You 
         -DLLVM_ENABLE_ASSERTIONS=ON \
         -DLLVM_INSTALL_UTILS=ON \
         -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
-        -DPython3_EXECUTABLE=`which python3`
+        -DPython3_EXECUTABLE="$(command -v python3)"
     ninja
-    # export environment variable
-    export LLVM_BUILD_DIR=$(pwd)
-    export PATH=$(pwd)/bin:$PATH
 
-We recommend creating a new conda environment for Allo. Since we are using the latest Python features, the minimum Python version is **3.12**.
-
-.. code-block:: console
-
-  $ conda create -n allo python=3.12
-  $ conda activate allo
+    # Export and verify the completed LLVM/MLIR build
+    export LLVM_BUILD_DIR="$(pwd)"
+    export PATH="$LLVM_BUILD_DIR/bin:$PATH"
+    test -x "$LLVM_BUILD_DIR/bin/llvm-config"
+    test -f "$LLVM_BUILD_DIR/lib/cmake/mlir/MLIRConfig.cmake"
+    "$LLVM_BUILD_DIR/bin/llvm-config" --version
 
 You can now install Allo by running the following commands.
 
-.. code-block:: console
+.. code-block:: bash
 
-  $ python3 -m pip install -v -e .
+    cd "$ALLO_ROOT"
+    python3 -m pip install -v -e .
 
 
 Testing
@@ -136,18 +160,11 @@ If you see no error messages, then the installation is successful. Otherwise, pl
 Troubleshooting
 ---------------
 
-If you encounter the following issue when building Allo, it is mostly because you source the Vitis environment at the same time, which may cause some library conflicts. Please disable it and try again.
+For source-build prerequisites, diagnostic commands, and common installation
+failures, see :doc:`troubleshooting`.
 
-.. code-block:: console
+.. toctree::
+   :maxdepth: 1
+   :hidden:
 
-  running build_ext
-    cmake: error while loading shared libraries: libidn.so.11: cannot open shared object file: No such file or directory
-
-
-If you are seeing the errors reported by the linker like this:
-
-.. code-block:: console
-
-  /opt/rh/devtoolset-9/root/usr/libexec/gcc/x86_64-redhat-linux/9/ld: cannot find /work/shared/common/llvm-project-main/build/lib/libMLIRLLVMToLLVMIRTranslation.a: Too many open files
-
-It means you have hit the limit of file descriptors that can be open at a time. You can fix this by :code:`ulimit -n 4096`, then try compiling Allo again.
+   troubleshooting

--- a/docs/source/setup/troubleshooting.rst
+++ b/docs/source/setup/troubleshooting.rst
@@ -49,13 +49,25 @@ Run these checks before retrying a long build:
 
 The expected results are:
 
-* Python belongs to the active ``allo`` environment.
+* Python (must be at least 3.12) belongs to the active ``allo`` environment.
 * CMake, Ninja, and C/C++ compilers are available.
 * nanobind is version 2.x. Current Allo builds require
   ``nanobind>=2.9,<3.0``.
 * ``ALLO_ROOT`` points to the Allo repository root.
 * ``LLVM_BUILD_DIR`` points to the LLVM *build* directory, not the LLVM source
   directory.
+
+If the issues and fixes below do not cover the problem, raise a GitHub issue
+for help. Include the failing command, the first relevant error, the output of
+the checks above, and these additional diagnostics. Avoid including only the
+final generic pip traceback.
+
+.. code-block:: bash
+
+    git rev-parse HEAD
+    git submodule status
+    test -x "$LLVM_BUILD_DIR/bin/llvm-config"; echo "llvm-config: $?"
+    test -f "$LLVM_BUILD_DIR/lib/cmake/mlir/MLIRConfig.cmake"; echo "MLIRConfig.cmake: $?"
 
 Editable Install Runs in the Wrong Directory
 ============================================
@@ -306,55 +318,56 @@ backend build and is separate from Allo's generated extension in
 after the checks above demonstrate a Python/extension mismatch; it is not a
 general fix for unrelated import errors.
 
-Verify the Installation
-=======================
-
-After resolving the error, install from the repository root and perform a
-small import check:
-
-.. code-block:: bash
-
-    cd "$ALLO_ROOT"
-    python3 -m pip install -v -e .
-    python3 -c "import allo; import allo.ir"
-
-When Asking for Help
-====================
-
-Include the failing command, the first relevant error, and the output of these
-diagnostics. Avoid pasting only the final generic pip traceback.
-
-.. code-block:: bash
-
-    pwd
-    git rev-parse HEAD
-    git submodule status
-    python3 --version
-    python3 -c "import sys; print(sys.executable)"
-    cmake --version
-    ninja --version
-    python3 -m pip show nanobind
-    echo "LLVM_BUILD_DIR=$LLVM_BUILD_DIR"
-    test -x "$LLVM_BUILD_DIR/bin/llvm-config"; echo "llvm-config: $?"
-    test -f "$LLVM_BUILD_DIR/lib/cmake/mlir/MLIRConfig.cmake"; echo "MLIRConfig.cmake: $?"
-
 Vitis Environment Library Conflicts
 ===================================
 
-If you encounter the following issue when building Allo, it is mostly because you source the Vitis environment at the same time, which may cause some library conflicts. Please disable it and try again.
+**Symptom**
+
+The Allo build fails while CMake is starting:
 
 .. code-block:: console
 
   running build_ext
     cmake: error while loading shared libraries: libidn.so.11: cannot open shared object file: No such file or directory
 
+**Cause**
+
+The Vitis environment is sourced in the same shell and introduces conflicting
+library paths.
+
+**Fix**
+
+Disable the Vitis environment, or start a new shell without sourcing it, and
+then build Allo again:
+
+.. code-block:: bash
+
+    cd "$ALLO_ROOT"
+    python3 -m pip install -v -e .
+
 Too Many Open Files
 ===================
 
-If you are seeing the errors reported by the linker like this:
+**Symptom**
+
+The linker reports that it cannot open an LLVM or MLIR library even though the
+file exists:
 
 .. code-block:: console
 
   /opt/rh/devtoolset-9/root/usr/libexec/gcc/x86_64-redhat-linux/9/ld: cannot find /work/shared/common/llvm-project-main/build/lib/libMLIRLLVMToLLVMIRTranslation.a: Too many open files
 
-It means you have hit the limit of file descriptors that can be open at a time. You can fix this by :code:`ulimit -n 4096`, then try compiling Allo again.
+**Cause**
+
+The build has reached the shell's limit on simultaneously open file
+descriptors.
+
+**Fix**
+
+Increase the limit for the current shell, then build Allo again:
+
+.. code-block:: bash
+
+    ulimit -n 4096
+    cd "$ALLO_ROOT"
+    python3 -m pip install -v -e .

--- a/docs/source/setup/troubleshooting.rst
+++ b/docs/source/setup/troubleshooting.rst
@@ -1,0 +1,360 @@
+..  Copyright Allo authors. All Rights Reserved.
+    SPDX-License-Identifier: Apache-2.0
+
+..  Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+..    http://www.apache.org/licenses/LICENSE-2.0
+
+..  Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+.. _source-installation-troubleshooting:
+
+###################################
+Source Installation Troubleshooting
+###################################
+
+This page covers failures in the Linux source-installation workflow. The
+commands assume that the repository root is stored in ``ALLO_ROOT`` and that
+the ``allo`` Conda environment is active. Follow :ref:`install-from-source`
+before using the fixes below.
+
+Initial Checks
+==============
+
+Run these checks before retrying a long build:
+
+.. code-block:: bash
+
+    echo "ALLO_ROOT=$ALLO_ROOT"
+    echo "LLVM_BUILD_DIR=$LLVM_BUILD_DIR"
+    pwd
+    python3 --version
+    python3 -c "import sys; print(sys.executable)"
+    cmake --version
+    ninja --version
+    cc --version
+    c++ --version
+    python3 -m pip show nanobind
+
+The expected results are:
+
+* Python belongs to the active ``allo`` environment.
+* CMake, Ninja, and C/C++ compilers are available.
+* nanobind is version 2.x. Current Allo builds require
+  ``nanobind>=2.9,<3.0``.
+* ``ALLO_ROOT`` points to the Allo repository root.
+* ``LLVM_BUILD_DIR`` points to the LLVM *build* directory, not the LLVM source
+  directory.
+
+Editable Install Runs in the Wrong Directory
+============================================
+
+**Symptom**
+
+.. code-block:: text
+
+    ERROR: ... does not appear to be a Python project:
+    neither 'setup.py' nor 'pyproject.toml' found.
+
+**Cause**
+
+The LLVM build finishes in ``allo/externals/llvm-project/build``. Running
+``pip install -e .`` there asks pip to install the LLVM build directory rather
+than Allo.
+
+**Fix**
+
+Return to the repository root and confirm that the packaging files exist:
+
+.. code-block:: bash
+
+    cd "$ALLO_ROOT"
+    test -f pyproject.toml
+    test -f setup.py
+    python3 -m pip install -v -e .
+
+``LLVM_BUILD_DIR`` Is Not Set
+=============================
+
+**Symptom**
+
+.. code-block:: text
+
+    RuntimeError: LLVM_BUILD_DIR environment variable is not set
+
+**Cause**
+
+Allo uses ``LLVM_BUILD_DIR`` to locate the LLVM and MLIR build products. A new
+shell does not retain variables exported in an earlier shell.
+
+**Fix**
+
+Set the variable to the absolute LLVM build directory, add its tools to
+``PATH``, and verify the expected files:
+
+.. code-block:: bash
+
+    export LLVM_BUILD_DIR="$ALLO_ROOT/externals/llvm-project/build"
+    export PATH="$LLVM_BUILD_DIR/bin:$PATH"
+
+    test -x "$LLVM_BUILD_DIR/bin/llvm-config"
+    test -f "$LLVM_BUILD_DIR/lib/cmake/mlir/MLIRConfig.cmake"
+
+If either check fails, the path is wrong or the LLVM/MLIR build is incomplete.
+The presence of ``llvm-config`` alone does not prove that MLIR finished
+building.
+
+``MLIRConfig.cmake`` Cannot Be Found
+====================================
+
+**Symptom**
+
+.. code-block:: text
+
+    Could not find a package configuration file provided by "MLIR"
+    with any of the following names:
+      MLIRConfig.cmake
+      mlir-config.cmake
+
+**Check**
+
+.. code-block:: bash
+
+    test -f "$LLVM_BUILD_DIR/lib/cmake/mlir/MLIRConfig.cmake"
+
+**Cause**
+
+The most common causes are:
+
+* ``LLVM_BUILD_DIR`` points to the source directory or a different build.
+* The LLVM build stopped before producing the MLIR CMake package.
+* LLVM was configured without MLIR in ``LLVM_ENABLE_PROJECTS``.
+
+**Fix**
+
+Configure the pinned LLVM submodule with MLIR enabled, finish the Ninja build,
+and repeat the check before installing Allo:
+
+.. code-block:: bash
+
+    cd "$ALLO_ROOT/externals/llvm-project/build"
+    cmake -G Ninja ../llvm \
+        -DLLVM_ENABLE_PROJECTS="clang;mlir;openmp" \
+        -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
+        -DPython3_EXECUTABLE="$(command -v python3)"
+    ninja
+
+    export LLVM_BUILD_DIR="$(pwd)"
+    test -f "$LLVM_BUILD_DIR/lib/cmake/mlir/MLIRConfig.cmake"
+
+Use the complete CMake options from :ref:`install-from-source` when creating a
+new build directory.
+
+nanobind Is Missing During LLVM Configuration
+==============================================
+
+**Symptom**
+
+.. code-block:: text
+
+    not found (install via 'pip install nanobind' or set nanobind_DIR)
+
+**Cause**
+
+MLIR checks for nanobind in the Python interpreter selected by
+``Python3_EXECUTABLE``. Installing nanobind later, while installing Allo, does
+not make it available to an earlier LLVM configuration.
+
+**Fix**
+
+Activate the same environment used to configure LLVM, install the supported
+nanobind version, and rerun CMake:
+
+.. code-block:: bash
+
+    conda activate allo
+    python3 -m pip install "nanobind>=2.9,<3.0"
+    python3 -c "import sys; print(sys.executable)"
+    python3 -c "import nanobind; print(nanobind.__version__)"
+    python3 -c "import nanobind; print(nanobind.cmake_dir())"
+
+    cd "$ALLO_ROOT/externals/llvm-project/build"
+    cmake -DPython3_EXECUTABLE="$(command -v python3)" ../llvm
+
+The Python path printed by ``python3 -c`` must be the interpreter intended for
+both LLVM and Allo.
+
+Linux Wheel Is Rejected on Another Platform
+===========================================
+
+**Symptom**
+
+.. code-block:: text
+
+    past-0.7.2-cp312-cp312-linux_x86_64.whl is not a supported wheel on this platform
+
+**Cause**
+
+Allo currently depends on a CPython 3.12 Linux x86-64 wheel for ``past``.
+Pip rejects that wheel on Windows, macOS, other architectures, and other
+Python versions.
+
+**Fix**
+
+Use the documented Docker installation or a Python 3.12 Linux x86-64
+environment. Other platforms require a compatible ``past`` build and are not
+covered by the current source-installation commands.
+
+``_py_stats`` Is Undefined When Importing Allo
+==============================================
+
+**Symptom**
+
+.. code-block:: text
+
+    ImportError: .../_mlir.cpython-312-x86_64-linux-gnu.so:
+    undefined symbol: _py_stats
+
+**Cause**
+
+``_py_stats`` is a private CPython symbol used when Python is built with
+internal performance statistics enabled. This error can occur when Allo's
+compiled MLIR extension was built against a Python configuration that provided
+the symbol, but the current Python runtime does not provide it.
+
+Allo generates the extension under ``mlir/build`` and imports it through
+``allo/_mlir``. The build directory is reused by later editable installs. If
+Python is rebuilt in place, or the active Python installation changes while
+keeping the same extension suffix, the existing MLIR build can be incompatible
+with the current runtime.
+
+**Checks**
+
+First confirm the current interpreter and its build configuration:
+
+.. code-block:: bash
+
+    python3 -c "import sys; print(sys.executable)"
+    python3 -c "import sysconfig; print(sysconfig.get_config_var('CONFIG_ARGS'))"
+    python3 -c "import sysconfig; print('Py_STATS:', sysconfig.get_config_var('Py_STATS'))"
+    python3 -c "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX'))"
+
+A runtime built without performance statistics normally reports
+``Py_STATS: 0``. Next locate the generated Allo extension and inspect its
+dynamic symbols:
+
+.. code-block:: bash
+
+    MLIR_EXTENSION="$(find \
+        "$ALLO_ROOT/mlir/build/tools/allo/_mlir/_mlir_libs" \
+        -maxdepth 1 -name '_mlir*.so' -print -quit)"
+    echo "MLIR_EXTENSION=$MLIR_EXTENSION"
+    test -n "$MLIR_EXTENSION"
+    nm -D "$MLIR_EXTENSION" | grep -w _py_stats
+
+An entry such as the following proves that the extension expects the symbol
+from the Python runtime:
+
+.. code-block:: text
+
+                     U _py_stats
+
+Check whether the current Python process exports the symbol:
+
+.. code-block:: bash
+
+    python3 -c "import ctypes; getattr(ctypes.CDLL(None), '_py_stats')"
+
+A runtime that does not provide the symbol reports an ``AttributeError``
+ending in ``undefined symbol: _py_stats``.
+
+If the extension reports ``U _py_stats``, the current runtime has
+``Py_STATS: 0``, and the Python process does not export ``_py_stats``, the
+extension and runtime are inconsistent.
+
+**Fix**
+
+Remove only Allo's generated MLIR build, then rebuild it with the active Python
+and the existing LLVM build:
+
+.. code-block:: bash
+
+    conda activate allo || exit 1
+    cd "$ALLO_ROOT" || exit 1
+    test -f setup.py || exit 1
+    test -d mlir || exit 1
+    test -f "$LLVM_BUILD_DIR/lib/cmake/mlir/MLIRConfig.cmake" || exit 1
+
+    rm -rf -- mlir/build
+    python3 -m pip install -v -e .
+    python3 -c "import allo; import allo.ir; print('Allo MLIR import passed')"
+
+Do not remove ``LLVM_BUILD_DIR`` for this error. It contains the LLVM/MLIR
+backend build and is separate from Allo's generated extension in
+``$ALLO_ROOT/mlir/build``. A clean Allo extension rebuild is appropriate only
+after the checks above demonstrate a Python/extension mismatch; it is not a
+general fix for unrelated import errors.
+
+Verify the Installation
+=======================
+
+After resolving the error, install from the repository root and perform a
+small import check:
+
+.. code-block:: bash
+
+    cd "$ALLO_ROOT"
+    python3 -m pip install -v -e .
+    python3 -c "import allo; import allo.ir"
+
+When Asking for Help
+====================
+
+Include the failing command, the first relevant error, and the output of these
+diagnostics. Avoid pasting only the final generic pip traceback.
+
+.. code-block:: bash
+
+    pwd
+    git rev-parse HEAD
+    git submodule status
+    python3 --version
+    python3 -c "import sys; print(sys.executable)"
+    cmake --version
+    ninja --version
+    python3 -m pip show nanobind
+    echo "LLVM_BUILD_DIR=$LLVM_BUILD_DIR"
+    test -x "$LLVM_BUILD_DIR/bin/llvm-config"; echo "llvm-config: $?"
+    test -f "$LLVM_BUILD_DIR/lib/cmake/mlir/MLIRConfig.cmake"; echo "MLIRConfig.cmake: $?"
+
+Vitis Environment Library Conflicts
+===================================
+
+If you encounter the following issue when building Allo, it is mostly because you source the Vitis environment at the same time, which may cause some library conflicts. Please disable it and try again.
+
+.. code-block:: console
+
+  running build_ext
+    cmake: error while loading shared libraries: libidn.so.11: cannot open shared object file: No such file or directory
+
+Too Many Open Files
+===================
+
+If you are seeing the errors reported by the linker like this:
+
+.. code-block:: console
+
+  /opt/rh/devtoolset-9/root/usr/libexec/gcc/x86_64-redhat-linux/9/ld: cannot find /work/shared/common/llvm-project-main/build/lib/libMLIRLLVMToLLVMIRTranslation.a: Too many open files
+
+It means you have hit the limit of file descriptors that can be open at a time. You can fix this by :code:`ulimit -n 4096`, then try compiling Allo again.


### PR DESCRIPTION
<!--- Copyright Allo authors. All Rights Reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0  -->

## Description ##

This documentation PR makes the source-installation procedure more
reproducible and adds troubleshooting guidance for installation failures
observed while building Allo on a shared RHEL 9.8 server.

It corrects the order of the Python and LLVM setup, ensures that the editable
installation runs from the Allo repository root, and adds checks for required
LLVM/MLIR build artifacts. The newly added troubleshooting entries describe
failures that were reproduced or independently verified. The existing Vitis
environment and file-descriptor guidance is preserved without claiming new
reproduction coverage.

### Problems ###

The previous source-installation instructions had several gaps:

- The Python environment was created after LLVM was configured, which could
  cause LLVM and Allo to use different Python interpreters.
- The instructions did not return to the Allo repository root before running
  `pip install -e .`.
- They did not verify that the LLVM build produced `llvm-config` and
  `MLIRConfig.cmake`.
- They did not explain common failures caused by:
  - an unset or incorrect `LLVM_BUILD_DIR`;
  - a missing `MLIRConfig.cmake`;
  - nanobind being unavailable while configuring LLVM;
  - platform-incompatible Python wheels;
  - a stale Allo MLIR extension after changing the Python build configuration.
- The two existing troubleshooting entries were embedded at the end of the
  installation page instead of being part of a structured troubleshooting
  guide.

### Proposed Solutions ###

This PR:

- Creates and activates the Python 3.12 environment before configuring LLVM.
- Installs and checks CMake, Ninja, the C/C++ toolchain, and the supported
  nanobind version before the LLVM build.
- Preserves the repository root in `ALLO_ROOT`.
- Configures LLVM using the active Python interpreter.
- Verifies `llvm-config` and `MLIRConfig.cmake` after the LLVM build.
- Explicitly returns to `ALLO_ROOT` before installing Allo.
- Adds a dedicated source-installation troubleshooting page.
- Provides a symptom, cause, diagnostic procedure, and targeted fix for each
  newly documented failure.
- Preserves the existing Vitis environment and “too many open files”
  troubleshooting guidance.

### Examples ###

This PR does not change Allo programs, generated IR, or runtime behavior.

Example 1: running the editable installation from the LLVM build directory
resulted in:

```text
ERROR: ... does not appear to be a Python project:
neither 'setup.py' nor 'pyproject.toml' found.
```

Returning to the recorded repository root resolved the problem:

```bash
cd "$ALLO_ROOT"
test -f setup.py
test -f pyproject.toml
python3 -m pip install -v -e .
```

Example 2: starting a new shell without restoring `LLVM_BUILD_DIR` caused the
LLVM backend, including LLVM examples executed by Sphinx Gallery, to fail with:

```text
AssertionError: LLVM_BUILD_DIR is not set
```

The proposed procedure restores the variable and verifies both required build
artifacts before continuing:

```bash
export LLVM_BUILD_DIR="$ALLO_ROOT/externals/llvm-project/build"
export PATH="$LLVM_BUILD_DIR/bin:$PATH"

test -x "$LLVM_BUILD_DIR/bin/llvm-config"
test -f "$LLVM_BUILD_DIR/lib/cmake/mlir/MLIRConfig.cmake"
```

Example 3: loading an Allo MLIR extension left over from an earlier Python
configuration resulted in:

```text
ImportError: .../_mlir.cpython-312-x86_64-linux-gnu.so:
undefined symbol: _py_stats
```

The current Python runtime was checked to confirm that `Py_STATS` was disabled
and that `_py_stats` was not exported. Inspecting the stale extension showed
that it still expected `_py_stats`. Removing only Allo's generated
`mlir/build` directory and rebuilding the extension against the current
Python installation resolved the import failure.

### Reproduction and Validation Environments ###

The failures were investigated using two complementary systems. Not every
failure was reproduced on both systems because some failures are
platform-specific.

#### System 1: RHEL 9.8 Allo Server ####

- Red Hat Enterprise Linux 9.8, x86-64
- CPython 3.12.4
- Python installed under `/Software/Software/Python/3.12.4`
- `pip3`/`python3 -m pip`; Conda was not used
- Python built with shared-library support
- `Py_STATS=0`
- Sphinx 9.1.0
- Allo built from source against the repository's pinned LLVM/MLIR checkout

This system was used for the real Allo source build and for validating the
installation and recovery procedures:

- Running the editable installation outside the Allo repository root caused
  pip to report that neither `setup.py` nor `pyproject.toml` could be found.
  Returning to `ALLO_ROOT` resolved the failure.
- Starting a new shell without exporting `LLVM_BUILD_DIR` caused Allo's LLVM
  backend, including the examples executed by Sphinx Gallery, to fail before
  compilation.
- Pointing `LLVM_BUILD_DIR` at an incomplete or incorrect LLVM build reproduced
  the missing `MLIRConfig.cmake` failure. Checking for both `llvm-config` and
  `MLIRConfig.cmake` distinguished a complete LLVM/MLIR build from a partial
  build.
- Configuring LLVM before nanobind was available to the selected Python
  interpreter reproduced the nanobind configuration failure. Installing the
  supported nanobind version before configuring LLVM resolved it.
- Reusing an Allo MLIR extension compiled against an earlier Python
  configuration reproduced the `_py_stats` import failure. The active Python
  configuration, headers, shared library, and extension symbols were inspected
  to confirm the mismatch. Rebuilding only Allo's generated MLIR extension
  against the active Python installation resolved the failure.

The recovery procedures were checked by repeating the failed operations and
confirming that `import allo` and `import allo.ir` completed successfully after
the corrected build.

#### System 2: Windows and WSL2 Validation Workstation ####

- Windows x86-64 host, NT build 10.0.26200
- CPython 3.12.13
- pip 26.1.2
- CMake 4.4.2
- Ninja 1.13
- nanobind 2.15.0
- WSL2 guest running Ubuntu 24.04.2, x86-64
- WSL2 CPython 3.12.3
- GNU Binutils 2.42

This system was used for independent, controlled reproductions of individual
failure mechanisms:

- Running `pip install -e .` from a directory without the Allo packaging files
  reproduced the wrong-working-directory error.
- Pointing CMake at a build directory without the MLIR package reproduced the
  `MLIRConfig.cmake` lookup failure.
- Installing the current dependency set on Windows reproduced rejection of
  the Linux-only `past-0.7.2-cp312-cp312-linux_x86_64.whl` wheel. This failure
  is not expected on the supported CPython 3.12 Linux x86-64 platform.
- The nanobind version constraint and CMake package location were checked
  using the same Python interpreter selected for configuration.
- On WSL2, a minimal ELF Python extension containing an undefined `_py_stats`
  reference reproduced the same dynamic-loader failure. The test also
  confirmed that a Python process built without statistics support does not
  export `_py_stats`.

A complete Allo build was not performed on Windows because the current source
dependency set includes a Linux x86-64 wheel. The Windows and WSL2 checks
validated individual failure mechanisms, while the RHEL system provided the
end-to-end Allo build validation.

The Vitis environment conflict and file-descriptor exhaustion sections were
already present in the project documentation. They are preserved in the new
troubleshooting page, but this PR does not claim that they were newly
reproduced on either validation system.

### Reading the New Troubleshooting Guide ###

The new guide is located at:

```text
docs/source/setup/troubleshooting.rst
```

It is linked from the **Troubleshooting** section of the source-installation
page. Reviewers can also read it directly from the PR's **Files changed** tab.

After building the documentation, the rendered page is available at:

```text
docs/build/html/setup/troubleshooting.html
```

The guide contains:

- initial environment and toolchain checks;
- recognizable error messages and symptoms;
- explanations of the likely causes;
- diagnostic commands for distinguishing similar failures;
- targeted recovery procedures;
- post-installation verification commands;
- diagnostic information to include when requesting help;
- the previously existing Vitis environment and file-descriptor guidance.

### Validation Commands ###

The following commands are used to validate the updated documentation and
source-installation workflow on RHEL:

```bash
cd /data/1/rreva/allo_fork

export ALLO_ROOT="$PWD"
export LLVM_BUILD_DIR="<absolute path to the completed LLVM build>"
export PATH="$LLVM_BUILD_DIR/bin:$PATH"

test -x "$LLVM_BUILD_DIR/bin/llvm-config"
test -f "$LLVM_BUILD_DIR/lib/cmake/mlir/MLIRConfig.cmake"

python3 -m pip install -v -e .
python3 -c "import allo; print(allo.__file__)"
python3 -c "import allo; import allo.ir; print('Allo MLIR import passed')"

bash scripts/lint/task_lint.sh
python3 -m pip install -r docs/requirements.txt
make -C docs clean
make -C docs SPHINXBUILD="python3 -m sphinx" html
```

The reported `allo.__file__` path is checked to ensure that validation uses
the PR checkout rather than another editable Allo installation.

## Checklist ##

Please make sure to review and check all of these items:

- [x] PR's title starts with a category (for example, `[Doc]`)
- [x] All changes have appropriate reproduction-based coverage for a
  documentation-only PR; no runtime code was changed
- [X] Pass the formatting check locally
- [x] The installation procedure and troubleshooting guidance are documented